### PR TITLE
Clean up gitignore and make clean a little

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ doc/_build
 coverage.xml
 coverage-gcovr.xml
 coverage-debug
+htmlcov/
+diff-cover.html
 khmer-cov.tgz
 cppcheck-result.xml
 MANIFEST

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-05-20  Kevin Murray  <spam@kdmurray.id.au>
+
+   * .gitignore: Add htmlcov/ and diff-cover.html to gitignore
+   * Makefile: Use rm -f to remove files to quash error messages on
+   non-existant files
+
 2015-05-18  Sherine Awad  <sherine.awad@gmail.com>
 
    * tests/test_scripts.py: Test loading of compressed counting table

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,12 @@ dist/khmer-$(VERSION).tar.gz: $(SOURCES)
 clean: FORCE
 	cd lib && ${MAKE} clean || true
 	cd tests && rm -rf khmertest_* || true
-	rm -f khmer/_khmermodule.so || true
-	rm khmer/*.pyc lib/*.pyc || true
+	rm -f khmer/_khmermodule.so
+	rm -f khmer/*.pyc lib/*.pyc
 	./setup.py clean --all || true
-	rm coverage-debug || true
-	rm -Rf .coverage || true
+	rm -f coverage-debug
+	rm -Rf .coverage
+	rm -f diff-cover.html
 
 debug: FORCE
 	export CFLAGS="-pg -fprofile-arcs"; python setup.py build_ext --debug \


### PR DESCRIPTION
Just a few housekeeping things:

- `make clean` now uses `rm -f`, which doesn't print an error message if a file doesn't exist.
- Add coverage outputs to gitignore