### PR TITLE
FIx #1353

### DIFF
--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -188,7 +188,7 @@ HashIntoType _hash_murmur(const std::string& kmer,
         // self complement kmer, can't use bitwise XOR
         r = out[0];
         return h;
-	}
+    }
 
     MurmurHash3_x64_128((void *)rev.c_str(), rev.size(), seed, &out);
     r = out[0];

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -184,6 +184,12 @@ HashIntoType _hash_murmur(const std::string& kmer,
     h = out[0];
 
     std::string rev = khmer::_revcomp(kmer);
+    if (rev == kmer) {
+        // self complement kmer, can't use bitwise XOR
+        r = out[0];
+        return h;
+	}
+
     MurmurHash3_x64_128((void *)rev.c_str(), rev.size(), seed, &out);
     r = out[0];
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -153,6 +153,7 @@ def test_hash_murmur3():
     assert khmer.hash_murmur3('TTTT') == 526240128537019279
     assert khmer.hash_murmur3('CCCC') == 14391997331386449225
     assert khmer.hash_murmur3('GGGG') == 14391997331386449225
+    assert khmer.hash_murmur3('TATA') != 0
 
 
 def test_hash_no_rc_murmur3():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -153,7 +153,9 @@ def test_hash_murmur3():
     assert khmer.hash_murmur3('TTTT') == 526240128537019279
     assert khmer.hash_murmur3('CCCC') == 14391997331386449225
     assert khmer.hash_murmur3('GGGG') == 14391997331386449225
-    assert khmer.hash_murmur3('TATA') != 0
+    assert khmer.hash_murmur3('TATATATATATATATATATA') != 0
+    assert khmer.hash_murmur3('TTTTGCAAAA') != 0
+    assert khmer.hash_murmur3('GAAAATTTTC') != 0
 
 
 def test_hash_no_rc_murmur3():


### PR DESCRIPTION
Fixes #1353 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
