### PR TITLE
fix syntax error introducing during pylint0 merge

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-05-11  Titus Brown  <titus@idyll.org>
+
+   * tests/test_read_parsers.py: fixed syntax error introduced by previous
+   merge.
+
 2016-05-08  Michael R. Crusoe  <crusoe@ucdavis.edu>
 
    * scripts/{do-partition,partition-graph}.py,oxli/partition.py: pulled up

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -1,6 +1,6 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -341,7 +341,7 @@ def test_read_pair_iterator_in_error_mode():
     for read_1, read_2 \
             in rparser.iter_read_pairs(ReadParser.PAIR_MODE_ERROR_ON_UNPAIRED):
         read_pairs_2.append([read_1, read_2])
-    matches = [(rp1, rp2) for rp1, rp2 in read_pairs_1, read_pairs_2
+    matches = [(rp1, rp2) for rp1, rp2 in zip(read_pairs_1, read_pairs_2)
                if rp1[0].name == rp2[0].name]
     assert all(matches)  # Assert ALL the matches. :-]
 


### PR DESCRIPTION
Fixes #1359.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

