### PR TITLE
Fix: substr parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-05-16  Luiz Irber  <khmer@luizirber.org>
+
+   * lib/hashtable.cc: fix bug with substr
+   * tests/test_countgraph.py: add test to trigger the substr bug.
+
 2016-05-11  Titus Brown  <titus@idyll.org>
 
    * scripts/trim-low-abund.py: refactor to use generators; add --diginorm

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2010-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -967,7 +967,7 @@ void Hashtable::get_kmers(const std::string &s,
         return;
     }
     for (unsigned int i = 0; i < s.length() - _ksize + 1; i++) {
-        std::string sub = s.substr(i, i + _ksize);
+        std::string sub = s.substr(i, _ksize);
         kmers_vec.push_back(sub);
     }
 }

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -1,6 +1,6 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2010-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -501,6 +501,9 @@ def test_get_kmers():
     kmers = hi.get_kmers("AAAAAAT")
     assert kmers == ["AAAAAA", "AAAAAT"]
 
+    kmers = hi.get_kmers("AGCTTTTC")
+    assert kmers == ['AGCTTT', 'GCTTTT', 'CTTTTC']
+
 
 @attr("huge")
 def test_save_load_large():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -888,8 +888,3 @@ def test_n_occupied_vs_countgraph_another_size():
 
     assert nodegraph.n_unique_kmers() == 3916, nodegraph.n_unique_kmers()
     assert countgraph.n_unique_kmers() == 3916, countgraph.n_unique_kmers()
-
-
-def test_get_kmers():
-    nodegraph = khmer.Nodegraph(5, 1000, 4)
-    assert nodegraph.get_kmers("AGCTTTTC") == ['AGCTT', 'GCTTT', 'CTTTT', 'TTTTC']

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -888,3 +888,8 @@ def test_n_occupied_vs_countgraph_another_size():
 
     assert nodegraph.n_unique_kmers() == 3916, nodegraph.n_unique_kmers()
     assert countgraph.n_unique_kmers() == 3916, countgraph.n_unique_kmers()
+
+
+def test_get_kmers():
+    nodegraph = khmer.Nodegraph(5, 1000, 4)
+    assert nodegraph.get_kmers("AGCTTTTC") == ['AGCTT', 'GCTTT', 'CTTTT', 'TTTTC']


### PR DESCRIPTION
[substr()][1] second parameter should be the length of the substring, not the index of the last character to copy. There is another occurence at [lib/hashtable.cc][2] that needs to be checked.

[1]: http://www.cplusplus.com/reference/string/string/substr/
[2]: https://github.com/dib-lab/khmer/blob/ff7f047b5b0d9acb6c1eb73d54cfd39c9e3d1393/lib/hashtable.cc#L1265

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?
