### PR TITLE
Add codecov support in Jenkins

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-04-29  Luiz Irber  <khmer@luizirber.org>
+
+   * jenkins-build.sh: add codecov coverage upload tool.
+
 2016-02-17  Daniel Standage <daniel.standage@gmail.com>
 
    * ./github/CONTRIBUTING.md,.github/PULL_REQUEST_TEMPLATE.md: auto-populate

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -116,4 +116,4 @@ make libtest
 
 # Upload code coverage to codecov.io
 pip install codecov
-codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml
+codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml &> /dev/null

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -113,3 +113,7 @@ unset CXXFLAGS
 
 # Don't do lib too, as we already compile as part of libtest
 make libtest
+
+# Upload code coverage to codecov.io
+pip install codecov
+codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml


### PR DESCRIPTION
Fixes #1337 (wow, I should have used that issue for something cooler, so L33T).

I modified jenkins-build.sh to install codecov and upload the coverage reports that were already generated by coverage and gcovr. I also exposed a new variable on the Jenkins credentials, but this is not in any PR (I needed to change configuration in the server).