### PR TITLE
Streaming unique-kmers.py using consume_fasta

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2015-07-17  Luiz Irber  <khmer@luizirber.org>
 
+   * scripts/unique-kmers.py: use consume_fasta again.
+   * khmer/_khmer.cc: expose output_records option on HLLCounter consume_fasta.
+   * lib/hllcounter.{cc,hh}: implement output_records in HLLCounter
+   consume_fasta, add utility function write_record.
+
+2015-07-17  Luiz Irber  <khmer@luizirber.org>
+
    * scripts/unique-kmers.py: fix import bug and initialize to_print earlier.
    * tests/test_scripts: add tests for unique-kmers.py.
    * sandbox/unique-kmers.py: moved to scripts.

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4461,16 +4461,22 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
         PyObject * args)
 {
     const char * filename;
+    PyObject * output_records_o = NULL;
+    bool output_records = false;
 
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
+    if (!PyArg_ParseTuple(args, "s|O", &filename, &output_records_o)) {
         return NULL;
+    }
+
+    if (output_records_o != NULL && PyObject_IsTrue(output_records_o)) {
+       output_records = true;
     }
 
     // call the C++ function, and trap signals => Python
     unsigned long long  n_consumed    = 0;
     unsigned int        total_reads   = 0;
     try {
-        me->hllcounter->consume_fasta(filename, total_reads, n_consumed);
+        me->hllcounter->consume_fasta(filename, output_records, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -232,6 +232,19 @@ int get_rho(HashIntoType w, int max_width)
     return max_width - floor(log2(w));
 }
 
+void write_record(const read_parsers::Read& read, std::ostream& output)
+{
+    if (read.quality.length() != 0) {
+        output << "@" << read.name << std::endl
+               << read.sequence << std::endl
+               << "+" << std::endl
+               << read.quality << std::endl;
+    } else {
+        output << ">" << read.name << std::endl
+               << read.sequence << std::endl;
+    }
+}
+
 HLLCounter::HLLCounter(double error_rate, WordLength ksize)
 {
     if (error_rate < 0) {
@@ -347,18 +360,20 @@ unsigned int HLLCounter::consume_string(const std::string &inp)
 
 void HLLCounter::consume_fasta(
     std::string const &filename,
+    bool output_records,
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
     read_parsers::IParser * parser = read_parsers::IParser::get_parser(filename);
 
-    consume_fasta(parser, total_reads, n_consumed);
+    consume_fasta(parser, output_records, total_reads, n_consumed);
 
     delete parser;
 }
 
 void HLLCounter::consume_fasta(
     read_parsers::IParser *parser,
+    bool output_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)
 {
@@ -372,7 +387,7 @@ void HLLCounter::consume_fasta(
 
     #pragma omp parallel
     {
-        #pragma omp single
+        #pragma omp master
         {
             counters = (HLLCounter**)calloc(omp_get_num_threads(),
             sizeof(HLLCounter*));
@@ -394,6 +409,10 @@ void HLLCounter::consume_fasta(
                     break;
                 }
 
+                if (output_records) {
+                    write_record(read, std::cout);
+                }
+
                 #pragma omp task default(none) firstprivate(read) \
                 shared(counters, n_consumed_partial, total_reads_partial)
                 {
@@ -411,7 +430,7 @@ void HLLCounter::consume_fasta(
         }
         #pragma omp taskwait
 
-        #pragma omp single
+        #pragma omp master
         {
             for (int i=0; i < omp_get_num_threads(); ++i) {
                 this->merge(*counters[i]);
@@ -447,8 +466,11 @@ bool HLLCounter::check_and_normalize_read(std::string &read) const
     }
 
     for (unsigned int i = 0; i < read.length(); i++) {
-        read[ i ] &= 0xdf; // toupper - knock out the "lowercase bit"
-        if (!is_valid_dna( read[ i ] )) {
+        read[i] &= 0xdf; // toupper - knock out the "lowercase bit"
+        if (read[i] == 'N') {
+            read[i] = 'A';
+        }
+        if (!is_valid_dna( read[i] )) {
             is_valid = false;
             break;
         }

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -26,9 +26,11 @@ public:
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
     void consume_fasta(std::string const &,
+                       bool,
                        unsigned int &,
                        unsigned long long &);
     void consume_fasta(read_parsers::IParser *,
+                       bool,
                        unsigned int &,
                        unsigned long long &);
     unsigned int check_and_process_read(std::string &,

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -91,11 +91,7 @@ def main():
     input_filename = None
     for index, input_filename in enumerate(args.input_filenames):
         hllcpp = khmer.HLLCounter(args.error_rate, args.ksize)
-        for record in screed.open(input_filename):
-            seq = record.sequence.upper().replace('N', 'A')
-            hllcpp.consume_string(seq)
-            if args.stream_out:
-                write_record(record, sys.stdout)
+        hllcpp.consume_fasta(input_filename, args.stream_out)
 
         cardinality = hllcpp.estimate_cardinality()
         print('Estimated number of unique {0}-mers in {1}: {2}'.format(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3282,7 +3282,7 @@ def test_unique_kmers_diagnostics():
             'size_hashtable(H)\texpected_memory_usage' in out)
 
 
-def test_unique_kmers_stream_out():
+def test_unique_kmers_stream_out_fasta():
     infile = utils.get_temp_filename('random-20-a.fa')
     shutil.copyfile(utils.get_test_data('random-20-a.fa'), infile)
 
@@ -3300,6 +3300,27 @@ def test_unique_kmers_stream_out():
     out = out.read()
     assert '>45' in out
     assert "ATACGCCACTCGACTTGGCTCGCCCTCGATCTAAAATAGCGGTCGTGTTGGGTTAACAA" in out
+
+
+def test_unique_kmers_stream_out_fastq_with_N():
+    infile = utils.get_temp_filename('test-filter-abund-Ns.fq')
+    shutil.copyfile(utils.get_test_data('test-filter-abund-Ns.fq'), infile)
+
+    args = '-k 20 -e 0.01 --stream-out -'
+
+    _, out, err = utils.runscriptredirect('unique-kmers.py', args, infile,
+                                          os.path.dirname(infile))
+
+    err.seek(0)
+    err = err.read()
+    assert 'Estimated number of unique 20-mers in -: 94' in err
+    assert 'Total estimated number of unique 20-mers: 94' in err
+
+    out.seek(0)
+    out = out.read()
+    assert '@895:1:37:17593:9954 1::FOO_withN' in out
+    assert "GGTTGACGGGGCTCAGGGGGCGGCTGACTCCGAGNGACAGCAGCCGCAGCTGTCGTCA" in out
+    assert "##########################################################" in out
 
 
 def test_unique_kmers_multiple_inputs():


### PR DESCRIPTION
Revert `unique-kmers.py` changes and use consume_fasta again. Needed to write a `write_record` equivalent in C++ for this, currently living in `lib/HLLCounter.cc`, but should probably go in `lib/read_parsers.cc`?

(don't merge this before #1176 )