### PR TITLE
Refactor diginorm reporting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-07-20  Titus Brown  <titus@idyll.org>
+
+   * scripts/normalize-by-median.py: corrected epilog.
+
 2015-07-17  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * oxli/{functions,build_graph}.py,scripts/{load-graph,normalize-by-median,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 2015-07-20  Titus Brown  <titus@idyll.org>
 
-   * scripts/normalize-by-median.py: corrected epilog.
+   * khmer/__init__.py: cleaned up FP rate reporting.
+   * scripts/normalize-by-median.py: corrected epilog; refactored reporting
+   to be a bit cleaner; use CSV for reporting file;
+   added --report-frequency arg.
+   * tests/test_normalize_by_median.py: updated/added tests for reporting.
 
 2015-07-17  Jacob Fenton  <bocajnotnef@gmail.com>
 

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -172,8 +172,8 @@ def calc_expected_collisions(hashtable, force=False, max_false_pos=.2):
         print("** Do not use these results!!", file=sys.stderr)
         print("**", file=sys.stderr)
         print("** (estimated false positive rate of %.3f;" % fp_all,
-              file=sys.stderr)
-        print("max allowable %.3f" % max_false_pos, file=sys.stderr)
+              file=sys.stderr, end=' ')
+        print("max recommended %.3f)" % max_false_pos, file=sys.stderr)
         print("**", file=sys.stderr)
 
         if not force:

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -166,10 +166,7 @@ def get_parser():
 
     With :option:`-s`/:option:`--savetable`, the k-mer counting table
     will be saved to the specified file after all sequences have been
-    processed. With :option:`-d`, the k-mer counting table will be
-    saved every d files for multifile runs; if :option:`-s` is set,
-    the specified name will be used, and if not, the name `backup.ct`
-    will be used.  :option:`-l`/:option:`--loadtable` will load the
+    processed. :option:`-l`/:option:`--loadtable` will load the
     specified k-mer counting table before processing the specified
     files.  Note that these tables are are in the same format as those
     produced by :program:`load-into-counting.py` and consumed by

--- a/tests/test_normalize_by_median.py
+++ b/tests/test_normalize_by_median.py
@@ -211,6 +211,9 @@ def test_normalize_by_median_known_good():
 
 
 def test_normalize_by_median_report_fp():
+    # this tests basic reporting of diginorm stats => report.out, including
+    # a test of aggregate stats for two input files.
+
     infile = utils.get_temp_filename('test.fa')
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
     infile2 = utils.get_temp_filename('test2.fa')
@@ -234,6 +237,9 @@ def test_normalize_by_median_report_fp():
 
 
 def test_normalize_by_median_report_fp_hifreq():
+    # this tests high-frequency reporting of diginorm stats for a single
+    # file => report.out.
+
     infile = utils.get_temp_filename('test.fa')
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
 
@@ -257,6 +263,9 @@ def test_normalize_by_median_report_fp_hifreq():
 
 @attr('huge')
 def test_normalize_by_median_report_fp_huge():
+    # this tests reporting of diginorm stats => report.out for a large
+    # file, with the default reporting interval of once every 100k.
+
     infile = utils.get_temp_filename('test.fa')
     in_dir = os.path.dirname(infile)
     outfile = utils.get_temp_filename('report.out')

--- a/tests/test_normalize_by_median.py
+++ b/tests/test_normalize_by_median.py
@@ -215,7 +215,7 @@ def test_normalize_by_median_report_fp():
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
     infile2 = utils.get_temp_filename('test2.fa')
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile2)
-    
+
     in_dir = os.path.dirname(infile)
     outfile = utils.get_temp_filename('report.out')
 
@@ -231,6 +231,28 @@ def test_normalize_by_median_report_fp():
     assert line == '1001,1,0.000999', line
     line = report.readline().strip()
     assert line == '2002,1,0.0004995', line
