### PR TITLE
reduce memory requirements to run tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2014-12-17  Michael R. Crusoe  <mcrusoe@msu.edu>
 
+    * setup.cfg,tests/test_{counting_hash,counting_single,filter,graph,
+    hashbits,hashbits_obj,labelhash,lump,read_parsers,scripts,subset_graph}.py:
+    reduce memory usage of tests to about 100 megabytes max.
+
+2014-12-17  Michael R. Crusoe  <mcrusoe@msu.edu>
+
     * scripts/load-graph.py,khmer/_khmermodule.cc: restore threading to
     load-graph.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,6 @@ verbosity = 2
 stop = TRUE
 attr = !known_failing,!jenkins
 #processes = -1 # breaks xunit output
-#attr = !known_failing,!highmem
-# where highmem > 0.5GiB memory
 
 [build_ext]
 define = SEQAN_HAS_BZIP2,SEQAN_HAS_ZLIB

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -267,7 +267,6 @@ def test_2_kadian():
     assert x == 1, x
 
 
-@attr('highmem')
 def test_save_load():
     inpath = utils.get_test_data('random-20-a.fa')
     savepath = utils.get_temp_filename('tempcountingsave0.ht')
@@ -292,7 +291,6 @@ def test_save_load():
     assert x == y, (x, y)
 
 
-@attr('highmem')
 def test_load_gz():
     inpath = utils.get_test_data('random-20-a.fa')
 
@@ -328,7 +326,6 @@ def test_load_gz():
     assert x == y, (x, y)
 
 
-@attr('highmem')
 def test_save_load_gz():
     inpath = utils.get_test_data('random-20-a.fa')
     savepath = utils.get_temp_filename('tempcountingsave2.ht.gz')
@@ -560,10 +557,9 @@ def test_nobigcount_save():
     assert kh.get('AAAA') == MAX_COUNT
 
 
-@attr('highmem')
 def test_bigcount_abund_dist():
-    kh = khmer.new_counting_hash(18, 1e7, 4)
-    tracking = khmer.new_hashbits(18, 1e7, 4)
+    kh = khmer.new_counting_hash(18, 1e2, 4)
+    tracking = khmer.new_hashbits(18, 1e2, 4)
     kh.set_use_bigcount(True)
 
     seqpath = utils.get_test_data('test-abund-read-2.fa')
@@ -577,7 +573,6 @@ def test_bigcount_abund_dist():
     assert dist[1001] == 1, pdist
 
 
-@attr('highmem')
 def test_bigcount_abund_dist_2():
     kh = khmer.new_counting_hash(18, 1e7, 4)
     tracking = khmer.new_hashbits(18, 1e7, 4)

--- a/tests/test_counting_single.py
+++ b/tests/test_counting_single.py
@@ -281,7 +281,6 @@ def test_64bitshift():
     assert 0 < kh.get_min_count(substr), kh.get_min_count(substr)
 
 
-@attr('highmem')
 def test_64bitshift_2():
     kh = khmer.new_hashtable(25, 4)
     fullstr = "GTATGCCAGCTCCAACTGGGCCGGTACGAGCAGGCCATTGCCTCTTGCCGCGATGCGTCGGCG"
@@ -292,7 +291,6 @@ def test_64bitshift_2():
         assert kh.get(substr) > 0
 
 
-@attr('highmem')
 def test_very_short_read():
     short_filename = utils.get_test_data('test-short.fa')
     kh = khmer.new_hashtable(9, 4)
@@ -323,7 +321,6 @@ class Test_ConsumeString(object):
         except TypeError, err:
             print str(err)
 
-    @attr('highmem')
     def test_abundance_by_pos(self):
         kh = self.kh
 
@@ -343,7 +340,6 @@ class Test_ConsumeString(object):
         assert dist[2] == 1
         assert sum(dist) == 2
 
