### PR TITLE
Don't complain about hashsize if we load a hash.

### DIFF
--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -142,7 +142,7 @@ def main():
     args = parser.parse_args()
 
     if not args.quiet:
-        if args.min_hashsize == DEFAULT_MIN_HASHSIZE:
+        if args.min_hashsize == DEFAULT_MIN_HASHSIZE and not args.loadhash:
             print >>sys.stderr, \
                 "** WARNING: hashsize is default!  " \
                 "You absodefly want to increase this!\n** " \


### PR DESCRIPTION
If we're loading a hash, we probably don't care if we don't specify a non-default hashsize (we would have complained the last time).
