### PR TITLE
updated normalize-by-median documentation for loadtable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,15 +3,20 @@
     * scripts/abundance-dist-single.py: fixed problem where ReadParser was
     being created anew for each thread; regression introduced in 4b823fc.
 
+2014-04-22  Michael R. Crusoe  <mcrusoe@msu.edu>
+
+    * *.py: switch to explicit python2 invocation. Fixes #385.
+
 2014-04-21  Michael R. Crusoe  <mcrusoe@msu.edu>
 
     * setup.py,doc/installing.txt: Remove argparse from the requirements
     unless it isn't available. Argparse is bundled with Python 2.7+. This
     simplifies the installation instructions.
 
-2014-04-22  Michael R. Crusoe  <mcrusoe@msu.edu>
+2014-04-06  Titus Brown  <titus@idyll.org>
 
-    * *.py: switch to explicit python2 invocation. Fixes #385.
+    * scripts/normalize-by-median.py: added comment about table compatibility
+    with abundance-dist.
 
 2014-04-01  Titus Brown  <titus@idyll.org>
 

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -139,13 +139,16 @@ def get_parser():
     keeping (or discarding) each sequencing fragment. This helps with retention
     of repeats, especially.
 
-    With :option:`-s`/:option:`--savetable`, the k-mer counting table will be
-    saved to the specified file after all sequences have been processed. With
-    :option:`-d`, the k-mer counting table will be saved every d files for
-    multifile runs; if :option:`-s` is set, the specified name will be used,
-    and if not, the name `backup.ct` will be used.
-    :option:`-l`/:option:`--loadtable` will load the specified k-mer counting
-    table before processsing the specified files.
+    With :option:`-s`/:option:`--savetable`, the k-mer counting table
+    will be saved to the specified file after all sequences have been
+    processed. With :option:`-d`, the k-mer counting table will be
+    saved every d files for multifile runs; if :option:`-s` is set,
+    the specified name will be used, and if not, the name `backup.ct`
+    will be used.  :option:`-l`/:option:`--loadtable` will load the
+    specified k-mer counting table before processsing the specified
+    files.  Note that these tables are are in the same format as those
+    produced by :program:`load-into-counting.py` and consumed by
+    :program:`abundance-dist.py`.
 
     :option:`-f`/:option:`--fault-tolerant` will force the program to continue
     upon encountering a formatting error in a sequence file; the k-mer counting


### PR DESCRIPTION
Point out that normalize-by-median outputs tables that can be loaded by abundance dist; see #376.