-    @attr('highmem')
     def test_abundance_by_pos_bigcount(self):
         kh = self.kh
         kh.set_use_bigcount(True)       # count past MAX_COUNT
@@ -411,7 +407,6 @@ class Test_AbundanceDistribution(object):
         A_filename = utils.get_test_data('all-A.fa')
         self.kh.consume_fasta(A_filename)
 
-    @attr('highmem')
     def test_count_A(self):
         A_filename = utils.get_test_data('all-A.fa')
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -24,7 +24,6 @@ def load_fa_seq_names(filename):
 
 class Test_Filter(object):
 
-    @attr('highmem')
     def test_abund(self):
         ht = khmer.new_hashtable(10, 4 ** 10)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -21,7 +21,6 @@ class Test_ExactGraphFu(object):
     def setup(self):
         self.ht = khmer.new_hashbits(12, 1e4)
 
-    @attr('highmem')
     def test_counts(self):
         ht = self.ht
         ht.consume_fasta(utils.get_test_data('test-graph.fa'))
@@ -193,7 +192,6 @@ class Test_InexactGraphFu(object):
 
 class Test_Partitioning(object):
 
-    @attr('highmem')
     def test_output_unassigned(self):
         import screed
 
@@ -211,7 +209,6 @@ class Test_Partitioning(object):
         assert len1 > 0
         assert len1 == len2, (len1, len2)
 
-    @attr('highmem')
     def test_not_output_unassigned(self):
         import screed
 
@@ -245,7 +242,6 @@ class Test_Partitioning(object):
         x = set([r.accuracy for r in screed.open(output_file)])
         assert x, x
 
-    @attr('highmem')
     def test_disconnected_20_a(self):
         filename = utils.get_test_data('random-20-a.fa')
 
@@ -256,7 +252,6 @@ class Test_Partitioning(object):
         x = ht.subset_count_partitions(subset)
         assert x == (99, 0), x             # disconnected @ 21
 
-    @attr('highmem')
     def test_connected_20_a(self):
         filename = utils.get_test_data('random-20-a.fa')
 
@@ -267,7 +262,6 @@ class Test_Partitioning(object):
         x = ht.subset_count_partitions(subset)
         assert x == (1, 0)             # connected @ 20
 
-    @attr('highmem')
     def test_disconnected_20_b(self):
         filename = utils.get_test_data('random-20-b.fa')
 
@@ -278,7 +272,6 @@ class Test_Partitioning(object):
         x = ht.subset_count_partitions(subset)
         assert x == (99, 0), x             # disconnected @ 21
 
-    @attr('highmem')
     def test_connected_20_b(self):
         filename = utils.get_test_data('random-20-b.fa')
 
@@ -289,7 +282,6 @@ class Test_Partitioning(object):
         x = ht.subset_count_partitions(subset)
         assert x == (1, 0)             # connected @ 20
 
-    @attr('highmem')
     def test_disconnected_31_c(self):
         filename = utils.get_test_data('random-31-c.fa')
 
@@ -300,7 +292,6 @@ class Test_Partitioning(object):
         x = ht.subset_count_partitions(subset)
         assert x == (999, 0), x            # disconnected @ K = 32
 
-    @attr('highmem')
     def test_connected_31_c(self):
         filename = utils.get_test_data('random-31-c.fa')
 

--- a/tests/test_hashbits.py
+++ b/tests/test_hashbits.py
@@ -137,7 +137,6 @@ def test_bloom_c_2():  # simple one
     assert ht2.n_unique_kmers() == 3
 
 
-@attr('highmem')
 def test_filter_if_present():
     ht = khmer.new_hashbits(32, 2, 2)
 
@@ -153,7 +152,6 @@ def test_filter_if_present():
     assert records[0]['name'] == '3'
 
 
-@attr('highmem')
 def test_combine_pe():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.new_hashbits(32, 1, 1)
@@ -179,7 +177,6 @@ def test_combine_pe():
     assert ht.count_partitions() == (1, 0)
 
 