+
+
+def test_normalize_by_median_report_fp_hifreq():
+    infile = utils.get_temp_filename('test.fa')
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
+
+    in_dir = os.path.dirname(infile)
+    outfile = utils.get_temp_filename('report.out')
+
+    script = 'normalize-by-median.py'
+    args = ['-C', '1', '-k', '17', '-R', outfile, infile,
+            '--report-frequency', '100']
+    (status, out, err) = utils.runscript(script, args, in_dir)
+
+    assert os.path.exists(outfile)
+    report = open(outfile, 'r')
+    line = report.readline().strip()
+    assert line == 'total,kept,f_kept', line
+    line = report.readline().strip()
+    assert line == '100,1,0.01', line
+    line = report.readline().strip()
+    assert line == '200,1,0.005', line
 
 
 @attr('huge')
@@ -249,7 +271,7 @@ def test_normalize_by_median_report_fp_huge():
     report = open(outfile, 'r')
     line = report.readline()            # skip header
     line = report.readline()
-    assert "100000,25261,0.25261" in line, line
+    assert "100000,25261,0.2526" in line, line
 
 
 def test_normalize_by_median_unpaired_and_paired():

--- a/tests/test_normalize_by_median.py
+++ b/tests/test_normalize_by_median.py
@@ -210,8 +210,31 @@ def test_normalize_by_median_known_good():
         assert False
 
 
-@attr('huge')
 def test_normalize_by_median_report_fp():
+    infile = utils.get_temp_filename('test.fa')
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
+    infile2 = utils.get_temp_filename('test2.fa')
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile2)
+    
+    in_dir = os.path.dirname(infile)
+    outfile = utils.get_temp_filename('report.out')
+
+    script = 'normalize-by-median.py'
+    args = ['-C', '1', '-k', '17', '-R', outfile, infile, infile2]
+    (status, out, err) = utils.runscript(script, args, in_dir)
+
+    assert os.path.exists(outfile)
+    report = open(outfile, 'r')
+    line = report.readline().strip()
+    assert line == 'total,kept,f_kept', line
+    line = report.readline().strip()
+    assert line == '1001,1,0.000999', line
+    line = report.readline().strip()
+    assert line == '2002,1,0.0004995', line
+
+
+@attr('huge')
+def test_normalize_by_median_report_fp_huge():
     infile = utils.get_temp_filename('test.fa')
     in_dir = os.path.dirname(infile)
     outfile = utils.get_temp_filename('report.out')
@@ -224,8 +247,9 @@ def test_normalize_by_median_report_fp():
 
     assert "fp rate estimated to be 0.623" in err, err
     report = open(outfile, 'r')
+    line = report.readline()            # skip header
     line = report.readline()
-    assert "100000 25261 0.25261" in line, line
+    assert "100000,25261,0.25261" in line, line
 
 
 def test_normalize_by_median_unpaired_and_paired():
@@ -262,12 +286,12 @@ def test_normalize_by_median_count_kmers_PE():
     args = ['-C', CUTOFF, '-k', '17', '--force-single', infile]
     (status, out, err) = utils.runscript(script, args, in_dir)
     assert 'Total number of unique k-mers: 98' in err, err
-    assert 'kept 1 of 2 or 50%' in err, err
+    assert 'kept 1 of 2 or 50.0%' in err, err
 
     args = ['-C', CUTOFF, '-k', '17', '-p', infile]
     (status, out, err) = utils.runscript(script, args, in_dir)
     assert 'Total number of unique k-mers: 99' in err, err
-    assert 'kept 2 of 2 or 100%' in err, err
+    assert 'kept 2 of 2 or 100.0%' in err, err
 
 
 def test_normalize_by_median_double_file_name():


### PR DESCRIPTION
This PR further refactors the diginorm script after #1010 and #1057.

Briefly,

* shifts tracking of sequences read/kept into the WithDiagnostics wrapper, which makes it much
   more general (so e.g. I think we can reuse this code in trim-low-abund.py);
* allows for users setting the reporting frequency via the command line;
* exchanges the expensive modulus operator for a simple comparison watermark approach;
* the watermark approach allows for increments of more than one sequence, which allows for more correct reporting during broken-paired reading;
* adds lightweight tests for report_fp that can be run frequently;
