### PR TITLE
Fix Python 3 errors and coding style

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2015-07-06  Luiz Irber  <khmer@luizirber.org>
+
+   * sandbox/collect-reads.py: Set a default value for coverage based
+   on the docstring.
+   * sandbox/count-kmers-single.py, tests/test_{functions,script_arguments}.py:
+   Replace xrange and cStringIO (not Python 3 compatible).
+   * lib/*.{hh,cc}, oxli/functions.py, tests/*.py: make format.
+
 2015-07-05  Jaob Fenton  <bocajnotnef@gmail.com>
 
    * doc/whats-new-2.0.rst: added in normalize-by-median.py broken paired 

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -40,8 +40,7 @@ protected:
 
     Byte ** _counts;
 
-    virtual void _allocate_counters()
-    {
+    virtual void _allocate_counters() {
         _n_tables = _tablesizes.size();
 
         _counts = new Byte*[_n_tables];
@@ -55,8 +54,7 @@ public:
 
     CountingHash( WordLength ksize, HashIntoType single_tablesize ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
-        _bigcount_spin_lock(false), _n_unique_kmers(0)
-    {
+        _bigcount_spin_lock(false), _n_unique_kmers(0) {
         _tablesizes.push_back(single_tablesize);
 
         _allocate_counters();
@@ -64,14 +62,12 @@ public:
 
     CountingHash( WordLength ksize, std::vector<HashIntoType>& tablesizes ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
-        _bigcount_spin_lock(false), _tablesizes(tablesizes), _n_unique_kmers(0)
-    {
+        _bigcount_spin_lock(false), _tablesizes(tablesizes), _n_unique_kmers(0) {
 
         _allocate_counters();
     }
 
-    virtual ~CountingHash()
-    {
+    virtual ~CountingHash() {
         if (_counts) {
             for (size_t i = 0; i < _n_tables; i++) {
                 if (_counts[i]) {
@@ -89,38 +85,32 @@ public:
 
     // Writing to the tables outside of defined methods has undefined behavior!
     // As such, this should only be used to return read-only interfaces
-    Byte ** get_raw_tables()
-    {
+    Byte ** get_raw_tables() {
         return _counts;
     }
 
-    virtual BoundedCounterType test_and_set_bits(const char * kmer)
-    {
+    virtual BoundedCounterType test_and_set_bits(const char * kmer) {
         BoundedCounterType x = get_count(kmer); // @CTB just hash it, yo.
         count(kmer);
         return !x;
     }
 
-    virtual BoundedCounterType test_and_set_bits(HashIntoType khash)
-    {
+    virtual BoundedCounterType test_and_set_bits(HashIntoType khash) {
         BoundedCounterType x = get_count(khash);
         count(khash);
         return !x;
     }
 
-    std::vector<HashIntoType> get_tablesizes() const
-    {
+    std::vector<HashIntoType> get_tablesizes() const {
         return _tablesizes;
     }
 
     virtual const HashIntoType n_unique_kmers() const;
 
-    void set_use_bigcount(bool b)
-    {
+    void set_use_bigcount(bool b) {
         _use_bigcount = b;
     }
-    bool get_use_bigcount()
-    {
+    bool get_use_bigcount() {
         return _use_bigcount;
     }
 
@@ -128,20 +118,17 @@ public:
     virtual void load(std::string);
 
     // accessors to get table info
-    const HashIntoType n_entries() const
-    {
+    const HashIntoType n_entries() const {
         return _tablesizes[0];
     }
 
-    const size_t n_tables() const
-    {
+    const size_t n_tables() const {
         return _n_tables;
     }
 
     // count number of occupied bins
     virtual const HashIntoType n_occupied(HashIntoType start=0,
-                                          HashIntoType stop=0) const
-    {
+                                          HashIntoType stop=0) const {
         HashIntoType n = 0;
         if (stop == 0) {
             stop = _tablesizes[0];
@@ -154,14 +141,12 @@ public:
         return n;
     }
 
-    virtual void count(const char * kmer)
-    {
+    virtual void count(const char * kmer) {
         HashIntoType hash = _hash(kmer, _ksize);
         count(hash);
     }
 
-    virtual void count(HashIntoType khash)
-    {
+    virtual void count(HashIntoType khash) {
         bool is_new_kmer = true;
         unsigned int  n_full	  = 0;
 
@@ -203,15 +188,13 @@ public:
     } // count
 
     // get the count for the given k-mer.
-    virtual const BoundedCounterType get_count(const char * kmer) const
-    {
+    virtual const BoundedCounterType get_count(const char * kmer) const {
         HashIntoType hash = _hash(kmer, _ksize);
         return get_count(hash);
     }
 
     // get the count for the given k-mer hash.
-    virtual const BoundedCounterType get_count(HashIntoType khash) const
-    {
+    virtual const BoundedCounterType get_count(HashIntoType khash) const {
         unsigned int	  max_count	= _max_count;
         BoundedCounterType  min_count	= max_count;
         for (unsigned int i = 0; i < _n_tables; i++) {

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -26,8 +26,7 @@ protected:
     HashIntoType _n_overlap_kmers;
     Byte ** _counts;
 
-    virtual void _allocate_counters()
-    {
+    virtual void _allocate_counters() {
         _n_tables = _tablesizes.size();
 
         _counts = new Byte*[_n_tables];
@@ -44,8 +43,7 @@ protected:
 public:
     Hashbits(WordLength ksize, std::vector<HashIntoType>& tablesizes)
         : khmer::Hashtable(ksize),
-          _tablesizes(tablesizes)
-    {
+          _tablesizes(tablesizes) {
         _occupied_bins = 0;
         _n_unique_kmers = 0;
         _n_overlap_kmers = 0;
@@ -53,8 +51,7 @@ public:
         _allocate_counters();
     }
 
-    ~Hashbits()
-    {
+    ~Hashbits() {
         if (_counts) {
             for (size_t i = 0; i < _n_tables; i++) {
                 delete[] _counts[i];
@@ -69,13 +66,11 @@ public:
     }
 
     // Accessors for protected/private table info members
-    std::vector<HashIntoType> get_tablesizes() const
-    {
+    std::vector<HashIntoType> get_tablesizes() const {
         return _tablesizes;
     }
 
-    const size_t n_tables() const
-    {
+    const size_t n_tables() const {
         return _n_tables;
     }
 
@@ -99,14 +94,12 @@ public:
 
     // count number of occupied bins
     virtual const HashIntoType n_occupied(HashIntoType start=0,
-                                          HashIntoType stop=0) const
-    {
+                                          HashIntoType stop=0) const {
         // @@ CTB need to be able to *save* this...
         return _occupied_bins/_n_tables;
     }
 
-    virtual const HashIntoType n_unique_kmers() const
-    {
+    virtual const HashIntoType n_unique_kmers() const {
         return _n_unique_kmers;	// @@ CTB need to be able to *save* this...
     }
 
@@ -114,8 +107,7 @@ public:
     inline
     virtual
     BoundedCounterType
-    test_and_set_bits(const char * kmer)
-    {
+    test_and_set_bits(const char * kmer) {
         HashIntoType hash = _hash(kmer, _ksize);
         return test_and_set_bits(hash);
     }
@@ -128,8 +120,7 @@ public:
     inline
     virtual
     BoundedCounterType
-    test_and_set_bits( HashIntoType khash )
-    {
+    test_and_set_bits( HashIntoType khash ) {
         bool is_new_kmer = false;
 
         for (size_t i = 0; i < _n_tables; i++) {
@@ -153,19 +144,16 @@ public:
     } // test_and_set_bits
 
     virtual const HashIntoType n_overlap_kmers(HashIntoType start=0,
-            HashIntoType stop=0) const
-    {
+            HashIntoType stop=0) const {
         return _n_overlap_kmers;	// @@ CTB need to be able to *save* this...
     }
 
-    virtual void count(const char * kmer)
-    {
+    virtual void count(const char * kmer) {
         HashIntoType hash = _hash(kmer, _ksize);
         count(hash);
     }
 
-    virtual void count(HashIntoType khash)
-    {
+    virtual void count(HashIntoType khash) {
         bool is_new_kmer = false;
 
         for (size_t i = 0; i < _n_tables; i++) {
@@ -183,8 +171,7 @@ public:
         }
     }
 
-    virtual bool check_overlap(HashIntoType khash, Hashbits &ht2)
-    {
+    virtual bool check_overlap(HashIntoType khash, Hashbits &ht2) {
 
         for (size_t i = 0; i < ht2._n_tables; i++) {
             HashIntoType bin = khash % ht2._tablesizes[i];
@@ -197,14 +184,12 @@ public:
         return true;
     }
 
-    virtual void count_overlap(const char * kmer, Hashbits &ht2)
-    {
+    virtual void count_overlap(const char * kmer, Hashbits &ht2) {
         HashIntoType hash = _hash(kmer, _ksize);
         count_overlap(hash,ht2);
     }
 
-    virtual void count_overlap(HashIntoType khash, Hashbits &ht2)
-    {
+    virtual void count_overlap(HashIntoType khash, Hashbits &ht2) {
         bool is_new_kmer = false;
 
         for (size_t i = 0; i < _n_tables; i++) {
@@ -226,15 +211,13 @@ public:
     }
 
     // get the count for the given k-mer.
-    virtual const BoundedCounterType get_count(const char * kmer) const
-    {
+    virtual const BoundedCounterType get_count(const char * kmer) const {
         HashIntoType hash = _hash(kmer, _ksize);
         return get_count(hash);
     }
 
     // get the count for the given k-mer hash.
-    virtual const BoundedCounterType get_count(HashIntoType khash) const
-    {
+    virtual const BoundedCounterType get_count(HashIntoType khash) const {
         for (size_t i = 0; i < _n_tables; i++) {
             HashIntoType bin = khash % _tablesizes[i];
             HashIntoType byte = bin / 8;
@@ -247,8 +230,7 @@ public:
         return 1;
     }
     // accessors to get table info
-    const HashIntoType n_entries() const
-    {
+    const HashIntoType n_entries() const {
         return _tablesizes[0];
     }
 

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -81,8 +81,7 @@ protected:
     size_t length;
     bool initialized;
 public:
-    KMerIterator(const char * seq, unsigned char k) : _seq(seq), _ksize(k)
-    {
+    KMerIterator(const char * seq, unsigned char k) : _seq(seq), _ksize(k) {
         bitmask = 0;
         for (unsigned char i = 0; i < _ksize; i++) {
             bitmask = (bitmask << 2) | 3;
@@ -97,8 +96,7 @@ public:
         initialized = false;
     }
 
-    HashIntoType first(HashIntoType& f, HashIntoType& r)
-    {
+    HashIntoType first(HashIntoType& f, HashIntoType& r) {
         HashIntoType x;
         x = _hash(_seq, _ksize, _kmer_f, _kmer_r);
 
@@ -110,8 +108,7 @@ public:
         return x;
     }
 
-    HashIntoType next(HashIntoType& f, HashIntoType& r)
-    {
+    HashIntoType next(HashIntoType& f, HashIntoType& r) {
         if (done()) {
             throw khmer_exception();
         }
@@ -146,27 +143,22 @@ public:
         return uniqify_rc(_kmer_f, _kmer_r);
     }
 
-    HashIntoType first()
-    {
+    HashIntoType first() {
         return first(_kmer_f, _kmer_r);
     }
-    HashIntoType next()
-    {
+    HashIntoType next() {
         return next(_kmer_f, _kmer_r);
     }
 
-    bool done()
-    {
+    bool done() {
         return index >= length;
     }
 
-    unsigned int get_start_pos() const
-    {
+    unsigned int get_start_pos() const {
         return index - _ksize;
     }
 
-    unsigned int get_end_pos() const
-    {
+    unsigned int get_end_pos() const {
         return index;
     }
 }; // class KMerIterator
@@ -188,8 +180,7 @@ protected:
     explicit Hashtable( WordLength ksize )
         : _max_count( MAX_KCOUNT ),
           _max_bigcount( MAX_BIGCOUNT ),
-          _ksize( ksize )
-    {
+          _ksize( ksize ) {
         _tag_density = DEFAULT_TAG_DENSITY;
         if (!(_tag_density % 2 == 0)) {
             throw khmer_exception();
@@ -200,13 +191,11 @@ protected:
 
     }
 
-    virtual ~Hashtable( )
-    {
+    virtual ~Hashtable( ) {
         delete partition;
     }
 
-    void _init_bitstuff()
-    {
+    void _init_bitstuff() {
         bitmask = 0;
         for (unsigned int i = 0; i < _ksize; i++) {
             bitmask = (bitmask << 2) | 3;
@@ -214,8 +203,7 @@ protected:
         _nbits_sub_1 = (_ksize*2 - 2);
     }
 
-    HashIntoType _next_hash(char ch, HashIntoType &h, HashIntoType &r) const
-    {
+    HashIntoType _next_hash(char ch, HashIntoType &h, HashIntoType &r) const {
         // left-shift the previous hash over
         h = h << 2;
 
@@ -232,8 +220,7 @@ protected:
         return uniqify_rc(h, r);
     }
 
-    void _clear_all_partitions()
-    {
+    void _clear_all_partitions() {
         if (partition != NULL) {
             partition->_clear_all_partitions();
         }
@@ -251,8 +238,7 @@ public:
     SeenSet repart_small_tags;
 
     // accessor to get 'k'
-    const WordLength ksize() const
-    {
+    const WordLength ksize() const {
         return _ksize;
     }
 
@@ -303,8 +289,7 @@ public:
     virtual const HashIntoType n_unique_kmers() const = 0;
 
     // partitioning stuff
-    void _validate_pmap()
-    {
+    void _validate_pmap() {
         if (partition) {
             partition->_validate_pmap();
         }
@@ -314,44 +299,37 @@ public:
     virtual void load_tagset(std::string, bool clear_tags=true);
 
     // for debugging/testing purposes only!
-    void _set_tag_density(unsigned int d)
-    {
+    void _set_tag_density(unsigned int d) {
         if (!(d % 2 == 0) || !all_tags.empty()) { // must be even and tags must exist
             throw khmer_exception();
         }
         _tag_density = d;
     }
 
-    unsigned int _get_tag_density() const
-    {
+    unsigned int _get_tag_density() const {
         return _tag_density;
     }
 
-    void add_tag(HashIntoType tag)
-    {
+    void add_tag(HashIntoType tag) {
         all_tags.insert(tag);
     }
-    void add_stop_tag(HashIntoType tag)
-    {
+    void add_stop_tag(HashIntoType tag) {
         stop_tags.insert(tag);
     }
 
     // Partitioning stuff.
 
-    size_t n_tags() const
-    {
+    size_t n_tags() const {
         return all_tags.size();
     }
 
     void divide_tags_into_subsets(unsigned int subset_size, SeenSet& divvy);
 
-    void add_kmer_to_tags(HashIntoType kmer)
-    {
+    void add_kmer_to_tags(HashIntoType kmer) {
         all_tags.insert(kmer);
     }
 
-    void clear_tags()
-    {
+    void clear_tags() {
         all_tags.clear();
     }
 
@@ -441,8 +419,7 @@ public:
                                    unsigned long long& count,
                                    SeenSet& keeper,
                                    const unsigned long long threshold=0,
-                                   bool break_on_circum=false) const
-    {
+                                   bool break_on_circum=false) const {
         HashIntoType r, f;
         _hash(kmer, _ksize, f, r);
         calc_connected_graph_size(f, r, count, keeper, threshold, break_on_circum);
@@ -459,8 +436,7 @@ public:
 
 
     unsigned int kmer_degree(HashIntoType kmer_f, HashIntoType kmer_r) const;
-    unsigned int kmer_degree(const char * kmer_s) const
-    {
+    unsigned int kmer_degree(const char * kmer_s) const {
         HashIntoType kmer_f, kmer_r;
         _hash(kmer_s, _ksize, kmer_f, kmer_r);
 

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -381,14 +381,12 @@ void HLLCounter::consume_fasta(
             total_reads_partial = (unsigned int*)calloc(omp_get_num_threads(),
             sizeof(unsigned int));
 
-            for (int i=0; i < omp_get_num_threads(); i++)
-            {
+            for (int i=0; i < omp_get_num_threads(); i++) {
                 HLLCounter *newc = new HLLCounter(this->p, this->_ksize);
                 counters[i] = newc;
             }
 
-            while (!parser->is_complete())
-            {
+            while (!parser->is_complete()) {
                 // Iterate through the reads and consume their k-mers.
                 try {
                     read = parser->get_next_read();
@@ -415,8 +413,7 @@ void HLLCounter::consume_fasta(
 
         #pragma omp single
         {
-            for (int i=0; i < omp_get_num_threads(); ++i)
-            {
+            for (int i=0; i < omp_get_num_threads(); ++i) {
                 this->merge(*counters[i]);
                 delete counters[i];
                 n_consumed += n_consumed_partial[i];

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -38,25 +38,20 @@ public:
     void merge(HLLCounter &);
     virtual ~HLLCounter() {}
 
-    double get_alpha()
-    {
+    double get_alpha() {
         return alpha;
     }
-    int get_p()
-    {
+    int get_p() {
         return p;
     }
-    int get_m()
-    {
+    int get_m() {
         return m;
     }
     void set_ksize(WordLength new_ksize);
-    int get_ksize()
-    {
+    int get_ksize() {
         return _ksize;
     }
-    std::vector<int> get_M()
-    {
+    std::vector<int> get_M() {
         return M;
     }
     double get_erate();

--- a/lib/khmer_exception.hh
+++ b/lib/khmer_exception.hh
@@ -26,8 +26,7 @@ public:
         : _msg(msg) { }
 
     virtual ~khmer_exception() throw() { }
-    virtual const char* what() const throw ()
-    {
+    virtual const char* what() const throw () {
         return _msg.c_str();
     }
 

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -225,7 +225,7 @@ void LabelHash::consume_sequence_and_tag_with_labels(const std::string& seq,
                     // TODO: MAKE THREADSAFE!
 
                     if (!_cmap_contains_label(tag_labels, kmer, current_label)) {
-                        printdbg(tag was not labeled: adding to labels...)
+printdbg(tag was not labeled: adding to labels...)
                         //ACQUIRE_TAG_COLORS_SPIN_LOCK
                         link_tag_and_label(kmer, current_label);
                         //RELEASE_TAG_COLORS_SPIN_LOCK
@@ -251,7 +251,7 @@ void LabelHash::consume_sequence_and_tag_with_labels(const std::string& seq,
 #endif
             //
             if (since >= graph->_tag_density) {
-                printdbg(exceeded tag density: drop a tag and label --
+printdbg(exceeded tag density: drop a tag and label --
                          getting tag lock)
                 //ACQUIRE_ALL_TAGS_SPIN_LOCK
                 printdbg(in tag spin lock)
@@ -272,7 +272,7 @@ void LabelHash::consume_sequence_and_tag_with_labels(const std::string& seq,
             }
             printdbg(moving to next iter)
         } // iteration over kmers
-    printdbg(finished iteration: dropping last tag)
+printdbg(finished iteration: dropping last tag)
     if (since >= graph->_tag_density/2 - 1) {
         //ACQUIRE_ALL_TAGS_SPIN_LOCK
         graph->all_tags.insert(kmer);	// insert the last k-mer, too.

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -24,8 +24,7 @@ protected:
     // Does the given tag already have the given label?
     bool _cmap_contains_label(const TagLabelPtrMap& cmap,
                               HashIntoType& kmer,
-                              Label& the_label)
-    {
+                              Label& the_label) {
         std::pair<TagLabelPtrMap::const_iterator, TagLabelPtrMap::const_iterator> ret;
         ret = cmap.equal_range(kmer);
         for (TagLabelPtrMap::const_iterator it=ret.first; it!=ret.second; ++it) {
@@ -39,8 +38,7 @@ protected:
     // Does the given label already have a tag associated with it?
     bool _cmap_contains_tag(const LabelTagMap& cmap,
                             Label& the_label,
-                            HashIntoType& kmer)
-    {
+                            HashIntoType& kmer) {
         std::pair<LabelTagMap::const_iterator, LabelTagMap::const_iterator> ret;
         ret = cmap.equal_range(the_label);
         for (LabelTagMap::const_iterator it=ret.first; it!=ret.second; ++it) {
@@ -53,8 +51,7 @@ protected:
 
     unsigned int _get_tag_labels(const HashIntoType& tag,
                                  const TagLabelPtrMap& cmap,
-                                 LabelPtrSet& found_labels)
-    {
+                                 LabelPtrSet& found_labels) {
         unsigned int num_labels = 0;
         std::pair<TagLabelPtrMap::const_iterator, TagLabelPtrMap::const_iterator> ret;
         ret = cmap.equal_range(tag);
@@ -67,8 +64,7 @@ protected:
 
     unsigned int _get_tags_from_label(const Label& label,
                                       const LabelTagMap& cmap,
-                                      TagSet& labeled_tags)
-    {
+                                      TagSet& labeled_tags) {
         unsigned int num_tags = 0;
         std::pair<LabelTagMap::const_iterator, LabelTagMap::const_iterator> ret;
         ret = cmap.equal_range(label);
@@ -84,8 +80,7 @@ protected:
 public:
     khmer::Hashtable * graph;
 
-    explicit LabelHash(Hashtable * ht) : graph(ht)
-    {
+    explicit LabelHash(Hashtable * ht) : graph(ht) {
         _tag_labels_spin_lock = 0;
 
     }
@@ -96,14 +91,12 @@ public:
     LabelTagMap label_tag_ptrs;
     LabelPtrMap label_ptrs;
 
-    size_t n_labels() const
-    {
+    size_t n_labels() const {
         return label_ptrs.size();
     }
 
 
-    Label * check_and_allocate_label(Label new_label)
-    {
+    Label * check_and_allocate_label(Label new_label) {
         Label * c;
         if (label_ptrs.count(new_label)) {
             c = label_ptrs[new_label];

--- a/lib/perf_metrics.hh
+++ b/lib/perf_metrics.hh
@@ -28,8 +28,7 @@ struct IPerformanceMetrics {
     IPerformanceMetrics( );
     virtual ~IPerformanceMetrics( );
 
-    inline void	    start_timers( )
-    {
+    inline void	    start_timers( ) {
 #if defined (__linux__)
         clock_gettime( CLOCK_REALTIME, &_temp_clock_start );
         clock_gettime( CLOCK_THREAD_CPUTIME_ID, &_temp_cpu_start );
@@ -39,8 +38,7 @@ struct IPerformanceMetrics {
         memset( &_temp_cpu_start, 0, sizeof( timespec ) );
 #endif
     }
-    inline void	    stop_timers( )
-    {
+    inline void	    stop_timers( ) {
 #if defined (__linux__)
         clock_gettime( CLOCK_THREAD_CPUTIME_ID, &_temp_cpu_stop );
         clock_gettime( CLOCK_REALTIME, &_temp_clock_stop );

--- a/lib/primes.hh
+++ b/lib/primes.hh
@@ -22,8 +22,7 @@ private:
     HashIntoType n;
 
     /* Returns true if n is prime, false otherwise */
