### PR TITLE
undo load-graph rename

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -54,7 +54,7 @@ any command line arguments.
 Graph partitioning and/or compressible graph representation
 ===========================================================
 
-The :program:`load-into-graph.py`, :program:`partition-graph.py`,
+The :program:`load-graph.py`, :program:`partition-graph.py`,
 and :program:`find-knots.py` scripts are part of the compressible graph
 representation and partitioning algorithms described in:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-09-02  Michael R. Crusoe  <crusoe@ucdavis.edu>
+
+   * *: finish undoing the `load-graph.py` rename
+
 2015-09-02  Micheal R. Crusoe  <crusoe@ucdavis.edu>
 
    * doc/requirements.txt: Update URL to sphinxcontrib-autoprogram tarball

--- a/doc/run-corn-50m.sh
+++ b/doc/run-corn-50m.sh
@@ -21,7 +21,7 @@ SCRIPTPATH=$KHMER_PATH/scripts
 
 # the next command will create a '50m.ht' and a '50m.tagset',
 # representing the de Bruijn graph
-${SCRIPTPATH}/load-into-graph.py -k 32 -N 4 -x 12e9 50m iowa-corn-50m.fa.gz
+${SCRIPTPATH}/load-graph.py -k 32 -N 4 -x 12e9 50m iowa-corn-50m.fa.gz
 
 # this will then partition that graph. should take a while.
 # update threads to something higher if you have more cores.
@@ -47,7 +47,7 @@ ${SCRIPTPATH}/extract-partitions.py iowa-corn-50m iowa-corn-50m.fa.gz.part
 mv iowa-corn-50m.group0007.fa corn-50m.lump.fa
 
 # create graph,
-${SCRIPTPATH}/load-into-graph.py -x 8e9 lump corn-50m.lump.fa
+${SCRIPTPATH}/load-graph.py -x 8e9 lump corn-50m.lump.fa
 
 # create an initial set of stoptags to help in knot-traversal; otherwise,
 # partitioning and knot-traversal (which is systematic) is really expensive.
@@ -63,7 +63,7 @@ ${SCRIPTPATH}/find-knots.py -x 2e8 -N 4 lump
 ${SCRIPTPATH}/filter-stoptags.py *.stoptags corn-50m.lump.fa
 
 # now, reload the filtered data set in and partition again.
-${SCRIPTPATH}/load-into-graph.py -x 8e9 lumpfilt corn-50m.lump.fa.stopfilt
+${SCRIPTPATH}/load-graph.py -x 8e9 lumpfilt corn-50m.lump.fa.stopfilt
 ${SCRIPTPATH}/partition-graph.py -T 4 lumpfilt
 ${SCRIPTPATH}/merge-partitions.py lumpfilt
 ${SCRIPTPATH}/annotate-partitions.py lumpfilt corn-50m.lump.fa.stopfilt

--- a/doc/user/choosing-table-sizes.rst
+++ b/doc/user/choosing-table-sizes.rst
@@ -55,7 +55,7 @@ you of the total memory usage, and (at the end) will complain if it's
 too small.
 
 Life is a bit more complicated than this, however, because some scripts --
-:program:`load-into-counting.py` and :program:`load-into-graph.py` -- keep
+:program:`load-into-counting.py` and :program:`load-graph.py` -- keep
 ancillary information that will consume memory beyond this table data
 structure.  So if you run out of memory, decrease the table size.
 

--- a/doc/user/partitioning-big-data.rst
+++ b/doc/user/partitioning-big-data.rst
@@ -55,7 +55,7 @@ https://s3.amazonaws.com/public.ged.msu.edu/khmer/iowa-corn-50m.fa.gz
   
   # the next command will create a '50m.ct' and a '50m.tagset',
   # representing the de Bruijn graph
-  load-into-graph.py -k 32 -N 4 -x 16e9 50m iowa-corn-50m.fa.gz
+  load-graph.py -k 32 -N 4 -x 16e9 50m iowa-corn-50m.fa.gz
   
   # this will then partition that graph. should take a while.
   # update threads to something higher if you have more cores.
@@ -81,7 +81,7 @@ https://s3.amazonaws.com/public.ged.msu.edu/khmer/iowa-corn-50m.fa.gz
   mv iowa-corn-50m.group0005.fa corn-50m.lump.fa
   
   # create graph,