-@attr('highmem')
 def test_load_partitioned():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.new_hashbits(32, 1, 1)
@@ -197,7 +194,6 @@ def test_load_partitioned():
     assert ht.get(s3)
 
 
-@attr('highmem')
 def test_count_within_radius_simple():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.new_hashbits(4, 2, 2)
@@ -210,7 +206,6 @@ def test_count_within_radius_simple():
     assert n == 1
 
 
-@attr('highmem')
 def test_count_within_radius_big():
     inpfile = utils.get_test_data('random-20-a.fa')
     ht = khmer.new_hashbits(20, 1e5, 4)
@@ -225,7 +220,6 @@ def test_count_within_radius_big():
     assert n == 39
 
 
-@attr('highmem')
 def test_count_kmer_degree():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.new_hashbits(4, 2, 2)
@@ -281,7 +275,6 @@ def test_save_load_tagset_noclear():
     assert len(data) == 34, len(data)
 
 
-@attr('highmem')
 def test_stop_traverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -303,7 +296,6 @@ def test_stop_traverse():
     assert n == 2, n
 
 
-@attr('highmem')
 def test_tag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -332,7 +324,6 @@ def test_tag_across_stoptraverse():
     assert n == 1, n
 
 
-@attr('highmem')
 def test_notag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -435,7 +426,6 @@ def test_extract_unique_paths_4():
     assert x == ['TGGAGAGACACAGATAGACAGG', 'TAGACAGGAGTGGCGAT']
 
 
-@attr('highmem')
 def test_find_unpart():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -458,7 +448,6 @@ def test_find_unpart():
     assert n == 1, n                     # all sequences connect
 
 
-@attr('highmem')
 def test_find_unpart_notraverse():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -481,7 +470,6 @@ def test_find_unpart_notraverse():
     assert n == 99, n                    # all sequences disconnected
 
 
-@attr('highmem')
 def test_find_unpart_fail():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.odd.fa')  # <- switch to odd

--- a/tests/test_hashbits_obj.py
+++ b/tests/test_hashbits_obj.py
@@ -143,7 +143,6 @@ def test_bloom_c_2():  # simple one
     assert ht2.n_unique_kmers() == 3
 
 
-@attr('highmem')
 def test_filter_if_present():
     ht = khmer.Hashbits(32, 1e6, 2)
 
@@ -159,7 +158,6 @@ def test_filter_if_present():
     assert records[0]['name'] == '3'
 
 
-@attr('highmem')
 def test_combine_pe():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.Hashbits(32, 1, 1)
@@ -185,7 +183,6 @@ def test_combine_pe():
     assert ht.count_partitions() == (1, 0)
 
 
-@attr('highmem')
 def test_load_partitioned():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.Hashbits(32, 1, 1)
@@ -203,7 +200,6 @@ def test_load_partitioned():
     assert ht.get(s3)
 
 
-@attr('highmem')
 def test_count_within_radius_simple():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.Hashbits(4, 1e6, 2)
@@ -216,7 +212,6 @@ def test_count_within_radius_simple():
     assert n == 1
 
 
-@attr('highmem')
 def test_count_within_radius_big():
     inpfile = utils.get_test_data('random-20-a.fa')
     ht = khmer.Hashbits(20, 1e6, 4)
@@ -231,7 +226,6 @@ def test_count_within_radius_big():
     assert n == 39
 
 
-@attr('highmem')
 def test_count_kmer_degree():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.Hashbits(4, 1e6, 2)
@@ -287,7 +281,6 @@ def test_save_load_tagset_noclear():
     assert len(data) == 34, len(data)
 
 
-@attr('highmem')
 def test_stop_traverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -309,7 +302,6 @@ def test_stop_traverse():
     assert n == 2, n
 
 
-@attr('highmem')
 def test_tag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -338,7 +330,6 @@ def test_tag_across_stoptraverse():
     assert n == 1, n
 
 
