### PR TITLE
Remove argparse from the requirements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2014-04-21  Michael R. Crusoe  <mcrusoe@msu.edu>
+
+    * setup.py,doc/installing.txt: Remove argparse from the requirements
+    unless it isn't available. Argparse is bundled with Python 2.7+. This
+    simplifies the installation instructions.
+
 2014-04-05  Michael R. Crusoe  <mcrusoe@msu.edu>
 
 2014-04-01  Titus Brown  <titus@idyll.org>

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -58,19 +58,9 @@ Linux
 Latest stable release
 ---------------------
 
-#) Check your pip version::
+#) Use pip to download, build, and install khmer and its dependencies::
 
-	pip --version
-
-#) Use pip to download, build, and install khmer and its dependencies.
-
-   - If you're running version 1.5 or greater of ``pip``::
-   
-        pip install --allow-external argparse khmer
-        
-   - For ``pip`` version 1.4.1 and earlier::
-   
-	    pip install khmer
+      pip install khmer
 
 #) The scripts are now in the ``env/bin`` directory and ready for your
    use. You can directly use them by name, see :doc:`scripts`.
@@ -83,13 +73,7 @@ Latest stable release
 Latest development branch
 -------------------------
 
-Repeat the above but modify the pip install line.
-
-- If you're running version 1.5 or greater of ``pip`` then::
-
-	pip install --allow-external argparse git+https://github.com/ged-lab/khmer.git@master#egg=khmer
-
-- For ``pip`` version 1.4.1 and earlier::
+Repeat the above but modify the pip install line::
 
    pip install git+https://github.com/ged-lab/khmer.git@master#egg=khmer
 

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,14 @@ SCRIPTS.extend([path_join("scripts", script)
                 for script in os_listdir("scripts")
                 if script.endswith(".py")])
 
+INSTALL_REQUIRES = ["screed >= 0.7.1"]
+
+try:
+    import argparse
+    del argparse
+except ImportError:
+    INSTALL_REQUIRES.append("argparse >= 1.2.1")
+
 SETUP_METADATA = \
     {
         "name": "khmer",
@@ -103,7 +111,7 @@ SETUP_METADATA = \
         # additiona-meta-data note #3
         "url": 'http://ged.msu.edu/',
         "packages": ['khmer'],
-        "install_requires": ["screed >= 0.7.1", 'argparse >= 1.2.1', ],
+        "install_requires": INSTALL_REQUIRES,
         "extras_require": {'docs': ['sphinx', 'sphinxcontrib-autoprogram'],
                            'tests': ['nose >= 1.0']},
         "scripts": SCRIPTS,


### PR DESCRIPTION
unless it isn't available. Argparse is bundled with Python 2.7+.
This simplifies the installation instructions. Tested with cpython 2.6
& 2.7 on Ubuntu 13.10.
