### PR TITLE
added in a test to make sure bigcount is off for normalize-by-median

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -435,6 +435,25 @@ def test_normalize_by_median_force():
     assert '*** Skipping' in err
     assert '** IOErrors' in err
 
+def test_normalize_by_median_no_bigcount():
+    infile = utils.get_temp_filename('test.fa')
+    hashfile = utils.get_temp_filename('test-out.kh')
+    outfile = infile + '.keep'
+
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
+    counting_ht = _make_counting(infile, K=8)
+
+    script = scriptpath('normalize-by-median.py')
+    args = ['-C', '1000', '-k 8', '--savehash', hashfile, infile]
+
+    (status, out, err) = runscript(script, args)
+    assert status == 0, (out, err)
+    print (out, err)
+    
+    assert os.path.exists(hashfile), hashfile
+    kh = khmer.load_counting_hash(hashfile)
+    
+    assert kh.get('GGTTGACG') == 255
 
 def test_normalize_by_median_dumpfrequency():
     CUTOFF = '1'


### PR DESCRIPTION
Re #240 -- I thought that by default bigcount was _on_, and that this might be causing an out of memory error.  So I added a test, which showed that bigcount is in fact off.  Still, the test is useful :)