-@attr('highmem')
 def test_notag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -441,7 +432,6 @@ def test_extract_unique_paths_4():
     assert x == ['TGGAGAGACACAGATAGACAGG', 'TAGACAGGAGTGGCGAT']
 
 
-@attr('highmem')
 def test_find_unpart():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -464,7 +454,6 @@ def test_find_unpart():
     assert n == 1, n                     # all sequences connect
 
 
-@attr('highmem')
 def test_find_unpart_notraverse():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -487,7 +476,6 @@ def test_find_unpart_notraverse():
     assert n == 99, n                    # all sequences disconnected
 
 
-@attr('highmem')
 def test_find_unpart_fail():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.odd.fa')  # <- switch to odd

--- a/tests/test_labelhash.py
+++ b/tests/test_labelhash.py
@@ -306,7 +306,6 @@ def test_bloom_c_2():  # simple one
     assert ht2.n_unique_kmers() == 3
 
 
-@attr('highmem')
 def test_filter_if_present():
     ht = khmer.LabelHash(32, 1e6, 2)
 
@@ -322,7 +321,6 @@ def test_filter_if_present():
     assert records[0]['name'] == '3'
 
 
-@attr('highmem')
 def test_combine_pe():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.LabelHash(32, 1, 1)
@@ -348,7 +346,6 @@ def test_combine_pe():
     assert ht.count_partitions() == (1, 0)
 
 
-@attr('highmem')
 def test_load_partitioned():
     inpfile = utils.get_test_data('combine_parts_1.fa')
     ht = khmer.LabelHash(32, 1, 1)
@@ -366,7 +363,6 @@ def test_load_partitioned():
     assert ht.get(s3)
 
 
-@attr('highmem')
 def test_count_within_radius_simple():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.LabelHash(4, 1e6, 2)
@@ -379,7 +375,6 @@ def test_count_within_radius_simple():
     assert n == 1
 
 
-@attr('highmem')
 def test_count_within_radius_big():
     inpfile = utils.get_test_data('random-20-a.fa')
     ht = khmer.LabelHash(20, 1e6, 4)
@@ -394,7 +389,6 @@ def test_count_within_radius_big():
     assert n == 39
 
 
-@attr('highmem')
 def test_count_kmer_degree():
     inpfile = utils.get_test_data('all-A.fa')
     ht = khmer.LabelHash(4, 1e6, 2)
@@ -450,7 +444,6 @@ def test_save_load_tagset_noclear():
     assert len(data) == 34, len(data)
 
 
-@attr('highmem')
 def test_stop_traverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -472,7 +465,6 @@ def test_stop_traverse():
     assert n == 2, n
 
 
-@attr('highmem')
 def test_tag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -501,7 +493,6 @@ def test_tag_across_stoptraverse():
     assert n == 1, n
 
 
-@attr('highmem')
 def test_notag_across_stoptraverse():
     filename = utils.get_test_data('random-20-a.fa')
 
@@ -604,7 +595,6 @@ def test_extract_unique_paths_4():
     assert x == ['TGGAGAGACACAGATAGACAGG', 'TAGACAGGAGTGGCGAT']
 
 
-@attr('highmem')
 def test_find_unpart():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -627,7 +617,6 @@ def test_find_unpart():
     assert n == 1, n                     # all sequences connect
 
 
-@attr('highmem')
 def test_find_unpart_notraverse():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.even.fa')
@@ -650,7 +639,6 @@ def test_find_unpart_notraverse():
     assert n == 99, n                    # all sequences disconnected
 
 
-@attr('highmem')
 def test_find_unpart_fail():
     filename = utils.get_test_data('random-20-a.odd.fa')
     filename2 = utils.get_test_data('random-20-a.odd.fa')  # <- switch to odd

