### PR TITLE
fix for Coverity CID 1173035:  Uninitialized scalar field  (UNINIT_CTOR)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
-2014-03-03  Michael R. Crusoe <mcrusoe@msu.edu>
+2014-03-03  Michael R. Crusoe  <mcrusoe@msu.edu>
 
     * lib/trace_logger.{cc,hh}: fix for Coverity CID 1063852: Uninitialized
     scalar field (UNINIT_CTOR) 
+    * lib/node.cc: fix for Coverity CID 1173035:  Uninitialized scalar field
+    (UNINIT_CTOR)
 
 2014-02-27  Michael R. Crusoe <mcrusoe@msu.edu>
 

--- a/lib/kmer.hh
+++ b/lib/kmer.hh
@@ -30,7 +30,6 @@ private:
 public:
     Kmer(std::string kmer);
     Kmer(HashIntoType, HashIntoType, unsigned char, unsigned int);
-    Kmer() { }
 
     HashIntoType getUniqueHash() const;
 

--- a/lib/node.cc
+++ b/lib/node.cc
@@ -108,10 +108,9 @@ Node::Node(Node* _parent,
            char _emission,
            unsigned int _stateNo,
            char _state,
-           Kmer _kmer)
+           Kmer _kmer) : kmer( _kmer)
 {
     parent = _parent;
-    kmer = _kmer;
     emission = _emission;
     stateNo = _stateNo;
     state = _state;


### PR DESCRIPTION
@luizirber @camillescott @ctb merge requested
- [x] Is it mergable
- [x] Did it pass the tests?
- [NA] If it introduce new functionality in scripts/ is it tested?
  Check for code coverage.
- [x] Is it well formatted? Look at `pep8`/`pylint`, `cppcheck`, and
  `make doc` output. Use `autopep8` and `astyle -A10` if needed.
- [x] Is it documented in the Changelog?
