### PR TITLE
Another silly Makefile PR: Make clean should remove all libkhmer.so versions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-05-26  Kevin Murray  <spam@kdmurray.id.au>
+
+   * lib/Makefile: Remove old libkhmer.so versions during make clean
+
 2015-05-25  Kevin Murray  <spam@kdmurray.id.au>
 
    * Makefile: Fix issue with 'lib' target not building by using FORCE

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -214,7 +214,7 @@ TEST_PROGS = test-Colors test-read-aligner test-compile
 all: $(LIBKHMERSO) libkhmer.a khmer.pc
 
 clean:
-	rm -f *.o *.a *.so khmer.pc $(LIBKHMERSO) $(TEST_PROGS)
+	rm -f *.o *.a libkhmer*.so* khmer.pc $(TEST_PROGS)
 	(cd $(ZLIB_DIR) && make distclean)
 	(cd $(BZIP2_DIR) && make -f Makefile-libbz2_so clean)
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -214,7 +214,7 @@ TEST_PROGS = test-Colors test-read-aligner test-compile
 all: $(LIBKHMERSO) libkhmer.a khmer.pc
 
 clean:
-	rm -f *.o *.a libkhmer*.so* khmer.pc $(TEST_PROGS)
+	rm -f *.o *.a *.so* khmer.pc $(TEST_PROGS)
 	(cd $(ZLIB_DIR) && make distclean)
 	(cd $(BZIP2_DIR) && make -f Makefile-libbz2_so clean)
 


### PR DESCRIPTION
Hi all

Another minor change to `./lib/Makefile`.

The glob to remove shared objects during `make clean` only caught the current version, leading to an accumulation of old `libkhmer.so.$VERSION` in `./lib`. This remove all `*.so*` during make clean so this doesn't happen.

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?

Cheers,
K