--- a/tests/test_lump.py
+++ b/tests/test_lump.py
@@ -15,7 +15,6 @@ from nose.plugins.attrib import attr
 # which the last 79 bases are common between the 3 sequences.
 
 
-@attr('highmem')
 def test_fakelump_together():
     fakelump_fa = utils.get_test_data('fakelump.fa')
 
@@ -31,7 +30,6 @@ def test_fakelump_together():
 # try loading stop tags from previously saved
 
 
-@attr('highmem')
 def test_fakelump_stop():
     fakelump_fa = utils.get_test_data('fakelump.fa')
     fakelump_stoptags_txt = utils.get_test_data('fakelump.fa.stoptags.txt')
@@ -51,7 +49,6 @@ def test_fakelump_stop():
 # check specific insertion of stop tag
 
 
-@attr('highmem')
 def test_fakelump_stop2():
     fakelump_fa = utils.get_test_data('fakelump.fa')
 
@@ -69,7 +66,6 @@ def test_fakelump_stop2():
 # try repartitioning
 
 
-@attr('highmem')
 def test_fakelump_repartitioning():
     fakelump_fa = utils.get_test_data('fakelump.fa')
     fakelump_fa_foo = utils.get_temp_filename('fakelump.fa.stopfoo')
@@ -113,7 +109,6 @@ def test_fakelump_repartitioning():
     assert n_partitions == 3, n_partitions
 
 
-@attr('highmem')
 def test_fakelump_load_stop_tags_trunc():
     fakelump_fa = utils.get_test_data('fakelump.fa')
     fakelump_fa_foo = utils.get_temp_filename('fakelump.fa.stopfoo')
@@ -160,7 +155,6 @@ def test_fakelump_load_stop_tags_trunc():
         pass
 
 
-@attr('highmem')
 def test_fakelump_load_stop_tags_notexist():
     fakelump_fa_foo = utils.get_temp_filename('fakelump.fa.stopfoo')
 

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -14,7 +14,6 @@ import khmer_tst_utils as utils
 from nose.plugins.attrib import attr
 
 
-@attr('highmem')
 def test_read_properties():
 
     # Note: Using a data file with only one read.
@@ -28,7 +27,6 @@ def test_read_properties():
         assert read.accuracy == """][aaX__aa[`ZUZ[NONNFNNNNNO_____^RQ_"""
 
 
-@attr('highmem')
 def test_with_default_arguments():
 
     read_names = []
@@ -46,7 +44,6 @@ def test_with_default_arguments():
         assert m == n
 
 
-@attr('highmem')
 def test_gzip_decompression():
 
     reads_count = 0
@@ -79,7 +76,6 @@ def test_gzip_decompression_truncated_pairiter():
         print str(err)
 
 
-@attr('highmem')
 def test_bzip2_decompression():
 
     reads_count = 0
@@ -125,7 +121,6 @@ def test_badbzip2():
 
 
 @attr('multithread')
-@attr('highmem')
 def test_with_multiple_threads(testfile="test-reads.fq.bz2"):
 
     import operator
@@ -159,7 +154,6 @@ def test_with_multiple_threads(testfile="test-reads.fq.bz2"):
 
 
 @attr('multithread')
-@attr('highmem')
 def test_with_multiple_threads_big():
     test_with_multiple_threads(testfile="test-large.fa")
 
@@ -268,7 +262,6 @@ def test_read_pair_iterator_in_error_mode():
     assert all(matches)  # Assert ALL the matches. :-]
 
 
-@attr('highmem')
 def test_read_pair_iterator_in_error_mode_xfail():
 
     rparser = \

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -41,7 +41,7 @@ def test_check_space():
 
 def test_load_into_counting():
     script = scriptpath('load-into-counting.py')
-    args = ['-x', '1e7', '-N', '2', '-k', '20', '-t']
+    args = ['-x', '1e3', '-N', '2', '-k', '20', '-t']
 
     outfile = utils.get_temp_filename('out.kh')
     infile = utils.get_test_data('test-abund-read-2.fa')
