### PR TITLE
fixed check_space_for_hashtable to use args.n_tables

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-04-11  Titus Brown  <t@idyll.org>
+
+    * scripts/*.py: fixed argument to check_space_for_hashtable to rely
+    on args.n_tables and not args.ksize.
+
 2014-04-10  Michael R. Crusoe  <mcrusoe@msu.edu>
 
     Version 1.0
@@ -17,12 +22,12 @@
     * tests/test-data/test-overlap1.ht,data/MSB2-surrender.fa &
     data/1m-filtered.fa: removed from repository history, .git is now 36M!
 
-2014-04-01  Titus Brown  <t@Titus-MacBook-Air-2.local>
+2014-04-01  Titus Brown  <t@idyll.org>
 
     * CITATION,khmer/khmer_args.py: Updated khmer software citation for
     release.
 
-2014-03-31  Titus Brown  <t@Titus-MacBook-Air-2.local>
+2014-03-31  Titus Brown  <t@idyll.org>
 
     * scripts/normalize-by-median.py: Fixed unbound variable bug introduced in
     20a433c2.
@@ -38,7 +43,7 @@
     * docs/release.txt,khmer/_version.py,MANIFEST.in: update ancillary
     versioneer files
 
-2014-03-31  Titus Brown  <t@Titus-MacBook-Air-2.local>
+2014-03-31  Titus Brown  <t@idyll.org>
 
     * scripts/*.py,khmer/khmer_args.py: added 'info' function to khmer_args,
     and added citation information to each script.

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -69,7 +69,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     check_file_status(args.input_sequence_filename)
     check_space([args.input_sequence_filename])
     if args.savetable:
-        check_space_for_hashtable(args.ksize * args.min_tablesize)
+        check_space_for_hashtable(args.n_tables * args.min_tablesize)
 
     if (not args.squash_output and
             os.path.exists(args.output_histogram_filename)):

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -63,7 +63,7 @@ def main():
     check_file_status(args.datafile)
     check_space([args.datafile])
     if args.savetable:
-        check_space_for_hashtable(args.ksize * args.min_tablesize)
+        check_space_for_hashtable(args.n_tables * args.min_tablesize)
     report_on_config(args)
 
     config = khmer.get_config()

--- a/scripts/load-graph.py
+++ b/scripts/load-graph.py
@@ -53,7 +53,7 @@ def main():
         check_file_status(_)
 
     check_space(args.input_filenames)
-    check_space_for_hashtable(args.ksize * args.min_tablesize)
+    check_space_for_hashtable(float(args.n_tables * args.min_tablesize) / 8.)
 
     print 'Saving k-mer presence table to %s' % base
     print 'Loading kmers from sequences in %s' % repr(filenames)

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -70,7 +70,7 @@ def main():
         check_file_status(name)
 
     check_space(args.input_sequence_filename)
-    check_space_for_hashtable(args.ksize * args.min_tablesize)
+    check_space_for_hashtable(args.n_tables * args.min_tablesize)
 
     print 'Saving k-mer counting table to %s' % base
     print 'Loading kmers from sequences in %s' % repr(filenames)
@@ -101,7 +101,7 @@ def main():
             _.join()
 
         if index > 0 and index % 10 == 0:
-            check_space_for_hashtable(args.ksize * args.min_tablesize)
+            check_space_for_hashtable(args.n_tables * args.min_tablesize)
             print 'mid-save', base
             htable.save(base)
             open(base + '.info', 'w').write('through %s' % filename)

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -208,7 +208,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     check_valid_file_exists(args.input_filenames)
     check_space(args.input_filenames)
     if args.savetable:
-        check_space_for_hashtable(args.ksize * args.min_tablesize)
+        check_space_for_hashtable(args.n_tables * args.min_tablesize)
 
     # list to save error files along with throwing exceptions
     if args.force:


### PR DESCRIPTION
Fixes bug where table size was calculated based on args.ksize instead of args.n_tables. Important bug to fix for some cloud computing systems w/limited disk space.
