### PR TITLE
Fix GCC warning

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-08-12  Luiz Irber  <khmer@luizirber.org>
+
+   * khmer/_khmer.cc: Fix a GCC string initialization warning.
+
 2015-08-11  Michael R. Crusoe  <crusoe@ucdavis.edu>
 
    * CITATION, doc/{index,introduction,user/scripts}.rst, khmer/khmer_args.py:

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4442,7 +4442,9 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
 {
     const char * filename;
     PyObject * output_records_o = NULL;
-    char * kwlist[] = {"filename", "stream_out", NULL};
+
+    static const char* const_kwlist[] = {"filename", "stream_out", NULL};
+    static char** kwlist = const_cast<char**>(const_kwlist);
 
     bool output_records = false;
 


### PR DESCRIPTION
per https://github.com/dib-lab/khmer/commit/01abd684c9a33e8e743fa49571f38e6dcfafaf54#commitcomment-12652683

We'll probably need to do this again whenever we use keywords in the extension methods.
- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?

Ready for review @mr-c 
