### PR TITLE
Track occupied bins in hashbits

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2015-09-11  Camille Scott  <camille.scott.w@gmail.com>
+
+   * lib/hashbits.cc: Make hasbits::update_from() correctly update
+   _occupied_bins.
+   * lib/test_nodegraph.py: Test Nodegraph.n_occupied() after update.
+
 2015-09-07  Michael R. Crusoe  <crusoe@ucdavis.edu>
 
    * doc/roadmap.rst: Updated for 2.0 release.

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -208,8 +208,17 @@ void Hashbits::update_from(const Hashbits &other)
         HashIntoType tablebytes = tablesize / 8 + 1;
 
         for (HashIntoType index = 0; index < tablebytes; index++) {
+            // Bloom filters can be unioned with bitwise OR.
+            // First, get the new value
             tmp = me[index] | ot[index];
             if (table_num == 0) {
+                // We'd like for the merged filter to have an accurate count of occupied bins.
+                // First, observe that HammingDistance(x,y) is equivalent to HammingWeight(x^y).
+                // Then, observe that the number of additional occupied bins from the update
+                // is the hamming distance between the original bin and the OR'd bin. Thus,
+                // we can use the builtin popcountll function, which calls a hardware instruction
+                // for hamming weight, with the original and merged bin, to find the number of
+                // additional occupied bins.
                 _occupied_bins += __builtin_popcountll(me[index] ^ tmp);
             }
             me[index] = tmp;

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -200,6 +200,7 @@ void Hashbits::update_from(const Hashbits &other)
     if (_tablesizes != other._tablesizes) {
         throw khmer_exception("both nodegraphs must have same table sizes");
     }
+    Byte tmp = 0;
     for (unsigned int table_num = 0; table_num < _n_tables; table_num++) {
         Byte * me = _counts[table_num];
         Byte * ot = other._counts[table_num];
@@ -207,7 +208,11 @@ void Hashbits::update_from(const Hashbits &other)
         HashIntoType tablebytes = tablesize / 8 + 1;
 
         for (HashIntoType index = 0; index < tablebytes; index++) {
-            me[index] |= ot[index];     // bitwise or
+            tmp = me[index] | ot[index];
+            if (table_num == 0) {
+                _occupied_bins += __builtin_popcountll(me[index] ^ tmp);
+            }
+            me[index] = tmp;
         }
     }
 }

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -74,29 +74,51 @@ def test_update_from():
 
     assert nodegraph.get('AAAAA') == 0
     assert nodegraph.get('GCGCG') == 0
+    assert nodegraph.n_occupied() == 0
     assert other_nodegraph.get('AAAAA') == 0
     assert other_nodegraph.get('GCGCG') == 0
+    assert other_nodegraph.n_occupied() == 0
 
     other_nodegraph.count('AAAAA')
 
     assert nodegraph.get('AAAAA') == 0
     assert nodegraph.get('GCGCG') == 0
+    assert nodegraph.n_occupied() == 0
     assert other_nodegraph.get('AAAAA') == 1
     assert other_nodegraph.get('GCGCG') == 0
+    assert other_nodegraph.n_occupied() == 1
 
     nodegraph.count('GCGCG')
 
     assert nodegraph.get('AAAAA') == 0
     assert nodegraph.get('GCGCG') == 1
+    assert nodegraph.n_occupied() == 1
     assert other_nodegraph.get('AAAAA') == 1
     assert other_nodegraph.get('GCGCG') == 0
+    assert other_nodegraph.n_occupied() == 1
 
     nodegraph.update(other_nodegraph)
 
     assert nodegraph.get('AAAAA') == 1
     assert nodegraph.get('GCGCG') == 1
+    assert nodegraph.n_occupied() == 2
     assert other_nodegraph.get('AAAAA') == 1
     assert other_nodegraph.get('GCGCG') == 0
+    assert other_nodegraph.n_occupied() == 1
+
+def test_update_from_2():
+
+    ng1 = khmer.Nodegraph(20, 1000, 4)
+    ng2 = khmer.Nodegraph(20, 1000, 4)
+
+    filename = utils.get_test_data('random-20-a.fa')
+    ng1.consume_fasta(filename)
+    ng2.consume_fasta(filename)
+
+    assert ng1.n_occupied() == ng2.n_occupied()
+    ng1.update(ng2)
+
+    assert ng1.n_occupied() == ng2.n_occupied()
 
 
 def test_update_from_diff_ksize_2():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -106,6 +106,7 @@ def test_update_from():
     assert other_nodegraph.get('GCGCG') == 0
     assert other_nodegraph.n_occupied() == 1
 
+
 def test_update_from_2():
 
     ng1 = khmer.Nodegraph(20, 1000, 4)


### PR DESCRIPTION
Sequence Bloom Trees require merging bloom filters. Our implementation supports this, but does not properly track the number of occupied bins after doing so, which is necessary to calculate the FPR. This adds the feature to the update_from function on hashbits.