### PR TITLE
Handle borked-but-obvious FASTQ formats with an option

### DIFF
--- a/scripts/interleave-reads.py
+++ b/scripts/interleave-reads.py
@@ -13,7 +13,7 @@ Take two files containing left & right reads from a paired-end sequencing run,
 and interleave them.
 
 % scripts/interleave-reads.py <R1> <R2> [ -o <outputfile> ]
-
+#needs updating in arguments here
 By default, output is sent to stdout; or use -o. Use '-h' for parameter help.
 """
 from __future__ import print_function


### PR DESCRIPTION
Working on #1154 