### PR TITLE
Use absolute URI in CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -31,5 +31,5 @@ at the BEACON Center for the Study of Evolution in Action, an NSF Center for
 Science and Technology.
 
 This Code of Conduct is adapted from the `Contributor
-Covenant <http:contributor-covenant.org>`__, version 1.0.0, available at
+Covenant <http://contributor-covenant.org>`__, version 1.0.0, available at
 http://contributor-covenant.org/version/1/0/0/


### PR DESCRIPTION
sphinx (at least the version used by readthedocs) appears to interpret http:contributor-covenant.org`__ as http://khmer.readthedocs.org/en/v1.2/dev/contributor-covenant.org.  Using an absolute URI (despite this format appearing in the restructuredText documentation) should fix this.

github appears to render it fine, however...
