### PR TITLE
add get_kmer_hashes_as_hashset function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2016-07-03  Titus Brown  <titus@idyll.org>
+
+   * lib{hashtable.cc, hashtable.hh}: added get_kmer_hashes_as_hashset to
+   graphs.
+   * khmer/_khmer.cc: updated CPython API to add get_kmer_hashes_as_hashset.
+   * tests/test_countgraph.py: added test for get_kmer_hashes_as_hashset.
+
 2016-06-27  Titus Brown  <titus@idyll.org>
 
    * doc/requirements.txt: updated sphinx-autoprogram requirement for building

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -2817,6 +2817,27 @@ hashtable_get_kmer_hashes(khmer_KHashtable_Object * me, PyObject * args)
 }
 
 
+static
+PyObject *
+hashtable_get_kmer_hashes_as_hashset(khmer_KHashtable_Object * me, PyObject * args)
+{
+    Hashtable * hashtable = me->hashtable;
+    const char * sequence;
+
+    if (!PyArg_ParseTuple(args, "s", &sequence)) {
+        return NULL;
+    }
+
+    SeenSet * hashes = new SeenSet;
+    hashtable->get_kmer_hashes_as_hashset(sequence, *hashes);
+
+    PyObject * x = (PyObject *) create_HashSet_Object(hashes,
+                                                      hashtable->ksize());
+
+    return x;
+}
+
+
 static PyMethodDef khmer_hashtable_methods[] = {
     //
     // Basic methods
@@ -2903,6 +2924,11 @@ static PyMethodDef khmer_hashtable_methods[] = {
         "get_kmer_hashes",
         (PyCFunction)hashtable_get_kmer_hashes, METH_VARARGS,
         "Retrieve an ordered list of all hashes of all k-mers in the string."
+    },
+    {
+        "get_kmer_hashes_as_hashset",
+        (PyCFunction)hashtable_get_kmer_hashes_as_hashset, METH_VARARGS,
+        "Retrieve a HashSet containing all the k-mers in the string."
     },
     {
         "get_kmer_counts",

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -985,6 +985,18 @@ void Hashtable::get_kmer_hashes(const std::string &s,
 }
 
 
+void Hashtable::get_kmer_hashes_as_hashset(const std::string &s,
+                                           SeenSet& hashes) const
+{
+    KmerIterator kmers(s.c_str(), _ksize);
+
+    while(!kmers.done()) {
+        HashIntoType kmer = kmers.next();
+        hashes.insert(kmer);
+    }
+}
+
+
 void Hashtable::get_kmer_counts(const std::string &s,
                                 std::vector<BoundedCounterType> &counts) const
 {

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -328,6 +328,10 @@ public:
     void get_kmer_hashes(const std::string &s,
                          std::vector<HashIntoType> &kmers) const;
 
+    // return hash values for all k-mer substrings in a SeenSet
+    void get_kmer_hashes_as_hashset(const std::string &s,
+                                    SeenSet& hashes) const;
+
     // return counts of all k-mers in this string.
     void get_kmer_counts(const std::string &s,
                          std::vector<BoundedCounterType> &counts) const;

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -540,6 +540,42 @@ def test_get_kmer_hashes():
     assert hi.get(hashes[1]) == 3
 
 
+def test_get_kmer_hashes_as_hashset():
+    hi = khmer.Countgraph(6, 1e6, 2)
+    def get_counts(hs):
+        return list(sorted([ hi.get(h) for h in hs ]))
+
+    hi.consume("AAAAAA")
+    hashes = hi.get_kmer_hashes_as_hashset("AAAAAA")
+    print(hashes)
+    assert len(hashes) == 1
+    assert [1] == get_counts(hashes)
+
+    hi.consume("AAAAAA")
+    hashes = hi.get_kmer_hashes_as_hashset("AAAAAA")
+    print(hashes)
+    assert len(hashes) == 1
+    assert [2] == get_counts(hashes)
+
+    hi.consume("AAAAAT")
+    hashes = hi.get_kmer_hashes_as_hashset("AAAAAAT")
+    print(hashes)
+    assert len(hashes) == 2
+    assert [1, 2] == get_counts(hashes)
+
+    hi.consume("AAAAAT")
+    hashes = hi.get_kmer_hashes_as_hashset("AAAAAAT")
+    print(hashes)
+    assert len(hashes) == 2
+    assert [2, 2] == get_counts(hashes)
+
+    hi.consume("AAAAAT")
+    hashes = hi.get_kmer_hashes_as_hashset("AAAAAAT")
+    print(hashes)
+    assert len(hashes) == 2
+    assert [2, 3] == get_counts(hashes)
+
+
 def test_get_kmers():
     hi = khmer.Countgraph(6, 1e6, 2)
 

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -542,8 +542,9 @@ def test_get_kmer_hashes():
 
 def test_get_kmer_hashes_as_hashset():
     hi = khmer.Countgraph(6, 1e6, 2)
+
     def get_counts(hs):
-        return list(sorted([ hi.get(h) for h in hs ]))
+        return list(sorted([hi.get(h) for h in hs]))
 
     hi.consume("AAAAAA")
     hashes = hi.get_kmer_hashes_as_hashset("AAAAAA")


### PR DESCRIPTION
the existing function get_kmer_hashes returns all the hashes of all the k-mers in a string, in order; get_kmer_hashes_as_hashset returns them in a HashSet instead, which is much faster for certain use cases.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