-  load-into-graph.py -x 8e9 lump corn-50m.lump.fa
+  load-graph.py -x 8e9 lump corn-50m.lump.fa
 
   # create an initial set of stoptags to help in knot-traversal; otherwise,
   # partitioning and knot-traversal (which is systematic) is really expensive.
@@ -97,12 +97,12 @@ https://s3.amazonaws.com/public.ged.msu.edu/khmer/iowa-corn-50m.fa.gz
   filter-stoptags.py *.stoptags corn-50m.lump.fa
 
   # now, reload the filtered data set in and partition again.
-  # NOTE: 'load-into-graph.py' uses the file extension to determine
+  # NOTE: 'load-graph.py' uses the file extension to determine
   # if the file is formatted as FASTA or FASTQ. The default is
   # fasta, therefore if your files are fastq formatted you need
-  # to append 'fastq' to the name so that 'load-into-graph.py'
+  # to append 'fastq' to the name so that 'load-graph.py'
   # will parse the file correctly
-  load-into-graph.py -x 8e9 lumpfilt corn-50m.lump.fa.stopfilt
+  load-graph.py -x 8e9 lumpfilt corn-50m.lump.fa.stopfilt
   partition-graph.py -T 4 lumpfilt
   merge-partitions.py lumpfilt
   annotate-partitions.py lumpfilt corn-50m.lump.fa.stopfilt

--- a/doc/user/partitioning-workflow.graffle
+++ b/doc/user/partitioning-workflow.graffle
@@ -558,7 +558,7 @@
 {\colortbl;\red255\green255\blue255;}
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc
 
-\f0\fs24 \cf0 load-into-graph}</string>
+\f0\fs24 \cf0 load-graph}</string>
 			</dict>
 		</dict>
 	</array>

--- a/doc/user/scripts.rst
+++ b/doc/user/scripts.rst
@@ -65,8 +65,8 @@ Partitioning
 .. autoprogram:: do-partition:get_parser()
         :prog: do-partition.py
 
-.. autoprogram:: load-into-graph:get_parser()
-        :prog: load-into-graph.py
+.. autoprogram:: load-graph:get_parser()
+        :prog: load-graph.py
 
 See :program:`extract-partitions.py` for a complete workflow.
 

--- a/oxli/build_graph.py
+++ b/oxli/build_graph.py
@@ -9,7 +9,7 @@
 """
 Build a graph from the given sequences, save in <ptname>.
 
-% python scripts/load-into-graph.py <ptname> <data1> [ <data2> <...> ]
+% python scripts/load-graph.py <ptname> <data1> [ <data2> <...> ]
 
 Use '-h' for parameter help.
 """

--- a/scripts/annotate-partitions.py
+++ b/scripts/annotate-partitions.py
@@ -38,7 +38,7 @@ def get_parser():
 
     Example (results will be in ``random-20-a.fa.part``)::
 
-        load-into-graph.py -k 20 example tests/test-data/random-20-a.fa
+        load-graph.py -k 20 example tests/test-data/random-20-a.fa
         partition-graph.py example
         merge-partitions.py -k 20 example
         annotate-partitions.py -k 20 example tests/test-data/random-20-a.fa

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -73,7 +73,7 @@ def get_parser():
     annotate the original sequences files with the partition information.
 
     This script combines the functionality of
-    :program:`load-into-graph.py`, :program:`partition-graph.py`,
+    :program:`load-graph.py`, :program:`partition-graph.py`,
     :program:`merge-partitions.py`, and :program:`annotate-partitions.py` into
     one script. This is convenient but should probably not be used for large
     data sets, because :program:`do-partition.py` doesn't provide save/resume

--- a/scripts/extract-partitions.py
+++ b/scripts/extract-partitions.py
@@ -46,7 +46,7 @@ def get_parser():
     epilog = """\
     Example (results will be in ``example.group0000.fa``)::
 
-        load-into-graph.py -k 20 example tests/test-data/random-20-a.fa
+        load-graph.py -k 20 example tests/test-data/random-20-a.fa
         partition-graph.py example
         merge-partitions.py -k 20 example
         annotate-partitions.py -k 20 example tests/test-data/random-20-a.fa

--- a/scripts/find-knots.py
+++ b/scripts/find-knots.py
@@ -51,7 +51,7 @@ EXCURSION_KMER_COUNT_THRESHOLD = 2
 def get_parser():
     epilog = """\
     Load an k-mer nodegraph/tagset pair created by
