### PR TITLE
Streaming unique-kmers.py using consume_fasta

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
    * lib/hllcounter.{cc,hh}: implement output_records option in consume_fasta.
    * lib/read_parsers.{cc,hh}: add Read method write_to, useful for outputting
    the read to an output stream.
+   * doc/whats-new-2.0.rst: Add unique-kmers description.
 
 2015-08-09  Jacob Fenton  <bocajnotnef@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-08-10  Luiz Irber  <khmer@luizirber.org>
+
+   * scripts/unique-kmers.py: use consume_fasta again.
+   * khmer/_khmer.cc: expose output_records option on HLLCounter consume_fasta.
+   * lib/hllcounter.{cc,hh}: implement output_records in HLLCounter
+   consume_fasta, add utility function write_record.
+
 2015-08-09  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * khmer/khmer_args.py: pep8

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,9 @@
 
    * scripts/unique-kmers.py: use consume_fasta again.
    * khmer/_khmer.cc: expose output_records option on HLLCounter consume_fasta.
-   * lib/hllcounter.{cc,hh}: implement output_records in HLLCounter
-   consume_fasta, add utility function write_record.
+   * lib/hllcounter.{cc,hh}: implement output_records option in consume_fasta.
+   * lib/read_parsers.{cc,hh}: add Read method write_to, useful for outputting
+   the read to an output stream.
 
 2015-08-09  Jacob Fenton  <bocajnotnef@gmail.com>
 

--- a/doc/whats-new-2.0.rst
+++ b/doc/whats-new-2.0.rst
@@ -24,6 +24,21 @@ Reservoir sampling script extracts paired reads by default
 default.  This can be overridden to match previous behavior
 with :option:`--force_single`.
 
+New scripts
+===========
+
+Estimate number of unique kmers
+-------------------------------
+
+`unique-kmers.py` estimates the k-mer cardinality of a dataset using the
+HyperLogLog probabilistic data structure. This allows very low memory
+consumption, which can be configured through an expected error rate.
+Even with low error rate (and higher memory consumption), it is still much
+more efficient than exact counting and alternative methods.
+It supports multicore processing (using OpenMP) and streaming,
+and so can be used in conjunction with other scripts (like
+`normalize-by-median.py` and `filter-abund.py`).
+
 Incompatible changes
 ====================
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4440,13 +4440,16 @@ hllcounter_consume_string(khmer_KHLLCounter_Object * me, PyObject * args)
 }
 
 static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
-        PyObject * args)
+        PyObject * args, PyObject * kwds)
 {
     const char * filename;
     PyObject * output_records_o = NULL;
+    char * kwlist[] = {"filename", "stream_out", NULL};
+
     bool output_records = false;
 
-    if (!PyArg_ParseTuple(args, "s|O", &filename, &output_records_o)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|O", kwlist,
+          &filename, &output_records_o)) {
         return NULL;
     }
 
