### PR TITLE
fix two regressions introduced overnight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ CPPSOURCES=$(wildcard {lib,khmer}/*.{cc,hh})
 PYSOURCES=$(wildcard {khmer,scripts}/*.py)
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
 
-SHELL=/bin/bash
 GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 VERSION=$(shell git describe --tags --dirty | sed s/v//)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1574,7 +1574,6 @@ def test_sample_reads_randomly_S():
     (status, out, err) = runscript(script, badargs, in_dir, fail_ok=True)
     assert status == -1, (status, out, err)
 
-
     args.append('test.fq')
 
     runscript(script, args, in_dir)


### PR DESCRIPTION
SHELL=/bin/bash was reintroduced in 1a8f7762 after being removed in 7e1e82fe4; this is breaking many 'make' targets on my laptop.

pep8 whitespace violation was introduced in f4366198, and is causing continuous integration to fail.
