### PR TITLE
repartition_largest_partition parameters are not optional

### DIFF
--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -2683,7 +2683,7 @@ static PyObject * hashbits_repartition_largest_partition(PyObject * self, PyObje
     PyObject * subset_o = NULL;
     unsigned int distance, threshold, frequency;
 
-    if (!PyArg_ParseTuple(args, "OO!III", &subset_o, &khmer_KCountingHashType,
+    if (!PyArg_ParseTuple(args, "OOIII", &subset_o, &khmer_KCountingHashType,
                           &counting_o, &distance, &threshold, &frequency)) {
         return NULL;
     }


### PR DESCRIPTION
In the [original code](https://github.com/ged-lab/khmer/commit/f05b5bbaedf314d3f6fa5b1df89c3902ca4119ee#diff-ace8ca86673d4c80b9a93a6f69ac7126R1622) these parameters are not optional.

The [current test case](https://github.com/ged-lab/khmer/blob/9e6474c88493cff59e8e47010a15a4944204a1e9/tests/test_lump.py#L94) pass the parameters.

[Both](https://github.com/ged-lab/khmer/blob/9e6474c88493cff59e8e47010a15a4944204a1e9/scripts/make-initial-stoptags.py#L91) [scripts](https://github.com/ged-lab/khmer/blob/b40585817695550b4c7fda860eb1ed8f085b9841/scripts/find-knots.py#L93) pass the parameters.

The [C++ code](https://github.com/ged-lab/khmer/blob/b40585817695550b4c7fda860eb1ed8f085b9841/lib/subset.cc#L1454) and [header](https://github.com/ged-lab/khmer/blob/b40585817695550b4c7fda860eb1ed8f085b9841/lib/subset.hh#L139) doesn't define defaults.

I rest my case.