@@ -4593,9 +4596,10 @@ static PyMethodDef khmer_hllcounter_methods[] = {
     },
     {
         "consume_fasta", (PyCFunction)hllcounter_consume_fasta,
-        METH_VARARGS,
+        METH_VARARGS | METH_KEYWORDS,
         "Read sequences from file, break into k-mers, "
-        "and add each k-mer to the counter."
+        "and add each k-mer to the counter. If optional keyword 'stream_out' "
+        "is True, also prints each sequence to stdout."
     },
     {
         "merge", (PyCFunction)hllcounter_merge,

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4443,16 +4443,22 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
         PyObject * args)
 {
     const char * filename;
+    PyObject * output_records_o = NULL;
+    bool output_records = false;
 
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
+    if (!PyArg_ParseTuple(args, "s|O", &filename, &output_records_o)) {
         return NULL;
+    }
+
+    if (output_records_o != NULL && PyObject_IsTrue(output_records_o)) {
+       output_records = true;
     }
 
     // call the C++ function, and trap signals => Python
     unsigned long long  n_consumed    = 0;
     unsigned int        total_reads   = 0;
     try {
-        me->hllcounter->consume_fasta(filename, total_reads, n_consumed);
+        me->hllcounter->consume_fasta(filename, output_records, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -232,19 +232,6 @@ int get_rho(HashIntoType w, int max_width)
     return max_width - floor(log2(w));
 }
 
-void write_record(const read_parsers::Read& read, std::ostream& output)
-{
-    if (read.quality.length() != 0) {
-        output << "@" << read.name << std::endl
-               << read.sequence << std::endl
-               << "+" << std::endl
-               << read.quality << std::endl;
-    } else {
-        output << ">" << read.name << std::endl
-               << read.sequence << std::endl;
-    }
-}
-
 HLLCounter::HLLCounter(double error_rate, WordLength ksize)
 {
     if (error_rate < 0) {
@@ -412,7 +399,7 @@ void HLLCounter::consume_fasta(
                 }
 
                 if (output_records) {
-                    write_record(read, std::cout);
+                    read.write_to(std::cout);
                 }
 
                 #pragma omp task default(none) firstprivate(read) \

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -35,9 +35,11 @@ public:
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
     void consume_fasta(std::string const &,
+                       bool,
                        unsigned int &,
                        unsigned long long &);
     void consume_fasta(read_parsers::IParser *,
+                       bool,
                        unsigned int &,
                        unsigned long long &);
     unsigned int check_and_process_read(std::string &,

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -20,6 +20,21 @@ namespace khmer
 namespace read_parsers
 {
 
+void
+Read::write_to(std::ostream& output)
+{
+    if (quality.length() != 0) {
+        output << "@" << name << std::endl
+               << sequence << std::endl
+               << "+" << std::endl
+               << quality << std::endl;
+    } else {
+        output << ">" << name << std::endl
+               << sequence << std::endl;
+    }
+}
+
+
 struct SeqAnParser::Handle {
     seqan::SequenceStream stream;
     uint32_t seqan_spin_lock;

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -69,6 +69,8 @@ struct Read {
         sequence.clear( );
         quality.clear( );
     }
+
+    void write_to(std::ostream&);
 };
 
 typedef std:: pair< Read, Read >	ReadPair;

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -117,11 +117,7 @@ def main():
     input_filename = None
     for index, input_filename in enumerate(args.input_filenames):
         hllcpp = khmer.HLLCounter(args.error_rate, args.ksize)
-        for record in screed.open(input_filename):
-            seq = record.sequence.upper().replace('N', 'A')
-            hllcpp.consume_string(seq)
-            if args.stream_out:
-                write_record(record, sys.stdout)
+        hllcpp.consume_fasta(input_filename, args.stream_out)
 
         cardinality = hllcpp.estimate_cardinality()
         print('Estimated number of unique {0}-mers in {1}: {2}'.format(

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -117,7 +117,7 @@ def main():
     input_filename = None
     for index, input_filename in enumerate(args.input_filenames):
         hllcpp = khmer.HLLCounter(args.error_rate, args.ksize)
-        hllcpp.consume_fasta(input_filename, args.stream_out)
+        hllcpp.consume_fasta(input_filename, stream_out=args.stream_out)
 
         cardinality = hllcpp.estimate_cardinality()
         print('Estimated number of unique {0}-mers in {1}: {2}'.format(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3624,22 +3624,6 @@ def test_unique_kmers_defaults():
     assert 'Total estimated number of unique 20-mers: 3950' in err
 
 
-def test_unique_kmers_streaming():
-    infile = utils.get_temp_filename('random-20-a.fa')
-    shutil.copyfile(utils.get_test_data('random-20-a.fa'), infile)
-
-    args = ['-k', '20', '-e', '0.01', '--stream-out', infile]
-
-    _, out, err = utils.runscript('unique-kmers.py', args,
-                                  os.path.dirname(infile))
-
-    err = err.splitlines()
-    assert ('Estimated number of unique 20-mers in {0}: 3950'.format(infile)
-            in err)
-    assert 'Total estimated number of unique 20-mers: 3950' in err
-    assert "CCAACCATGGTAGGTTAGGAAAGCCGCCAAATAAGTTCTTATACG" in out, out
-
-
 def test_unique_kmers_report_fp():
     infile = utils.get_temp_filename('random-20-a.fa')
     shutil.copyfile(utils.get_test_data('random-20-a.fa'), infile)


### PR DESCRIPTION
Revert `unique-kmers.py` changes and use consume_fasta again. I wrote a `write_record` equivalent in C++ for this, currently living in `lib/HLLCounter.cc`, but I think this should probably go in `lib/read_parsers.cc`.

(reopening #1177 now that #1176 was merged)
