### PR TITLE
WIP: Refactor khmer's graph traversal

### DIFF
--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -175,6 +175,7 @@ class Hashtable  		// Base class implementation of a Bloom ht.
 {
     friend class SubsetPartition;
     friend class LabelHash;
+    friend class Traverser;
 protected:
     unsigned int _tag_density;
 

--- a/lib/traversal.cc
+++ b/lib/traversal.cc
@@ -1,0 +1,103 @@
+//
+// This file is part of khmer, https://github.com/dib-lab/khmer/, and is
+// Copyright (C) Michigan State University, 2009-2015. It is licensed under
+// the three-clause BSD license; see LICENSE.
+// Contact: khmer-project@idyll.org
+//
+
+#include "hashtable.hh"
+#include "traversal.hh"
+
+using namespace khmer;
+using namespace std;
+
+KmerNode Traverser::get_next(KmerNode& node, const char ch)
+{
+    HashIntoType kmer_f, kmer_r;
+    kmer_f = (((node.kmer_f) << 2) & bitmask) | (twobit_repr(ch));
+    kmer_r = ((node.kmer_r) >> 2) | (twobit_comp(ch) << rc_left_shift);
+    return KmerNode(kmer_f, kmer_r, K);
+}
+
+KmerNode Traverser::get_prev(KmerNode& node, const char ch)
+{
+    HashIntoType kmer_f, kmer_r;
+    kmer_f = ((node.kmer_f) >> 2 | twobit_repr(ch) << rc_left_shift);
+    kmer_r = (((node.kmer_r) << 2) & bitmask) | (twobit_comp(ch));
+    return KmerNode(kmer_f, kmer_r, K);
+}
+
+unsigned int Traverser::traverse_right(KmerNode& node,
+                                       KmerNodeQueue & node_q)
+{
+    unsigned int degree = 0;
+
+    char bases[] = "ATCG";
+    char * base = bases;
+    while(base != NULL) {
+        KmerNode next_node = get_next(node, *base);
+        if (graph->get_count(next_node.kmer_u)) {
+            node_q.push(next_node);
+            ++degree;
+        }
+        ++base;
+    }
+   
+    return degree;
+}
+
+unsigned int Traverser::traverse_left(KmerNode& node,
+                                       KmerNodeQueue & node_q)
+{
+    unsigned int degree = 0;
+
+    char bases[] = "ATCG";
+    char * base = bases;
+    while(base != NULL) {
+        KmerNode prev_node = get_prev(node, *base);
+        if (graph->get_count(prev_node.kmer_u)) {
+            node_q.push(prev_node);
+            ++degree;
+        }
+        ++base;
+    }
+   
+    return degree;
+}
+
+unsigned int Traverser::degree_right(KmerNode& node)
+{
+    unsigned int degree = 0;
+
+    char bases[] = "ATCG";
+    char * base = bases;
+    while(base != NULL) {
+        if (graph->get_count(get_next(node, *base).kmer_u)) {
+            ++degree;
+        }
+        ++base;
+    }
+   
+    return degree;
+}
+
+unsigned int Traverser::degree_left(KmerNode& node)
+{
+    unsigned int degree = 0;
+
+    char bases[] = "ATCG";
+    char * base = bases;
+    while(base != NULL) {
+        if (graph->get_count(get_prev(node, *base).kmer_u)) {
+            ++degree;
+        }
+        ++base;
+    }
+   
+    return degree;
+}
+
+unsigned int Traverser::degree(KmerNode& node)
+{
+    return degree_right(node) + degree_left(node);
+}

--- a/lib/traversal.hh
+++ b/lib/traversal.hh
@@ -1,0 +1,100 @@
+//
+// This file is part of khmer, https://github.com/dib-lab/khmer/, and is
+// Copyright (C) Michigan State University, 2009-2015. It is licensed under
+// the three-clause BSD license; see LICENSE.
+// Contact: khmer-project@idyll.org
+//
+
+#ifndef TRAVERSAL_HH
+#define TRAVERSAL_HH
+
+#include <queue>
+
+#include "khmer.hh"
+
+#include "khmer_exception.hh"
+#include "read_parsers.hh"
+#include "subset.hh"
+#include "kmer_hash.hh"
+
+namespace khmer {
+
+class KmerNode;
+typedef std::queue<KmerNode> KmerNodeQueue;
+
+class KmerNode {
+
+public:
+
+    HashIntoType kmer_f, kmer_r;
+    HashIntoType kmer_u;
+    unsigned int K;
+    
+    KmerNode(HashIntoType kmer, unsigned int K) {
+        this->K = K;
+        kmer_u = kmer;
+        _hash(_revhash(kmer, K).c_str(), K, kmer_f, kmer_r);
+    }
+
+    KmerNode(HashIntoType kmer_f, HashIntoType kmer_r, unsigned int K) {
+        this->K = K;
+        this->kmer_f = kmer_f;
+        this->kmer_r = kmer_r;
+        kmer_u = uniqify_rc(kmer_f, kmer_f);
+    }
+
+    KmerNode(std::string kmer, unsigned int K) {
+        this->K = K;
+        kmer_u = _hash(kmer.c_str(), K, kmer_f, kmer_r);
+    }
+
+    KmerNode(const char * kmer, unsigned int K) {
+        this->K = K;
+        kmer_u = _hash(kmer, K, kmer_f, kmer_r);
+    }
+
+    std::string get_string_rep() {
+        return _revhash(kmer_u, K);
+    }
+
+    const char * get_char_rep() {
+        return _revhash(kmer_u, K).c_str();
+    }
+};
+
+class Traverser {
+
+    friend class Hashtable;
+    
+protected:
+
+    HashIntoType bitmask;
+    unsigned int rc_left_shift;
+
+public:
+
+    Hashtable * graph;
+    unsigned int K;
+
+    explicit Traverser(Hashtable * ht) : graph(ht)
+    {
+        bitmask = graph->bitmask;
+        K = graph->ksize();
+        rc_left_shift = K * 2 - 2;
+    }
+
+    KmerNode get_next(KmerNode& node, const char ch);
+    KmerNode get_prev(KmerNode& node, const char ch);
+
+    unsigned int traverse_right(KmerNode& node,
+                                KmerNodeQueue &node_q);
+    unsigned int traverse_left(KmerNode& node,
+                               KmerNodeQueue &node_q);
+    
+    unsigned int degree_right(KmerNode& node);
+    unsigned int degree_left(KmerNode& node);
+    unsigned int degree(KmerNode& node);
+
+};
+};
+#endif

--- a/setup.py
+++ b/setup.py
@@ -102,13 +102,14 @@ BZIP2DIR = 'third-party/bzip2'
 BUILD_DEPENDS = []
 BUILD_DEPENDS.extend(path_join("lib", bn + ".hh") for bn in [
     "khmer", "kmer_hash", "hashtable", "counting", "hashbits", "labelhash",
-    "hllcounter", "khmer_exception", "read_aligner", "subset", "read_parsers"])
+    "hllcounter", "khmer_exception", "read_aligner", "subset", "read_parsers",
+    "traversal"])
 
 SOURCES = ["khmer/_khmermodule.cc"]
 SOURCES.extend(path_join("lib", bn + ".cc") for bn in [
     "trace_logger", "perf_metrics", "read_parsers", "kmer_hash", "hashtable",
     "hashbits", "labelhash", "counting", "subset", "read_aligner",
-    "hllcounter"])
+    "hllcounter", "traversal"])
 
 SOURCES.extend(path_join("third-party", "smhasher", bn + ".cc") for bn in [
     "MurmurHash3"])


### PR DESCRIPTION
After conversations w/ @drtamermansour regarding labeling, graphalign, and using our methods for population-level genome/transcriptome/etc graphs, and went ahead with the plan to implement lossless labeling. This requires some graph traversal stuff, which I immediately remembered is ridiculously rage-inducing for even the simplest tasks in the current implementation. This is a WIP for ripping out at that repeated code and producing a more maintainable and generalizable set of traversal functions; given that  *"...& graph traversal FTW"* is the end of the first line in our project description, this seems to be a long time coming :)