### PR TITLE
make version test more specific

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-09-05  Michael R. Crusoe  <crusoe@ucdavis.edu>
+
+   * tests/test_scripts.py: make the script version test more specific; double
+   check that script in question is from the 'khmer' project based upon the
+   second line of the file.
+
 2015-09-04  Michael R. Crusoe  <crusoe@ucdavis.edu>
 
    * tests/khmer_tst_utils.py: look in "EGG-INFO" for scripts before checking

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3711,7 +3711,7 @@ def test_unique_kmers_multiple_inputs():
     assert 'Total estimated number of unique 20-mers: 4170' in err
 
 
-def check_version(scriptname):
+def check_version_and_basic_citation(scriptname):
     version = re.compile("^khmer .*$", re.MULTILINE)
     status, out, err = utils.runscript(scriptname, ["--version"])
     assert status == 0, status
@@ -3725,5 +3725,6 @@ def test_version():
             with open(os.path.join(utils.scriptpath(), entry)) as script:
                 line = script.readline()
                 line = script.readline()
-                if 'khmer' in line:
-                    yield check_version, entry
+                if 'khmer' in line:  # simple check of copyright line.
+                    yield check_version_and_basic_citation, entry
+                    # emit test for each script

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3722,4 +3722,8 @@ def check_version(scriptname):
 def test_version():
     for entry in os.listdir(utils.scriptpath()):
         if entry.endswith(".py"):
-            yield check_version, entry
+            with open(os.path.join(utils.scriptpath(), entry)) as script:
+                line = script.readline()
+                line = script.readline()
+                if 'khmer' in line:
+                    yield check_version, entry


### PR DESCRIPTION
The test for the `--version` option & citation output is dynamically generated so as to avoid hard coding the lists of scripts that we provide. The folder the scripts get installed to may have other non-khmer scripts in them; this pull request ensures that we only test khmer scripts for khmer functionality by looking for the word 'khmer' on the second line of the script. This works due to the recent copyright audit #1289.

Currently the tests fail after installation from PyPI with `pip`. This PR fixes that.