### PR TITLE
Adds hash table write error alert.

### DIFF
--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -706,7 +706,9 @@ CountingHashFileWriter::CountingHashFileWriter(const std::string &outfilename, c
             outfile.write((const char *) &it->second, sizeof(it->second));
         }
     }
-
+    if (outfile.fail()) {
+        perror("Hash writing file access failure:");
+    }
     outfile.close();
 }
 


### PR DESCRIPTION
Writing can silently fail on certain systems (like mine).  I don't know how to prevent it, but here's a few lines to add in error alerts.
