### PR TITLE
Use FORCE in lib target of root makefile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-05-25  Kevin Murray  <spam@kdmurray.id.au>
+
+   * Makefile: Fix issue with 'lib' target not building by using FORCE
+
 2015-05-20  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * oxli/{__init__,khmer_api,common}.py,scripts/build-graph.py,

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ doc/doxygen/html/index.html: ${CPPSOURCES} ${PYSOURCES}
 		Doxyfile
 	doxygen
 
-lib:
+lib: FORCE
 	cd lib && \
 	$(MAKE)
 


### PR DESCRIPTION
Yo @mr-c,

I've been working on the libkhmer-dev package tonight, and found one issue in my earlier C++ lib PR. If you do `make lib` from the root makefile, nothing happens as `FORCE` is not used, and `./lib` already exists.

This just adds `FORCE` to that target.

Cheers,
Kevin