### PR TITLE
Implement human-friendly memory request handling

### DIFF
--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -94,6 +94,39 @@ class ComboFormatter(argparse.ArgumentDefaultsHelpFormatter,
     pass
 
 
+def memory_setting(label):
+    """
+    Parse user-supplied memory setting.
+
+    Converts strings into floats, representing a number of bytes. Supports the
+    following notations.
+      - raw integers: 1, 1000, 1000000000
+      - scientific notation: 1, 1e3, 1e9
+      - "common" notation: 1, 1K, 1G
+
+    Suffixes supported: K/k, M/m, G/g, T/t. Do not include a trailing B/b.
+    """
+    suffixes = {
+        'K': 1000.0,
+        'M': 1000.0 ** 2,
+        'G': 1000.0 ** 3,
+        'T': 1000.0 ** 4,
+    }
+    try:
+        mem = float(label)
+        return mem
+    except ValueError:
+        prefix = label[:-1]
+        suffix = label[-1:].upper()
+        if suffix not in suffixes.keys():
+            raise ValueError('cannot parse memory setting "{}"'.format(label))
+        try:
+            multiplier = float(prefix)
+            return multiplier * suffixes[suffix]
+        except ValueError:
+            raise ValueError('cannot parse memory setting "{}"'.format(label))
+
+
 def optimal_size(num_kmers, mem_cap=None, fp_rate=None):
     """
     Utility function for estimating optimal countgraph args.
@@ -328,10 +361,10 @@ def build_graph_args(descr=None, epilog=None, parser=None):
     group.add_argument('--max-tablesize', '-x', type=float,
                        default=DEFAULT_MAX_TABLESIZE,
                        help='upper bound on tablesize to use; overrides ' +
-                       '--max-memory-usage/-M.')
-    group.add_argument('-M', '--max-memory-usage', type=float,
+                       '--max-memory-usage/-M')
+    group.add_argument('-M', '--max-memory-usage', type=memory_setting,
                        help='maximum amount of memory to use for data ' +
-                       'structure.')
+                       'structure')
 
     return parser
 

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -325,13 +325,21 @@ def test_memory_setting():
     assert khmer_args.memory_setting('16T') == 16e12
     try:
         _ = khmer_args.memory_setting('16Tb')
+        assert False, 'previous command should have failed'
     except ValueError as err:
         assert 'cannot parse memory setting' in str(err)
     try:
         _ = khmer_args.memory_setting('16E')
+        assert False, 'previous command should have failed'
     except ValueError as err:
         assert 'cannot parse memory setting' in str(err)
     try:
         _ = khmer_args.memory_setting('16Ki')
+        assert False, 'previous command should have failed'
+    except ValueError as err:
+        assert 'cannot parse memory setting' in str(err)
+    try:
+        _ = khmer_args.memory_setting('b0gu$G')
+        assert False, 'previous command should have failed'
     except ValueError as err:
         assert 'cannot parse memory setting' in str(err)

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -1,6 +1,6 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2014-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -310,3 +310,28 @@ def test_fail_calculate_foograph_size():
         assert 0, "previous statement should fail"
     except ValueError as err:
         assert "unknown graph type: foograph" in str(err), str(err)
+
+
+def test_memory_setting():
+    assert khmer_args.memory_setting('1') == 1.0
+    assert khmer_args.memory_setting('42') == 42.0
+    assert khmer_args.memory_setting('10000') == 1e4
+    assert khmer_args.memory_setting('2.3e5') == 230000.0
+    assert khmer_args.memory_setting('1e9') == 1e9
+    assert khmer_args.memory_setting('1K') == 1e3
+    assert khmer_args.memory_setting('3.14m') == 3.14e6
+    assert khmer_args.memory_setting('8G') == 8e9
+    assert khmer_args.memory_setting('8g') == 8e9
+    assert khmer_args.memory_setting('16T') == 16e12
+    try:
+        _ = khmer_args.memory_setting('16Tb')
+    except ValueError as err:
+        assert 'cannot parse memory setting' in str(err)
+    try:
+        _ = khmer_args.memory_setting('16E')
+    except ValueError as err:
+        assert 'cannot parse memory setting' in str(err)
+    try:
+        _ = khmer_args.memory_setting('16Ki')
+    except ValueError as err:
+        assert 'cannot parse memory setting' in str(err)


### PR DESCRIPTION
Supports raw numbers and scientific notation (as before), but now also supports common suffixes.

- 1K: 1000 bytes (1 KB)
- 700m: 700,000,000 bytes (700 MB)
- 16G: 16,000,000,000 bytes (16 GB)
- 1.3T: 1,300,000,000,000 bytes (1.3 TB)

Upper- and lower-case single-letter suffixes are supported. I'd prefer to update the documentation after #1396 is merged.

------

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

