### PR TITLE
Make khmer master compatible with screed Python 3 PR

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-05-29  Luiz Irber  <khmer@luizirber.org>
+
+   * khmer/{khmermodule.cc},tests/test_hashbits.py: Add Unicode support to
+   hashbits.get method.
+   * tests/test_hll.py: Avoid using translate for revcomp calculation.
+   * scripts/trim-low-abund.py: Use new screed Record instead of old class.
+
 2015-05-26  Titus Brown  <titus@idyll.org>
 
    * khmer/{__init__.py,_khmermodule.cc},lib/labelhash.{cc,hh},

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -2124,6 +2124,15 @@ hashbits_get(khmer_KHashbits_Object * me, PyObject * args)
         }
 
         count = hashbits->get_count(s.c_str());
+    } else if (PyUnicode_Check(arg)) {
+        std::string s = PyBytes_AsString(PyUnicode_AsEncodedString(
+            arg, "utf-8", "strict"));
+        if (strlen(s.c_str()) != hashbits->ksize()) {
+            PyErr_SetString(PyExc_ValueError,
+                            "k-mer size must equal the presence table k-mer size");
+            return NULL;
+        }
+        count = hashbits->get_count(s.c_str());
     } else {
         PyErr_SetString(PyExc_ValueError, "must pass in an int or string");
         return NULL;

--- a/khmer/_khmermodule.cc
+++ b/khmer/_khmermodule.cc
@@ -2126,7 +2126,7 @@ hashbits_get(khmer_KHashbits_Object * me, PyObject * args)
         count = hashbits->get_count(s.c_str());
     } else if (PyUnicode_Check(arg)) {
         std::string s = PyBytes_AsString(PyUnicode_AsEncodedString(
-            arg, "utf-8", "strict"));
+                                             arg, "utf-8", "strict"));
         if (strlen(s.c_str()) != hashbits->ksize()) {
             PyErr_SetString(PyExc_ValueError,
                             "k-mer size must equal the presence table k-mer size");

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -23,7 +23,7 @@ import shutil
 import textwrap
 import argparse
 
-from screed.screedRecord import _screed_record_dict
+from screed.screedRecord import Record
 from khmer.khmer_args import (build_counting_args, info, add_loadhash_args,
                               report_on_config)
 from khmer.utils import write_record, write_record_pair, broken_paired_reader
@@ -35,7 +35,7 @@ DEFAULT_CUTOFF = 2
 
 
 def trim_record(read, trim_at):
-    new_read = _screed_record_dict()
+    new_read = Record()
     new_read.name = read.name
     new_read.sequence = read.sequence[:trim_at]
     if hasattr(read, 'quality'):

--- a/tests/test_hashbits.py
+++ b/tests/test_hashbits.py
@@ -521,7 +521,13 @@ def test_badget():
     assert hbts.get("GATGAG") == 0
 
     try:
-        hbts.get("AGCTT")
+        hbts.get(b"AGCTT")
+        assert 0, "this should fail"
+    except ValueError as err:
+        print str(err)
+
+    try:
+        hbts.get(u"AGCTT")
         assert 0, "this should fail"
     except ValueError as err:
         print str(err)

--- a/tests/test_hll.py
+++ b/tests/test_hll.py
@@ -7,7 +7,6 @@
 # pylint: disable=missing-docstring,protected-access
 
 import math
-import string
 
 import khmer
 
@@ -17,10 +16,10 @@ import khmer_tst_utils as utils
 from nose.tools import assert_raises
 
 
-TT = string.maketrans('ACGT', 'TGCA')
 K = 20  # size of kmer
 ERR_RATE = 0.01
 N_UNIQUE = 3960
+TRANSLATE = {'A': 'T', 'C': 'G', 'T': 'A', 'G': 'C'}
 
 
 def teardown():
@@ -41,7 +40,7 @@ def test_hll_add_python():
         seq_len = len(sequence)
         for n in range(0, seq_len + 1 - K):
             kmer = sequence[n:n + K]
-            rc = kmer[::-1].translate(TT)
+            rc = "".join(TRANSLATE[c] for c in kmer[::-1])
 
             hllcpp.add(kmer)
 


### PR DESCRIPTION
- `hashbits.get(kmer)` supports unicode `kmer`
- HLL tests use a different revcomp calculation
- Use `Record` instead of `_screed_record_dict`