-    bool is_prime()
-    {
+    bool is_prime() {
         if (n < 2) {
             return false;
         }
@@ -43,8 +42,7 @@ private:
     }
 
 public:
-    Primes(HashIntoType num)
-    {
+    Primes(HashIntoType num) {
         /* Make sure that the initial number to start from is odd
          * and strictly greater than num */
         n = ++num;
@@ -54,8 +52,7 @@ public:
     }
 
     /* Returns the next prime >= n */
-    HashIntoType get_next_prime()
-    {
+    HashIntoType get_next_prime() {
         for (;;) {
             if (is_prime()) {
                 /* If n is prime, we need to make sure to increment

--- a/lib/read_aligner.cc
+++ b/lib/read_aligner.cc
@@ -10,8 +10,7 @@ namespace khmer
 {
 
 struct del_alignment_node_t {
-    del_alignment_node_t& operator()(AlignmentNode* p)
-    {
+    del_alignment_node_t& operator()(AlignmentNode* p) {
         delete p;
         return *this;
     }

--- a/lib/read_aligner.hh
+++ b/lib/read_aligner.hh
@@ -113,15 +113,13 @@ struct AlignmentNode {
          rc_hash(_rc_hash), score(0), f_score(0), h_score(0), trusted(false),
          num_indels(0), length(_length) {}
 
-    bool operator== (const AlignmentNode& rhs) const
-    {
+    bool operator== (const AlignmentNode& rhs) const {
         return (seq_idx == rhs.seq_idx) && (state == rhs.state) &&
                uniqify_rc(fwd_hash, rc_hash) == uniqify_rc(rhs.fwd_hash, rhs.rc_hash)
                && trans == rhs.trans;
     }
 
-    bool operator< (const AlignmentNode& rhs) const
-    {
+    bool operator< (const AlignmentNode& rhs) const {
         return f_score < rhs.f_score;
     }
 };
@@ -129,8 +127,7 @@ struct AlignmentNode {
 class AlignmentNodeCompare
 {
 public:
-    bool operator()(AlignmentNode* o1, AlignmentNode* o2)
-    {
+    bool operator()(AlignmentNode* o1, AlignmentNode* o2) {
         if (o1->f_score < o2->f_score) {
             return true;
         } else {
@@ -195,8 +192,7 @@ private:
     size_t m_trusted_cutoff;
     double m_bits_theta;
 
-    HashIntoType comp_bitmask(WordLength k)
-    {
+    HashIntoType comp_bitmask(WordLength k) {
         HashIntoType ret = 0;
         for (size_t i = 0; i < k; i++) {
             ret = (ret << 2) | 3;
@@ -215,8 +211,7 @@ public:
               log2(.955), log2(.04), log2(.004),
               log2(.001), trans_default),
           m_trusted_cutoff(trusted_cutoff),
-          m_bits_theta(bits_theta)
-    {
+          m_bits_theta(bits_theta) {
 #if READ_ALIGNER_DEBUG
         std::cerr << "Trusted cutoff: " << m_trusted_cutoff
                   << " bits theta: " << bits_theta

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -56,8 +56,7 @@ struct Read {
     std:: string    quality;
     // TODO? Add description field.
 
-    inline void reset ( )
-    {
+    inline void reset ( ) {
         name.clear( );
         annotations.clear( );
         sequence.clear( );
@@ -90,8 +89,7 @@ struct IParser {
     //	     upon return.
     // TODO: Eliminate all calls to 'get_next_read'.
     // Or switch to C++11 w/ move constructors
-    inline Read		get_next_read( )
-    {
+    inline Read		get_next_read( ) {
         Read the_read;
         imprint_next_read( the_read );
         return the_read;
@@ -103,8 +101,7 @@ struct IParser {
         uint8_t mode = PAIR_MODE_ERROR_ON_UNPAIRED
     );
 
-    size_t		    get_num_reads()
-    {
+    size_t		    get_num_reads() {
         return _num_reads;
     }
 

--- a/lib/subset.hh
+++ b/lib/subset.hh
@@ -40,13 +40,11 @@ protected:
                                            const HashIntoType kmer);
 
 public:
-    explicit SubsetPartition(Hashtable * ht) : next_partition_id(2), _ht(ht)
-    {
+    explicit SubsetPartition(Hashtable * ht) : next_partition_id(2), _ht(ht) {
         ;
     };
 
-    ~SubsetPartition()
-    {
+    ~SubsetPartition() {
         _clear_all_partitions();
     }
 
@@ -58,8 +56,7 @@ public:
     PartitionID get_partition_id(std::string kmer_s);
     PartitionID get_partition_id(HashIntoType kmer);
 
-    PartitionID * get_new_partition()
-    {
+    PartitionID * get_new_partition() {
         PartitionID* pp = new PartitionID(next_partition_id);
         next_partition_id++;
         return pp;

--- a/oxli/functions.py
+++ b/oxli/functions.py
@@ -17,13 +17,13 @@ def estimate_optimal_with_N_and_M(N, M):
     Utility function for estimating optimal counting table args where N is the
     number of unique kmer and M is the allotted amount of memory
     """
-    Z = math.log(2)*(M/float(N))
+    Z = math.log(2) * (M / float(N))
     intZ = int(Z)
     if intZ == 0:
         intZ = 1
-    H = int(M/intZ)
-    M = H*intZ
-    f2 = (1-math.exp(-N/float(H)))**intZ
+    H = int(M / intZ)
+    M = H * intZ
+    f2 = (1 - math.exp(-N / float(H))) ** intZ
     res = namedtuple("result", ["num_htables", "htable_size", "mem_use",
                                 "fp_rate"])
     return res(intZ, H, M, f2)
@@ -39,9 +39,9 @@ def estimate_optimal_with_N_and_f(N, f):
     if intZ == 0:
         intZ = 1
 
-    H1 = int(-N/(math.log(1-f**(1/float(intZ)))))
+    H1 = int(-N / (math.log(1 - f ** (1 / float(intZ)))))
     M1 = H1 * intZ
-    f1 = (1-math.exp(-N/float(H1)))**intZ
+    f1 = (1 - math.exp(-N / float(H1))) ** intZ
 
     res = namedtuple("result", ["num_htables", "htable_size", "mem_use",
                                 "fp_rate"])
@@ -63,7 +63,8 @@ def optimal_args_output_gen(unique_kmers, fp_rate):
                     'expected_memory_usage')
 
     for fp_rate in range(1, 10):
-        Z, H, M, f = estimate_optimal_with_N_and_f(unique_kmers, fp_rate/10.0)
+        Z, H, M, f = estimate_optimal_with_N_and_f(
+            unique_kmers, fp_rate / 10.0)
         to_print.append('{:11.3f}\t{:19}\t{:17e}\t{:21e}'.format(f, Z, H, M))
 
     mem_list = [1, 5, 10, 20, 50, 100, 200, 300, 400, 500, 1000, 2000, 5000]
@@ -75,7 +76,7 @@ def optimal_args_output_gen(unique_kmers, fp_rate):
 
     for mem in mem_list:
         Z, H, M, f = estimate_optimal_with_N_and_M(unique_kmers,
-                                                   mem*1000000000)
+                                                   mem * 1000000000)
         to_print.append('{:21e}\t{:19}\t{:17e}\t{:11.3f}'.format(M, Z, H, f))
     return "\n".join(to_print)
 

--- a/sandbox/collect-reads.py
+++ b/sandbox/collect-reads.py
@@ -54,7 +54,7 @@ def get_parser():
                         "sequence files.")
     parser.add_argument('--report-total-kmers', '-t', action='store_true',
                         help="Prints the total number of k-mers to stderr")
-    parser.add_argument('-C', '--coverage', type=int,
+    parser.add_argument('-C', '--coverage', type=int, default=50,
                         help='Collect reads until this coverage, then exit.')
     parser.add_argument('-o', '--output', type=argparse.FileType('w'),
                         help='Write collect reads into this file.')

--- a/sandbox/count-kmers-single.py
+++ b/sandbox/count-kmers-single.py
@@ -73,7 +73,7 @@ def main():
     threads = []
     print ('consuming input, round 1 -- %s' % (args.input_sequence_filename),
            file=sys.stderr)
-    for _ in xrange(args.threads):
+    for _ in range(args.threads):
         thread = \
             threading.Thread(
                 target=counting_hash.consume_fasta_with_reads_parser,

--- a/tests/test_counting_hash.py
+++ b/tests/test_counting_hash.py
@@ -574,7 +574,7 @@ def test_save_load_large():
         inpath = utils.get_test_data('random-20-a.fa')
         savepath = utils.get_temp_filename(ctfile)
 
-        sizes = khmer.get_n_primes_near_x(1, 2**31 + 1000)
+        sizes = khmer.get_n_primes_near_x(1, 2 ** 31 + 1000)
 
         orig = khmer._CountingHash(12, sizes)
         orig.consume_fasta(inpath)

--- a/tests/test_counting_single.py
+++ b/tests/test_counting_single.py
@@ -69,7 +69,7 @@ def test_hashtable_n_entries():
 
 
 def test_complete_no_collision():
-    kh = khmer._CountingHash(4, [4**4])
+    kh = khmer._CountingHash(4, [4 ** 4])
 
     for i in range(0, kh.n_entries()):
         s = khmer.reverse_hash(i, 4)
@@ -318,7 +318,7 @@ def test_very_short_read():
 class Test_ConsumeString(object):
 
     def setup(self):
-        self.kh = khmer._CountingHash(4, [4**4])
+        self.kh = khmer._CountingHash(4, [4 ** 4])
 
     def test_n_occupied(self):
         assert self.kh.n_occupied() == 0

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -14,7 +14,10 @@ from . import khmer_tst_utils as utils
 from khmer.utils import (check_is_pair, broken_paired_reader, check_is_left,
                          check_is_right)
 from khmer.kfile import check_input_files
-from cStringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 def test_forward_hash():

--- a/tests/test_normalize_by_median.py
+++ b/tests/test_normalize_by_median.py
@@ -64,7 +64,7 @@ def test_normalize_by_median_unpaired_final_read():
     shutil.copyfile(utils.get_test_data('single-read.fq'), infile)
 
     script = 'normalize-by-median.py'
-    args = ['-C', CUTOFF, '-k', '17', '-p',  infile]
+    args = ['-C', CUTOFF, '-k', '17', '-p', infile]
     try:
         (status, out, err) = utils.runscript(script, args, in_dir)
         raise Exception("Shouldn't get to this")

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -18,7 +18,10 @@ from . import khmer_tst_utils as utils
 import argparse
 import khmer.kfile
 from khmer import khmer_args
-from cStringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import sys
 

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -185,7 +185,8 @@ def test_create_nodegraph_1():
     expected_hashsz = utils.longify([19999999, 19999981, 19999963, 19999927])
     assert nodegraph.hashsizes() == expected_hashsz, nodegraph.hashsizes()
 
-    assert sum(nodegraph.hashsizes())/8.0 < max_mem, sum(nodegraph.hashsizes())
+    assert sum(nodegraph.hashsizes()) / \
+        8.0 < max_mem, sum(nodegraph.hashsizes())
 
 
 def test_create_nodegraph_2():
@@ -232,7 +233,7 @@ def test_create_nodegraph_4_multiplier():
     args = FakeArgparseObject(ksize, n_tables, max_tablesize, max_mem)
 
     nodegraph = khmer_args.create_nodegraph(args, multiplier=2.0)
-    assert sum(nodegraph.hashsizes())/8.0 < max_mem / 2.0, \
+    assert sum(nodegraph.hashsizes()) / 8.0 < max_mem / 2.0, \
         sum(nodegraph.hashsizes())
 
 


### PR DESCRIPTION
Fix issues on master introduced recently:

- `sandbox/collect_reads.py` didn't have a default value for -C (set it to 50, based on docstring)
- xrange and cStringIO usage (not available on Python 3)
- Coding style issues (just ran `make format`)