### PR TITLE
fixed duplicated test    'get_kmer_counts_too_short' by changing to 'get_kmer_hashes_too_short'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-06-14  Titus Brown  <titus@idyll.org>
+
+   * tests/test_counting_hash.py: fixed duplicated test
+   'get_kmer_counts_too_short' by changing to 'get_kmer_hashes_too_short'.
+
 2015-06-14  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * scripts/abundance-dist.py: added weird bigcount circumstance detection

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -468,12 +468,12 @@ def test_get_kmer_counts_too_short():
     assert len(counts) == 0
 
 
-def test_get_kmer_counts_too_short():
+def test_get_kmer_hashes_too_short():
     hi = khmer.new_counting_hash(6, 1e6, 2)
 
     hi.consume("AAAAAA")
-    counts = hi.get_kmer_counts("A")
-    assert len(counts) == 0
+    hashes = hi.get_kmer_hashes("A")
+    assert len(hashes) == 0
 
 
 def test_get_kmers_too_short():


### PR DESCRIPTION
thx @kdmurray91!

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?