### PR TITLE
Makefile adaptations for Py3/2 and Jenkins configuration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -177,6 +177,11 @@
 
 2015-07-08  Luiz Irber  <khmer@luizirber.org>
 
+   * Makefile: Adapt Makefile rules for py3 changes.
+   * jenkins-build.sh: Read PYTHON_EXECUTABLE and TEST_ATTR from environment.
+
+2015-07-08  Luiz Irber  <khmer@luizirber.org>
+
    * lib/{counting,hashbits,hashtable,labelhash,subset}.cc: print hexadecimal
    representation of the signature read from the file.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,12 @@
-2015-07-29  Amanda Charbonneau  <charbo24@msu.edu>
-
-   * scripts/fastq-to-fasta.py: Changed '-n' default description to match
-   behaviour
-
 2015-07-29  Luiz Irber  <khmer@luizirber.org>
 
    * Makefile: Adapt Makefile rules for py3 changes.
    * jenkins-build.sh: Read PYTHON_EXECUTABLE and TEST_ATTR from environment.
+
+2015-07-29  Amanda Charbonneau  <charbo24@msu.edu>
+
+   * scripts/fastq-to-fasta.py: Changed '-n' default description to match
+   behaviour
 
 2015-07-29  Luiz Irber  <khmer@luizirber.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,11 @@
 
 2015-07-29  Luiz Irber  <khmer@luizirber.org>
 
+   * Makefile: Adapt Makefile rules for py3 changes.
+   * jenkins-build.sh: Read PYTHON_EXECUTABLE and TEST_ATTR from environment.
+
+2015-07-29  Luiz Irber  <khmer@luizirber.org>
+
    * tests/test_{scripts,streaming_io}.py: Fix the build + add a test
 
 2015-07-28  Titus Brown  <titus@idyll.org>
@@ -174,11 +179,6 @@
    optimization/sanity checking via oxli estimation funcs.
    * tests/test_normalize_by_median.py: updated tests to cover estimation
    functions.
-
-2015-07-08  Luiz Irber  <khmer@luizirber.org>
-
-   * Makefile: Adapt Makefile rules for py3 changes.
-   * jenkins-build.sh: Read PYTHON_EXECUTABLE and TEST_ATTR from environment.
 
 2015-07-08  Luiz Irber  <khmer@luizirber.org>
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #  and documentation
 # make coverage-report to check coverage of the python scripts by the tests
 
-CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmermodule.cc)
+CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmer.cc)
 PYSOURCES=$(wildcard khmer/*.py scripts/*.py)
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
 DEVPKGS=pep8==1.5.7 diff_cover autopep8 pylint coverage gcovr nose pep257 \
@@ -44,9 +44,9 @@ install-dependencies:
 	pip install --upgrade --requirement doc/requirements.txt
 
 ## sharedobj   : build khmer shared object file
-sharedobj: khmer/_khmermodule.so
+sharedobj: khmer/_khmer.so
 
-khmer/_khmermodule.so: $(CPPSOURCES)
+khmer/_khmer.so: $(CPPSOURCES)
 	./setup.py build_ext --inplace
 
 coverage-debug: $(CPPSOURCES)
@@ -68,7 +68,7 @@ dist/khmer-$(VERSION).tar.gz: $(SOURCES)
 clean: FORCE
 	cd lib && ${MAKE} clean || true
 	cd tests && rm -rf khmertest_* || true
-	rm -f khmer/_khmermodule.so
+	rm -f khmer/_khmer*.so
 	rm -f khmer/*.pyc lib/*.pyc
 	./setup.py clean --all || true
 	rm -f coverage-debug
@@ -160,7 +160,7 @@ diff_pylint_report: pylint_report.txt
 # We need to get coverage to look at our scripts. Since they aren't in a
 # python module we can't tell nosetests to look for them (via an import
 # statement). So we run nose inside of coverage.
-.coverage: $(PYSOURCES) $(wildcard tests/*.py) khmer/_khmermodule.so
+.coverage: $(PYSOURCES) $(wildcard tests/*.py) $(wildcard khmer/_khmer*.so)
 	coverage run --branch --source=scripts,khmer,oxli --omit=khmer/_version.py \
 		-m nose --with-xunit --attr=\!known_failing,\!huge \
 		--processes=0

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ CPPCHECK=ls lib/*.cc khmer/_khmer.cc | grep -v test | cppcheck -DNDEBUG \
 
 UNAME := $(shell uname)
 ifeq ($(UNAME),Linux)
-	TESTATTR='!known_failing,!jenkins,!huge'
+	TESTATTR ?= '!known_failing,!jenkins,!huge'
 else
-	TESTATTR='!known_failing,!jenkins,!huge,!linux'
+	TESTATTR ?= '!known_failing,!jenkins,!huge,!linux'
 endif
 
 ## all         : default task; compile C++ code, build shared object library
@@ -162,8 +162,7 @@ diff_pylint_report: pylint_report.txt
 # statement). So we run nose inside of coverage.
 .coverage: $(PYSOURCES) $(wildcard tests/*.py) $(wildcard khmer/_khmer*.so)
 	coverage run --branch --source=scripts,khmer,oxli --omit=khmer/_version.py \
-		-m nose --with-xunit --attr=\!known_failing,\!huge \
-		--processes=0
+		-m nose --with-xunit --attr $(TEST_ATTR) --processes=0
 
 coverage.xml: .coverage
 	coverage xml

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,8 @@ diff_pylint_report: pylint_report.txt
 # statement). So we run nose inside of coverage.
 .coverage: $(PYSOURCES) $(wildcard tests/*.py) khmer/_khmermodule.so
 	coverage run --branch --source=scripts,khmer,oxli --omit=khmer/_version.py \
-		-m nose --with-xunit --attr=\!known_failing --processes=0
+		-m nose --with-xunit --attr=\!known_failing,\!huge \
+		--processes=0
 
 coverage.xml: .coverage
 	coverage xml

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -4,12 +4,12 @@ make clean
 
 rm -Rf .env dist cov-int
 
-if type python2> /dev/null 2>&1
-then
-    PYTHON_EXECUTABLE=$(which python2)
-else
-    PYTHON_EXECUTABLE=$(which python)
-fi
+#if type python2> /dev/null 2>&1
+#then
+#    PYTHON_EXECUTABLE=$(which python2)
+#else
+#    PYTHON_EXECUTABLE=$(which python)
+#fi
 virtualenv -p ${PYTHON_EXECUTABLE} .env
 
 . .env/bin/activate

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -4,12 +4,14 @@ make clean
 
 rm -Rf .env dist cov-int
 
-#if type python2> /dev/null 2>&1
-#then
-#    PYTHON_EXECUTABLE=$(which python2)
-#else
-#    PYTHON_EXECUTABLE=$(which python)
-#fi
+if [ -z "${PYTHON_EXECUTABLE}" ]; then
+    if type python2> /dev/null 2>&1
+    then
+        PYTHON_EXECUTABLE=$(which python2)
+    else
+        PYTHON_EXECUTABLE=$(which python)
+    fi
+fi
 virtualenv -p ${PYTHON_EXECUTABLE} .env
 
 . .env/bin/activate

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -34,7 +34,7 @@ then
 	export CFLAGS="-pg -fprofile-arcs -ftest-coverage"
 	python setup.py build_ext --build-temp $PWD --debug --inplace \
 		--libraries gcov develop
-	make coverage-gcovr.xml coverage.xml
+	make coverage-gcovr.xml coverage.xml TESTATTR='!known_failing,!huge'
 	./setup.py install
 else
 	echo "gcov was not found (or we are on OSX), skipping coverage check"


### PR DESCRIPTION
- Jenkins: Reuse PYTHON_EXECUTABLE from the environment.
- Generate the appropriate name for the Python extension module based on the correct version and implementation.
- Update coverage arguments.
