### PR TITLE
fixed python/setup.py to no longer contaminate extra_objs with header fi...

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ extra_objs.extend( map(
     ]
 ) )
 
-build_depends = extra_objs
+build_depends = list(extra_objs)
 build_depends.extend( map(
     lambda bn: path_join( path_pardir, "lib", bn + ".hh" ),
     [


### PR DESCRIPTION
setup.py had a minor bug in it (assignment by value rather than with a copy) that was causing the headers to be compiled in.  This is clearly wrong and also causes trouble in some other work I'm doing; not sure why it's working now, to be honest!

@mr-c I think this is ready for merge to master.
