### PR TITLE
Renamed _screed_record_dict calls in khmer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-04-14  Sarah Guermond  <sarah.guermond@gmail.com>
+
+   * scripts/trim-low-abund.py: changed _screed_record_dict to Record
+
 2015-04-14  Josiah Seaman  <josiah@dnaskittle.com>
 
    * lib/{hashbits.cc}: changed: adding doxygen comments

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python2
 #
 # This file is part of khmer, http://github.com/ged-lab/khmer/, and is
-# Copyright (C) Michigan State University, 2009-2014. It is licensed under
+# Copyright (C) Michigan State University, 2009-2015. It is licensed under
 # the three-clause BSD license; see doc/LICENSE.txt.
 # Contact: khmer-project@idyll.org
 #

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -22,7 +22,7 @@ import tempfile
 import shutil
 import textwrap
 
-from screed.screedRecord import Record
+from screed import Record
 from khmer.khmer_args import (build_counting_args, info, add_loadhash_args,
                               report_on_config)
 from khmer.utils import write_record, write_record_pair, broken_paired_reader

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -22,7 +22,7 @@ import tempfile
 import shutil
 import textwrap
 
-from screed.screedRecord import _screed_record_dict
+from screed.screedRecord import Record
 from khmer.khmer_args import (build_counting_args, info, add_loadhash_args,
                               report_on_config)
 from khmer.utils import write_record, write_record_pair, broken_paired_reader
@@ -37,7 +37,7 @@ MAX_FALSE_POSITIVE_RATE = 0.8
 
 
 def trim_record(read, trim_at):
-    new_read = _screed_record_dict()
+    new_read = Record()
     new_read.name = read.name
     new_read.sequence = read.sequence[:trim_at]
     if hasattr(read, 'quality'):


### PR DESCRIPTION
Fix issue #767 

Added support for changes in screed - *need to have correct screed version in order to work*
Passes test when specifying the screed version.

- [ ] Is it mergeable?
- [ ] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?