### PR TITLE
[MRG] Error for counting args > 255

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,14 @@
 2016-09-01  Tim Head  <betatim@gmail.com>
 
+   * khmer/khmer_args.py: added check_argument_range to check an integer
+   command-line argument is within a given range.
+   * scripts/{normalize-by-median.py, filter-abund.py, filter-abund-single.py}
+   now use check_argument_range for the cutoff parameter.
+   * tests/test_normalize_by_median.py: modified
+   test_normalize_by_median_no_bigcount.
+
+2016-09-01  Tim Head  <betatim@gmail.com>
+
    * scripts/filter-abund-single.py: Add support for variable coverage trimming
 
 2016-08-31  Tim Head  <betatim@gmail.com>

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -192,6 +192,21 @@ def check_conflicting_args(args, hashtype):
             args.max_tablesize = max_tablesize
 
 
+def check_argument_range(low, high, parameter_name):
+    """Check if parameter value is in the range `low` to `high`."""
+    def _in_range(x):
+        x = int(x)
+        if not (low <= x < high):
+            print_error("\n** ERROR: khmer only supports "
+                        "%i <= %s < %i.\n" % (low, parameter_name, high))
+            sys.exit(1)
+
+        else:
+            return x
+
+    return _in_range
+
+
 # pylint: disable=invalid-name
 def estimate_optimal_with_K_and_M(num_kmers, mem_cap):
     """

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -194,15 +194,15 @@ def check_conflicting_args(args, hashtype):
 
 def check_argument_range(low, high, parameter_name):
     """Check if parameter value is in the range `low` to `high`."""
-    def _in_range(x):
-        x = int(x)
-        if not (low <= x < high):
+    def _in_range(value):
+        value = int(value)
+        if not low <= value < high:
             print_error("\n** ERROR: khmer only supports "
                         "%i <= %s < %i.\n" % (low, parameter_name, high))
             sys.exit(1)
 
         else:
-            return x
+            return value
 
     return _in_range
 

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -55,7 +55,7 @@ from khmer.thread_utils import ThreadedSequenceProcessor, verbose_loader
 from khmer import khmer_args
 from khmer.khmer_args import (build_counting_args, report_on_config,
                               add_threading_args, info, calculate_graphsize,
-                              sanitize_help)
+                              sanitize_help, check_argument_range)
 from khmer.kfile import (check_input_files, check_space,
                          check_space_for_graph,
                          add_output_compression_type,
@@ -86,7 +86,8 @@ def get_parser():
         "(in memory version).", epilog=textwrap.dedent(epilog))
     add_threading_args(parser)
 
-    parser.add_argument('--cutoff', '-C', default=DEFAULT_CUTOFF, type=int,
+    parser.add_argument('--cutoff', '-C', default=DEFAULT_CUTOFF,
+                        type=check_argument_range(0, 256, "cutoff"),
                         help="Trim at k-mers below this abundance.")
     parser.add_argument('--variable-coverage', '-V', action='store_true',
                         dest='variable_coverage', default=False,

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -52,7 +52,8 @@ import argparse
 import sys
 from khmer.thread_utils import ThreadedSequenceProcessor, verbose_loader
 from khmer.khmer_args import (ComboFormatter, add_threading_args, info,
-                              sanitize_help, _VersionStdErrAction)
+                              sanitize_help, _VersionStdErrAction,
+                              check_argument_range)
 from khmer.kfile import (check_input_files, check_space,
                          add_output_compression_type, get_file_writer)
 from khmer import __version__
@@ -85,7 +86,8 @@ def get_parser():
                         help='Input FAST[AQ] sequence filename', nargs='+')
     add_threading_args(parser)
     parser.add_argument('--cutoff', '-C', dest='cutoff',
-                        default=DEFAULT_CUTOFF, type=int,
+                        default=DEFAULT_CUTOFF,
+                        type=check_argument_range(0, 256, 'cutoff'),
                         help="Trim at k-mers below this abundance.")
     parser.add_argument('--variable-coverage', '-V', action='store_true',
                         dest='variable_coverage', default=False,

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -268,7 +268,7 @@ def get_parser():
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
                         action='store_true')
     parser.add_argument('-C', '--cutoff', help="when the median "
-                        "k-mer coverage level above is this numer the "
+                        "k-mer coverage level is above this number the "
                         "read is not kept.",
                         type=check_argument_range(0, 256, "cutoff"),
                         default=DEFAULT_DESIRED_COVERAGE)

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2011-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -56,7 +56,7 @@ from khmer import khmer_args
 from contextlib import contextmanager
 from khmer.khmer_args import (build_counting_args, add_loadgraph_args,
                               report_on_config, info, calculate_graphsize,
-                              sanitize_help)
+                              sanitize_help, check_argument_range)
 import argparse
 from khmer.kfile import (check_space, check_space_for_graph,
                          check_valid_file_exists, add_output_compression_type,
@@ -267,9 +267,10 @@ def get_parser():
         epilog=textwrap.dedent(epilog))
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
                         action='store_true')
-    parser.add_argument('-C', '--cutoff', type=int, help="when the median "
-                        "k-mer coverage level above is above this numer the "
+    parser.add_argument('-C', '--cutoff', help="when the median "
+                        "k-mer coverage level above is this numer the "
                         "read is not kept.",
+                        type=check_argument_range(0, 256, "cutoff"),
                         default=DEFAULT_DESIRED_COVERAGE)
     parser.add_argument('-p', '--paired', action='store_true',
                         help='require that all sequences be properly paired')

--- a/tests/test_normalize_by_median.py
+++ b/tests/test_normalize_by_median.py
@@ -521,19 +521,16 @@ def test_normalize_by_median_no_bigcount():
     hashfile = utils.get_temp_filename('test-out.ct')
     in_dir = os.path.dirname(infile)
 
-    _make_counting(infile, K=8)
+    shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
 
     script = 'normalize-by-median.py'
-    args = ['-C', '1000', '-k 8', '--savegraph', hashfile, infile]
+    # 256 is outside the range of valid values for C
+    args = ['-C', '256', '-k 8', '--savegraph', hashfile, infile]
 
-    (status, out, err) = utils.runscript(script, args, in_dir)
-    assert status == 0, (out, err)
+    (status, out, err) = utils.runscript(script, args, in_dir, fail_ok=True)
+    assert status == 1, (out, err)
+    assert "ERROR: khmer only supports 0 <= cutoff < 256" in err
     print((out, err))
-
-    assert os.path.exists(hashfile), hashfile
-    kh = khmer.load_countgraph(hashfile)
-
-    assert kh.get('GGTTGACG') == 255
 
 
 def test_normalize_by_median_empty():


### PR DESCRIPTION
Fixes parts of #1411

Started work on checking the range of counting args. This does not implement the "force and bigcount" part of #1411 

---

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?