### PR TITLE
Fix link in readme to virtualenv installation instructions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-06-27  Kevin Murray  <spam@kdmurray.id.au>
+
+   * README.rst: Fix link to virtualenv installation instructions.
+
 2015-06-19  Titus Brown  <titus@idyll.org>
 
    * khmer/__init__.py: split CountingHash into _CountingHash (CPython) and

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ version.
 For more details see `doc/install.txt <https://khmer.readthedocs.org/en/latest/user/install.html>`_
 
 The use of a virtualenv is recommended, see
-https://virtualenv.pypa.io/en/latest/virtualenv.html#installation
+https://virtualenv.readthedocs.org/en/latest/installation.html
 
 khmer is under the BSD license; see doc/LICENSE.txt. Distribution,
 modification and redistribution, incorporation into other software, and


### PR DESCRIPTION
https://virtualenv.pypa.io/en/latest/virtualenv.html#installation is a broken link, the new link is https://virtualenv.readthedocs.org/en/latest/installation.html I think...