### PR TITLE
removed incorrect warning for max_tablesize when -M is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-06-30  Titus Brown  <titus@idyll.org>
+
+   * khmer/khmer_args.py: removed incorrect warning for default max_tablesize
+   when -M is used.
+   * tests/test_scripts.py: added test for correct max_tablesize behavior.
+
 2015-06-29  Sherine Awad  <drmahmoud@ucdavis.edu>
 
    * Fix bug in naming in interleave-reads.py

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -195,17 +195,17 @@ def report_on_config(args, hashtype='countgraph'):
         print_error(
             "Estimated memory usage is {0:.2g} bytes "
             "(n_tables x max_tablesize)".format(
-                args.n_tables * args.max_tablesize))
+                args.n_tables * tablesize))
     elif hashtype == 'nodegraph':
         print_error(
             "Estimated memory usage is {0:.2g} bytes "
             "(n_tables x max_tablesize / 8)".format(args.n_tables *
-                                                    args.max_tablesize / 8)
+                                                    tablesize / 8)
         )
 
     print_error("-" * 8)
 
-    if DEFAULT_MAX_TABLESIZE == args.max_tablesize and \
+    if DEFAULT_MAX_TABLESIZE == tablesize and \
        not getattr(args, 'loadtable', None):
         print_error('''\
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -54,6 +54,20 @@ def test_load_into_counting():
     assert os.path.exists(outfile)
 
 
+def test_load_into_counting_tablesize_warning():
+    script = 'load-into-counting.py'
+    args = ['-k', '20', '-t']
+
+    outfile = utils.get_temp_filename('out.ct')
+    infile = utils.get_test_data('test-abund-read-2.fa')
+
+    args.extend([outfile, infile])
+
+    (status, out, err) = utils.runscript(script, args)
+    assert os.path.exists(outfile)
+    assert "WARNING: tablesize is default!" in err
+
+
 def test_load_into_counting_max_memory_usage_parameter():
     script = 'load-into-counting.py'
     args = ['-M', '2e3', '-k', '20', '-t']
@@ -65,6 +79,7 @@ def test_load_into_counting_max_memory_usage_parameter():
 
     (status, out, err) = utils.runscript(script, args)
     assert os.path.exists(outfile)
+    assert "WARNING: tablesize is default!" not in err
 
     kh = khmer.load_counting_hash(outfile)
     assert sum(kh.hashsizes()) < 3e8


### PR DESCRIPTION
A leftover bug from #1050.