### PR TITLE
Rename --stream-out to --stream-records

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-08-14  Luiz Irber  <khmer@luizirber.org>
+
+   * scripts/unique-kmers.py: Rename option --stream-out to --stream-records.
+   * tests/test_streaming_io.py: Fix unique-kmers tests, use new option.
+   * khmer/_khmer.cc, lib/hllcounter.cc: Rename some variables for consistency.
+
 2015-08-12  Jacob Fenton  <bocajnotnef@gmail.com>
 
    * doc/dev/{codebase-guide,coding-guidelines-and-review,development,

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4441,27 +4441,27 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
         PyObject * args, PyObject * kwds)
 {
     const char * filename;
-    PyObject * output_records_o = NULL;
+    PyObject * stream_records_o = NULL;
 
-    static const char* const_kwlist[] = {"filename", "stream_out", NULL};
+    static const char* const_kwlist[] = {"filename", "stream_records", NULL};
     static char** kwlist = const_cast<char**>(const_kwlist);
 
-    bool output_records = false;
+    bool stream_records = false;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|O", kwlist,
-          &filename, &output_records_o)) {
+          &filename, &stream_records_o)) {
         return NULL;
     }
 
-    if (output_records_o != NULL && PyObject_IsTrue(output_records_o)) {
-       output_records = true;
+    if (stream_records_o != NULL && PyObject_IsTrue(stream_records_o)) {
+       stream_records = true;
     }
 
     // call the C++ function, and trap signals => Python
     unsigned long long  n_consumed    = 0;
     unsigned int        total_reads   = 0;
     try {
-        me->hllcounter->consume_fasta(filename, output_records, total_reads, n_consumed);
+        me->hllcounter->consume_fasta(filename, stream_records, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -347,20 +347,20 @@ unsigned int HLLCounter::consume_string(const std::string &inp)
 
 void HLLCounter::consume_fasta(
     std::string const &filename,
-    bool output_records,
+    bool stream_records,
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
     read_parsers::IParser * parser = read_parsers::IParser::get_parser(filename);
 
-    consume_fasta(parser, output_records, total_reads, n_consumed);
+    consume_fasta(parser, stream_records, total_reads, n_consumed);
 
     delete parser;
 }
 
 void HLLCounter::consume_fasta(
     read_parsers::IParser *parser,
-    bool output_records,
+    bool stream_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)
 {
@@ -398,7 +398,7 @@ void HLLCounter::consume_fasta(
                     break;
                 }
 
-                if (output_records) {
+                if (stream_records) {
                     read.write_to(std::cout);
                 }
 

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -45,7 +45,7 @@ def get_parser():
     Informational output is sent to STDERR, but a report file can be generated
     with :option:`-R`/:option:`--report`.
 
-    :option:`--stream-out` will write the sequences taken in to STDOUT.
+    :option:`--stream-records` will write the sequences taken in to STDOUT.
     This is useful for workflows: count unique kmers in a stream, then do
     digital normalization.
 
@@ -63,7 +63,7 @@ def get_parser():
 
     Example::
 
-        unique-kmers.py --stream-out -k 17 tests/test-data/test-reads.fa | \\
+        unique-kmers.py --stream-records -k 17 tests/test-data/test-reads.fa | \\
         normalize-by-median.py -k 17 -o normalized /dev/stdin
 
     Example::
@@ -93,7 +93,7 @@ def get_parser():
                         help='generate informational report and write to'
                         ' filename')
 
-    parser.add_argument('--stream-out', '-S', default=False,
+    parser.add_argument('--stream-records', '-S', default=False,
                         action='store_true',
                         help='write input sequences to STDOUT')
 
@@ -117,7 +117,8 @@ def main():
     input_filename = None
     for index, input_filename in enumerate(args.input_filenames):
         hllcpp = khmer.HLLCounter(args.error_rate, args.ksize)
-        hllcpp.consume_fasta(input_filename, stream_out=args.stream_out)
+        hllcpp.consume_fasta(input_filename,
+                             stream_records=args.stream_records)
 
         cardinality = hllcpp.estimate_cardinality()
         print('Estimated number of unique {0}-mers in {1}: {2}'.format(

--- a/tests/test_streaming_io.py
+++ b/tests/test_streaming_io.py
@@ -486,7 +486,7 @@ def test_readstats_1():
 def test_unique_kmers_stream_out_fasta():
     infile = utils.get_test_data('random-20-a.fa')
 
-    cmd = "{scripts}/unique-kmers.py -k 20 -e 0.01 --stream-out {infile}"
+    cmd = "{scripts}/unique-kmers.py -k 20 -e 0.01 --stream-records {infile}"
     cmd = cmd.format(scripts=scriptpath(), infile=infile)
 
     (status, out, err) = run_shell_cmd(cmd)
@@ -503,7 +503,7 @@ def test_unique_kmers_stream_out_fasta():
 def test_unique_kmers_stream_out_fastq_with_N():
     infile = utils.get_test_data('test-filter-abund-Ns.fq')
 
-    cmd = "{scripts}/unique-kmers.py -k 20 -e 0.01 --stream-out {infile}"
+    cmd = "{scripts}/unique-kmers.py -k 20 -e 0.01 --stream-records {infile}"
     cmd = cmd.format(scripts=scriptpath(), infile=infile)
 
     (status, out, err) = run_shell_cmd(cmd)


### PR DESCRIPTION
Per #1239 discussion.
- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