@@ -49,7 +49,7 @@ def test_load_into_counting():
     args.extend([outfile, infile])
 
     (status, out, err) = utils.runscript(script, args)
-    assert 'Total number of unique k-mers: 95' in err, err
+    assert 'Total number of unique k-mers: 89' in err, err
     assert os.path.exists(outfile)
 
 
@@ -668,7 +668,7 @@ def test_load_graph_multithread():
     outfile = utils.get_temp_filename('test')
     infile = utils.get_test_data('test-reads.fa')
 
-    args = ['-N', '4', '-x', '1e9', '-T', '8', outfile, infile]
+    args = ['-N', '4', '-x', '1e7', '-T', '8', outfile, infile]
 
     (status, out, err) = utils.runscript(script, args)
 

--- a/tests/test_subset_graph.py
+++ b/tests/test_subset_graph.py
@@ -193,7 +193,6 @@ class Test_RandomData(object):
 
 class Test_SaveLoadPmap(object):
 
-    @attr('highmem')
     def test_save_load_merge(self):
         ht = khmer.new_hashbits(20, 4 ** 4 + 1)
         filename = utils.get_test_data('test-graph2.fa')
@@ -226,7 +225,6 @@ class Test_SaveLoadPmap(object):
         n_partitions = ht.output_partitions(filename, outfile)
         assert n_partitions == 1, n_partitions        # combined.
 
-    @attr('highmem')
     def test_save_load_merge_2(self):
         ht = khmer.new_hashbits(20, 4 ** 8 + 1)
         filename = utils.get_test_data('random-20-a.fa')
@@ -265,7 +263,6 @@ class Test_SaveLoadPmap(object):
         except IOError, e:
             print str(e)
 
-    @attr('highmem')
     def test_save_merge_from_disk(self):
         ht = khmer.new_hashbits(20, 4 ** 4 + 1)
         filename = utils.get_test_data('test-graph2.fa')
@@ -295,7 +292,6 @@ class Test_SaveLoadPmap(object):
         n_partitions = ht.output_partitions(filename, outfile)
         assert n_partitions == 1, n_partitions        # combined.
 
-    @attr('highmem')
     def test_save_merge_from_disk_2(self):
         ht = khmer.new_hashbits(20, 4 ** 7 + 1)
         filename = utils.get_test_data('random-20-a.fa')
@@ -323,7 +319,6 @@ class Test_SaveLoadPmap(object):
         n_partitions = ht.output_partitions(filename, outfile)
         assert n_partitions == 1, n_partitions        # combined.
 
-    @attr('highmem')
     def test_save_merge_from_disk_file_not_exist(self):
         ht = khmer.new_hashbits(20, 4 ** 4 + 1)
         filename = utils.get_test_data('test-graph2.fa')
@@ -345,7 +340,6 @@ class Test_SaveLoadPmap(object):
         except IOError, e:
             print str(e)
 
-    @attr('highmem')
     def test_merge_from_disk_file_bad_type(self):
         ht = khmer.new_hashbits(20, 4 ** 4 + 1)
         infile = utils.get_test_data('goodversion-k12.ht')
@@ -356,7 +350,6 @@ class Test_SaveLoadPmap(object):
         except IOError, e:
             print str(e)
 
-    @attr('highmem')
     def test_merge_from_disk_file_version(self):
         ht = khmer.new_hashbits(20, 4 ** 4 + 1)
         infile = utils.get_test_data('badversion-k12.ht')


### PR DESCRIPTION
You can check the memory usage with the following command:

```
/usr/bin/time ./setup.py nosetests
[...]
OK
16.08user 1.20system 0:18.00elapsed 96%CPU (0avgtext+0avgdata 105740maxresident)k
0inputs+810400outputs (0major+151138minor)pagefaults 0swaps
```

The number in question is "105740maxresident" (kilobytes) = 103.2 megabytes.
