### PR TITLE
Initial support for man page as a make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,15 @@ build/sphinx/latex/khmer.pdf: $(SOURCES) doc/conf.py $(wildcard doc/*.txt)
 	@echo ''
 	@echo '--> pdf in build/sphinx/latex/khmer.pdf'
 
+## man         : render documentation in Linux man
+man: build/sphinx/man/khmer.1
+
+build/sphinx/man/khmer.1: $(SOURCES) doc/conf.py $(wildcard doc/*.txt)
+	./setup.py build_sphinx --fresh-env --builder man
+	@echo ''
+	@echo '--> docs in build/sphinx/man <--'
+	@echo ''
+
 cppcheck-result.xml: $(CPPSOURCES)
 	${CPPCHECK} --xml-version=2 2> cppcheck-result.xml
 


### PR DESCRIPTION
Fixes Issue #619.

**Work In Progress**
_Not yet ready for review_
- [ ] Is it mergable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage.
- [ ] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the ChangeLog?
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