-    :program:`load-into-graph.py`, and a set of pmap files created by
+    :program:`load-graph.py`, and a set of pmap files created by
     :program:`partition-graph.py`. Go through each pmap file,
     select the largest partition in each, and do the same kind of traversal as
     in :program:`make-initial-stoptags.py` from each of the waypoints in that

--- a/scripts/load-graph.py
+++ b/scripts/load-graph.py
@@ -9,7 +9,7 @@
 """
 Build a graph from the given sequences, save in <ptname>.
 
-% python scripts/load-into-graph.py <ptname> <data1> [ <data2> <...> ]
+% python scripts/load-graph.py <ptname> <data1> [ <data2> <...> ]
 
 Use '-h' for parameter help.
 """
@@ -29,7 +29,7 @@ def get_parser():
 
 
 if __name__ == '__main__':
-    info('load-into-graph.py', ['graph', 'SeqAn'])
+    info('load-graph.py', ['graph', 'SeqAn'])
     build_graph.main(get_parser().parse_args())
 
 # vim: set ft=python ts=4 sts=4 sw=4 et tw=79:

--- a/scripts/make-initial-stoptags.py
+++ b/scripts/make-initial-stoptags.py
@@ -43,7 +43,7 @@ EXCURSION_KMER_COUNT_THRESHOLD = 5
 def get_parser():
     epilog = """\
     Loads a k-mer nodegraph/tagset pair created by
-    :program:`load-into-graph.py`, and
+    :program:`load-graph.py`, and
     does a small set of traversals from graph waypoints; on these traversals,
     looks for k-mers that are repeatedly traversed in high-density regions of
     the graph, i.e. are highly connected. Outputs those k-mers as an initial

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -767,7 +767,7 @@ def test_count_median_fq_csv_stdout():
 
 
 def test_load_graph():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-x', '1e7', '-N', '2', '-k', '20']
 
     outfile = utils.get_temp_filename('out')
@@ -793,7 +793,7 @@ def test_load_graph():
 
     # check to make sure we get the expected result for this data set
     # upon partitioning (all in one partition).  This is kind of a
-    # roundabout way of checking that load-into-graph.py worked :)
+    # roundabout way of checking that load-graph.py worked :)
     subset = ht.do_subset_partition(0, 0)
     x = ht.subset_count_partitions(subset)
     assert x == (1, 0), x
@@ -824,7 +824,7 @@ def test_oxli_build_graph():
 
     # check to make sure we get the expected result for this data set
     # upon partitioning (all in one partition).  This is kind of a
-    # roundabout way of checking that load-into-graph.py worked :)
+    # roundabout way of checking that load-graph.py worked :)
     subset = ht.do_subset_partition(0, 0)
     x = ht.subset_count_partitions(subset)
     assert x == (1, 0), x
@@ -857,7 +857,7 @@ def test_oxli_build_graph_unique_kmers_arg():
 
     # check to make sure we get the expected result for this data set
     # upon partitioning (all in one partition).  This is kind of a
-    # roundabout way of checking that load-into-graph.py worked :)
+    # roundabout way of checking that load-graph.py worked :)
     subset = ht.do_subset_partition(0, 0)
     x = ht.subset_count_partitions(subset)
     assert x == (1, 0), x
@@ -872,7 +872,7 @@ def test_oxli_nocommand():
 
 
 def test_load_graph_no_tags():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-x', '1e7', '-N', '2', '-k', '20', '-n']
 
     outfile = utils.get_temp_filename('out')
@@ -919,7 +919,7 @@ def test_oxli_build_graph_no_tags():
 
 
 def test_load_graph_fail():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-x', '1e3', '-N', '2', '-k', '20']  # use small HT
 
     outfile = utils.get_temp_filename('out')
@@ -948,7 +948,7 @@ def test_oxli_build_graph_fail():
 
 
 def test_load_graph_write_fp():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-x', '1e5', '-N', '2', '-k', '20']  # use small HT
 
     outfile = utils.get_temp_filename('out')
@@ -994,7 +994,7 @@ def test_oxli_build_graph_write_fp():
 
 
 def test_load_graph_multithread():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
 
     outfile = utils.get_temp_filename('test')
     infile = utils.get_test_data('test-reads.fa')
@@ -1017,7 +1017,7 @@ def test_oxli_build_graph_multithread():
 
 
 def test_load_graph_max_memory_usage_parameter():
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-M', '2e7', '-k', '20', '-n']
 
     outfile = utils.get_temp_filename('out')
@@ -1044,7 +1044,7 @@ def _make_graph(infilename, min_hashsize=1e7, n_hashes=2, ksize=20,
                 do_partition=False,
                 annotate_partitions=False,
                 stop_big_traverse=False):
-    script = 'load-into-graph.py'
+    script = 'load-graph.py'
     args = ['-x', str(min_hashsize), '-N', str(n_hashes), '-k', str(ksize)]
 
     outfile = utils.get_temp_filename('out')
@@ -1929,19 +1929,19 @@ def test_interleave_reads_2_fa():
 
 
 def test_make_initial_stoptags():
-    # gen input files using load-into-graph.py -t
+    # gen input files using load-graph.py -t
     # should keep test_data directory size down
     # or something like that
-    # this assumes (obv.) load-into-graph.py works properly
+    # this assumes (obv.) load-graph.py works properly
     bzinfile = utils.get_temp_filename('test-reads.fq.bz2')
     shutil.copyfile(utils.get_test_data('test-reads.fq.bz2'), bzinfile)
     in_dir = os.path.dirname(bzinfile)
 
-    genscript = 'load-into-graph.py'
+    genscript = 'load-graph.py'
     genscriptargs = ['test-reads', 'test-reads.fq.bz2']
     utils.runscript(genscript, genscriptargs, in_dir)
 
-    # test input file gen'd by load-into-graph.pys
+    # test input file gen'd by load-graph.pys
     infile = utils.get_temp_filename('test-reads.pt')
     infile2 = utils.get_temp_filename('test-reads.tagset', in_dir)
 
@@ -1961,19 +1961,19 @@ def test_make_initial_stoptags():
 
 
 def test_make_initial_stoptags_load_stoptags():
-    # gen input files using load-into-graph.py -t
+    # gen input files using load-graph.py -t
     # should keep test_data directory size down
     # or something like that
-    # this assumes (obv.) load-into-graph.py works properly
+    # this assumes (obv.) load-graph.py works properly
     bzinfile = utils.get_temp_filename('test-reads.fq.bz2')
     shutil.copyfile(utils.get_test_data('test-reads.fq.bz2'), bzinfile)
     in_dir = os.path.dirname(bzinfile)
 
-    genscript = 'load-into-graph.py'
+    genscript = 'load-graph.py'
     genscriptargs = ['test-reads', 'test-reads.fq.bz2']
     utils.runscript(genscript, genscriptargs, in_dir)
 
-    # test input file gen'd by load-into-graph.pys
+    # test input file gen'd by load-graph.pys
     infile = utils.get_temp_filename('test-reads.pt')
     infile2 = utils.get_temp_filename('test-reads.tagset', in_dir)
 
@@ -3064,7 +3064,7 @@ def _execute_load_graph_streaming(filename):
 
     args = '-x 1e7 -N 2 -k 20 out -'
 
-    cmd = 'cat {infile} | {scripts}/load-into-graph.py {args}'.format(
+    cmd = 'cat {infile} | {scripts}/load-graph.py {args}'.format(
         infile=infile, scripts=scripts, args=args)
 
     (status, out, err) = utils.run_shell_cmd(cmd, in_directory=in_dir)
@@ -3087,7 +3087,7 @@ def _execute_load_graph_streaming(filename):
 
     # check to make sure we get the expected result for this data set
     # upon partitioning (all in one partition).  This is kind of a
-    # roundabout way of checking that load-into-graph.py worked :)
+    # roundabout way of checking that load-graph.py worked :)
     subset = ht.do_subset_partition(0, 0)
     x = ht.subset_count_partitions(subset)
     assert x == (1, 0), x

--- a/tests/test_streaming_io.py
+++ b/tests/test_streaming_io.py
@@ -327,7 +327,7 @@ def test_load_graph_1():
 
     cmd = """
        cat {in1} |
-       {scripts}/load-into-graph.py -x 1e3 -N 2 -k 20 {out1} - \
+       {scripts}/load-graph.py -x 1e3 -N 2 -k 20 {out1} - \
        2> /dev/null
     """
 


### PR DESCRIPTION
In the #1247 pull request `load-graph.py` and `load-into-counting.py` scripts were renamed to `load-into-nodegraph.py` and `load-into-countgraph.py` as part of the general pattern of simplifying how we talk about concepts in the 2.0 release. In the discussion at issue #1256 it was decided to undo this. Pull request #1270 partially undid the change, but `load-into-nodegraph.py` became `load-into-graph.py` instead of the original `load-graph.py`. This pull request finishes undoing the rename, now it is `load-graph.py`.
