### PR TITLE
Added oxli to pep257 maketarget

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-08-02  Jacob Fenton  <bocajnotnef@gmail.com>
+
+   * Makefile: added oxli to pep257 make target
+
 2015-08-01  Jacob Fenton  <bocajnotnef@gmail.com> and Titus Brown
 <titus@idyll.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2015-08-02  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * Makefile: added oxli to pep257 make target, made clean target wipe out all
-   .pyc files in scripts/*
+   .pyc files in scripts/* and tests/* and oxli/*
 
 2015-08-01  Jacob Fenton  <bocajnotnef@gmail.com> and Titus Brown
 <titus@idyll.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2015-08-02  Jacob Fenton  <bocajnotnef@gmail.com>
 
-   * Makefile: added oxli to pep257 make target
+   * Makefile: added oxli to pep257 make target, made clean target wipe out all
+   .pyc files in scripts/*
 
 2015-08-01  Jacob Fenton  <bocajnotnef@gmail.com> and Titus Brown
 <titus@idyll.org>

--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ diff_pep8_report: pep8_report.txt
 ## pep257      : check Python code style
 pep257: $(PYSOURCES) $(wildcard tests/*.py)
 	pep257 --ignore=D100,D101,D102,D103 \
-		setup.py khmer/ scripts/ tests/ || true
+		setup.py khmer/ scripts/ tests/ oxli/ || true
 
 pep257_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
-	pep257 setup.py khmer/ scripts/ tests/ \
+	pep257 setup.py khmer/ scripts/ tests/ oxli/ \
 		> pep257_report.txt 2>&1 || true
 
 diff_pep257_report: pep257_report.txt

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ clean: FORCE
 	cd lib && ${MAKE} clean || true
 	cd tests && rm -rf khmertest_* || true
 	rm -f $(EXTENSION_MODULE)
-	rm -f khmer/*.pyc lib/*.pyc scripts/*.pyc
+	rm -f khmer/*.pyc lib/*.pyc scripts/*.pyc tests/*.pyc oxli/*.pyc
 	./setup.py clean --all || true
 	rm -f coverage-debug
 	rm -Rf .coverage

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ clean: FORCE
 	cd lib && ${MAKE} clean || true
 	cd tests && rm -rf khmertest_* || true
 	rm -f $(EXTENSION_MODULE)
-	rm -f khmer/*.pyc lib/*.pyc
+	rm -f khmer/*.pyc lib/*.pyc scripts/*.pyc
 	./setup.py clean --all || true
 	rm -f coverage-debug
 	rm -Rf .coverage


### PR DESCRIPTION
For the `clean` make target, should we also be removing all `.pyc` files in scripts? 'cause we purge tests and khmer, but not scripts.
- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
