### PR TITLE
Implementing bit sniffing as a failover for file identification; deals with #355 and stepping stone for #630

### DIFF
--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -1290,16 +1290,16 @@ get_parser(
     int             retval = 0;
 #endif
     std::string fa_ext = ".fa", fq_ext = ".fq", fasta_ext = ".fasta",
-     fastq_ext = ".fastq", gz_ext = ".gz", bz2_ext = ".bz2";
+     fastq_ext = ".fastq", gz_ext = ".gz", bz2_ext = ".bz2", fp_ext=".fp";
     int fa_here = ifile_name.find(fa_ext);
     int fq_here = ifile_name.find(fq_ext);
     int fasta_here = ifile_name.find(fasta_ext);
     int fastq_here = ifile_name.find(fastq_ext);
     int gz_here = ifile_name.find(gz_ext);
     int bz2_here = ifile_name.find(bz2_ext);
-    
+    int fp_here = ifile_name.find(fp_ext); 
     if(!(fa_here > 0 || fq_here > 0 || fasta_here > 0 || fastq_here > 0
-                || gz_here > 0 || bz2_here > 0))
+                || gz_here > 0 || bz2_here > 0 || fp_here > 0))
     {
         throw InvalidStreamHandle();
     }
@@ -1388,7 +1388,7 @@ get_parser(
             cache_size,
             trace_level
         );
-    if( (fa_here > 0 && fastq_here < 0) || fasta_here > 0)
+    if( (fa_here > 0 && fastq_here < 0) || fasta_here > 0 || fp_here> 0)
         parser =
             new FastaParser(
             *stream_reader,

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -699,10 +699,10 @@ def test_consume_absentfasta_with_reads_parser():
         assert 0, "this should fail"
     except ValueError, err:
         print str(err)
-    #try:
+    # try:
     #    countingtable.consume_fasta_with_reads_parser(readparser)
     #    assert 0, "this should fail"
-    #except IOError, err:
+    # except IOError, err:
     #    print str(err)
 
 

--- a/tests/test_hashbits.py
+++ b/tests/test_hashbits.py
@@ -772,8 +772,8 @@ def test_consume_absentfasta_with_reads_parser():
         assert 0, "this should fail"
     except ValueError, err:
         print str(err)
-    #try:
+    # try:
     #    presencetable.consume_fasta_with_reads_parser(readparser)
     #    assert 0, "this should fail"
-    #except IOError, err:
+    # except IOError, err:
     #    print str(err)


### PR DESCRIPTION
Ran into roadblocks in #630; doing stepping-stone implementation here. Extensions will be used to determine filetype; if unable to do so, read_parser will fail over to using bitsniffing to determine filetype. 
