### PR TITLE
The style roller

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-08-31  Tim Head  <betatim@gmail.com>
+
+   * Fixed several source code style issues in python and cpp.
+   * Makefile: removed setup.py from the list of files passed to astyle
+
 2016-08-30  Tim Head  <betatim@gmail.com>
 
    * Fix coverage reporting on OSX and rename nosetests.xml to pytests.xml

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@
 
 # `SHELL=bash` Will break Titus's laptop, so don't use BASH-isms like
 # `[[` conditional expressions.
-CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmer.cc) setup.py
+CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmer.cc) 
 PYSOURCES=$(filter-out khmer/_version.py, \
 	  $(wildcard khmer/*.py scripts/*.py oxli/*.py) )
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@
 
 # `SHELL=bash` Will break Titus's laptop, so don't use BASH-isms like
 # `[[` conditional expressions.
-CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmer.cc) 
+CPPSOURCES=$(wildcard lib/*.cc lib/*.hh khmer/_khmer.cc) setup.py
 PYSOURCES=$(filter-out khmer/_version.py, \
 	  $(wildcard khmer/*.py scripts/*.py oxli/*.py) )
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
@@ -196,7 +196,7 @@ diff_pydocstyle_report: pydocstyle_report.txt
 
 ## astyle      : fix most C++ code indentation and formatting
 astyle: $(CPPSOURCES)
-	astyle -A10 --max-code-length=80 $(CPPSOURCES)
+	astyle -A10 --max-code-length=80 $(filter-out setup.py,$(CPPSOURCES))
 
 ## autopep8    : fix most Python code indentation and formatting
 autopep8: $(PYSOURCES) $(wildcard tests/*.py)

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -127,7 +127,7 @@ static bool convert_PyObject_to_Kmer(PyObject * value,
         return true;
     } else if (PyUnicode_Check(value))  {
         std::string s = PyBytes_AsString(PyUnicode_AsEncodedString(
-                                            value, "utf-8", "strict"));
+                                             value, "utf-8", "strict"));
         if (strlen(s.c_str()) != ksize) {
             PyErr_SetString(PyExc_ValueError,
                             "k-mer length must equal the k-mer size");
@@ -161,8 +161,8 @@ static bool convert_PyObject_to_Kmer(PyObject * value,
 // that checks this.
 
 static bool convert_PyObject_to_HashIntoType(PyObject * value,
-                                             HashIntoType& hashval,
-                                             WordLength ksize)
+        HashIntoType& hashval,
+        WordLength ksize)
 {
     if (PyInt_Check(value) || PyLong_Check(value)) {
         if (PyLong_Check(value)) {
@@ -173,7 +173,7 @@ static bool convert_PyObject_to_HashIntoType(PyObject * value,
         return true;
     } else if (PyUnicode_Check(value))  {
         std::string s = PyBytes_AsString(PyUnicode_AsEncodedString(
-                                            value, "utf-8", "strict"));
+                                             value, "utf-8", "strict"));
         if (strlen(s.c_str()) != ksize) {
             PyErr_SetString(PyExc_ValueError,
                             "k-mer length must equal the k-mer size");
@@ -906,7 +906,7 @@ static PyObject * khmer_HashSet_iter(PyObject * self)
 {
     khmer_HashSet_Object * me = (khmer_HashSet_Object *) self;
     _HashSet_iterobj * iter_obj = (_HashSet_iterobj *)
-        _HashSet_iter_Type.tp_alloc(&_HashSet_iter_Type, 0);
+                                  _HashSet_iter_Type.tp_alloc(&_HashSet_iter_Type, 0);
     if (iter_obj != NULL) {
         Py_INCREF(me);
         iter_obj->parent = me;
@@ -931,7 +931,7 @@ static PyObject * khmer_HashSet_concat(khmer_HashSet_Object * o,
         return NULL;
     }
     khmer_HashSet_Object * no = create_HashSet_Object(new SeenSet,
-                                                      o->ksize);
+                                o->ksize);
     no->hashes->insert(o->hashes->begin(), o->hashes->end());
     no->hashes->insert(o2->hashes->begin(), o2->hashes->end());
 
@@ -939,7 +939,7 @@ static PyObject * khmer_HashSet_concat(khmer_HashSet_Object * o,
 }
 
 static PyObject * khmer_HashSet_concat_inplace(khmer_HashSet_Object * o,
-                                               khmer_HashSet_Object * o2)
+        khmer_HashSet_Object * o2)
 {
     if (o->ksize != o2->ksize) {
         PyErr_SetString(PyExc_ValueError,
@@ -1025,7 +1025,7 @@ hashset_update(khmer_HashSet_Object * me, PyObject * args)
             return NULL;
         }
         me->hashes->insert(h);
-        
+
         Py_DECREF(item);
         item = PyIter_Next(iterator);
     }
@@ -1116,7 +1116,7 @@ static khmer_HashSet_Object * create_HashSet_Object(SeenSet * h, WordLength k)
     khmer_HashSet_Object * self;
 
     self = (khmer_HashSet_Object *)
-        khmer_HashSet_Type.tp_alloc(&khmer_HashSet_Type, 0);
+           khmer_HashSet_Type.tp_alloc(&khmer_HashSet_Type, 0);
     if (self != NULL) {
         self->hashes = h;
         self->ksize = k;
@@ -1519,14 +1519,14 @@ hashtable_traverse_linear_path(khmer_KHashtable_Object * me, PyObject * args)
     SeenSet * adj = new SeenSet;
     SeenSet * visited = new SeenSet;
     unsigned int size = hashtable->traverse_linear_path(start_kmer,
-                                                        *adj, *visited,
-                                                        *nodegraph_o->hashbits,
-                                                        *hdn_o->hashes);
+                        *adj, *visited,
+                        *nodegraph_o->hashbits,
+                        *hdn_o->hashes);
 
     khmer_HashSet_Object * adj_o = create_HashSet_Object(adj,
-                                                         hashtable->ksize());
+                                   hashtable->ksize());
     khmer_HashSet_Object * visited_o = create_HashSet_Object(visited,
-                                                           hashtable->ksize());
+                                       hashtable->ksize());
 
     PyObject * ret = Py_BuildValue("kOO", (unsigned long) size,
                                    (PyObject *) adj_o, (PyObject *) visited_o);
@@ -1691,7 +1691,7 @@ hashtable_find_all_tags_list(khmer_KHashtable_Object * me, PyObject * args)
     Py_END_ALLOW_THREADS
 
     PyObject * x = (PyObject *) create_HashSet_Object(tags,
-                                                      hashtable->ksize());
+                   hashtable->ksize());
     return x;
 }
 
@@ -2698,7 +2698,7 @@ hashtable_divide_tags_into_subsets(khmer_KHashtable_Object * me,
     hashtable->divide_tags_into_subsets(subset_size, *divvy);
 
     PyObject * x = (PyObject *) create_HashSet_Object(divvy,
-                                                      hashtable->ksize());
+                   hashtable->ksize());
     return x;
 }
 
@@ -2833,7 +2833,8 @@ hashtable_get_kmer_hashes(khmer_KHashtable_Object * me, PyObject * args)
 
 static
 PyObject *
-hashtable_get_kmer_hashes_as_hashset(khmer_KHashtable_Object * me, PyObject * args)
+hashtable_get_kmer_hashes_as_hashset(khmer_KHashtable_Object * me,
+                                     PyObject * args)
 {
     Hashtable * hashtable = me->hashtable;
     const char * sequence;
@@ -2846,7 +2847,7 @@ hashtable_get_kmer_hashes_as_hashset(khmer_KHashtable_Object * me, PyObject * ar
     hashtable->get_kmer_hashes_as_hashset(sequence, *hashes);
 
     PyObject * x = (PyObject *) create_HashSet_Object(hashes,
-                                                      hashtable->ksize());
+                   hashtable->ksize());
 
     return x;
 }
@@ -3390,7 +3391,7 @@ count_abundance_distribution(khmer_KCountingHash_Object * me, PyObject * args)
     const char         *value_exception = NULL;
     const char         *file_exception  = NULL;
     std::string exc_string;
-    
+
     Py_BEGIN_ALLOW_THREADS
     try {
         dist = counting->abundance_distribution(filename, hashbits);
@@ -4014,7 +4015,7 @@ labelhash_consume_fasta_and_tag_with_labels(khmer_KGraphLabels_Object * me,
     unsigned long long  n_consumed      = 0;
     unsigned int        total_reads     = 0;
     std::string exc_string;
-    
+
     //Py_BEGIN_ALLOW_THREADS
     try {
         hb->consume_fasta_and_tag_with_labels(filename, total_reads,
@@ -4203,7 +4204,7 @@ labelhash_sweep_tag_neighborhood(khmer_KGraphLabels_Object * me,
     //Py_END_ALLOW_THREADS
 
     PyObject * x = (PyObject *) create_HashSet_Object(tagged_kmers,
-                                                   labelhash->graph->ksize());
+                   labelhash->graph->ksize());
     return x;
 }
 

--- a/khmer/_version.py
+++ b/khmer/_version.py
@@ -169,7 +169,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
         print("likely tags: %s" % ",".join(sorted(tags)))
     for ref in sorted(tags):

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2010-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -155,7 +155,7 @@ public:
             unsigned char bit = (unsigned char)(1 << (bin % 8));
 
             unsigned char bits_orig = __sync_fetch_and_or( *(_counts + i) +
-                                                           byte, bit );
+                                      byte, bit );
             if (!(bits_orig & bit)) {
                 if (i == 0) {
                     __sync_add_and_fetch( &_occupied_bins, 1 );

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -986,7 +986,7 @@ void Hashtable::get_kmer_hashes(const std::string &s,
 
 
 void Hashtable::get_kmer_hashes_as_hashset(const std::string &s,
-                                           SeenSet& hashes) const
+        SeenSet& hashes) const
 {
     KmerIterator kmers(s.c_str(), _ksize);
 
@@ -1011,7 +1011,7 @@ void Hashtable::get_kmer_counts(const std::string &s,
 
 void Hashtable::find_high_degree_nodes(const char * s,
                                        SeenSet& high_degree_nodes)
-    const
+const
 {
     Traverser traverser(this);
     KmerIterator kmers(s, _ksize);
@@ -1031,10 +1031,10 @@ void Hashtable::find_high_degree_nodes(const char * s,
 }
 
 unsigned int Hashtable::traverse_linear_path(const Kmer seed_kmer,
-                                             SeenSet &adjacencies,
-                                             SeenSet &visited, Hashtable &bf,
-                                             SeenSet &high_degree_nodes)
-    const
+        SeenSet &adjacencies,
+        SeenSet &visited, Hashtable &bf,
+        SeenSet &high_degree_nodes)
+const
 {
     unsigned int size = 0;
 
@@ -1052,7 +1052,7 @@ unsigned int Hashtable::traverse_linear_path(const Kmer seed_kmer,
     while (to_be_visited.size()) {
         Kmer kmer = to_be_visited.back();
         to_be_visited.pop_back();
-        
+
         visited.insert(kmer);
         size += 1;
 

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -110,7 +110,7 @@ HashIntoType _hash(const std::string kmer, const WordLength k)
 }
 
 HashIntoType _hash(const std::string kmer, const WordLength k,
-                    HashIntoType& h, HashIntoType& r)
+                   HashIntoType& h, HashIntoType& r)
 {
     return _hash(kmer.c_str(), k, h, r);
 }

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -782,9 +782,9 @@ PartitionID SubsetPartition::join_partitions(
     }
 
     if (!set_contains(reverse_pmap, orig) ||
-        !set_contains(reverse_pmap, join) ||
-        reverse_pmap[orig] == NULL ||
-        reverse_pmap[join] == NULL) {
+            !set_contains(reverse_pmap, join) ||
+            reverse_pmap[orig] == NULL ||
+            reverse_pmap[join] == NULL) {
         return 0;
     }
 

--- a/lib/traversal.hh
+++ b/lib/traversal.hh
@@ -78,7 +78,8 @@ public:
                                 std::function<bool (Kmer&)> filter=0);
     unsigned int traverse(Kmer& node,
                           KmerQueue &node_q,
-                          std::function<bool (Kmer&)> filter=0) {
+                          std::function<bool (Kmer&)> filter=0)
+    {
         unsigned int found;
         found = traverse_left(node, node_q, filter);
         found += traverse_right(node, node_q, filter);

--- a/oxli/partition.py
+++ b/oxli/partition.py
@@ -6,9 +6,7 @@
 # Contact: khmer-project@idyll.org
 #
 # pylint: disable=missing-docstring,no-member
-"""
-Common functions for partitioning
-"""
+"""Common functions for partitioning."""
 from __future__ import print_function, absolute_import, unicode_literals
 
 import sys

--- a/scripts/extract-partitions.py
+++ b/scripts/extract-partitions.py
@@ -123,12 +123,11 @@ def PartitionedReader(filename_list, quiet=False, single=False):
 
 def PartitionedReadIterator(filename_list, quiet=False, single=False):
     """
-    Generator to do boilerplate output of statistics
+    Generator to do boilerplate output of statistics.
 
     Uses a list of input files and verbosity
     Returns reads and partition IDs
     """
-
     for filename in filename_list:
         for index, read, pid in read_partition_file(filename):
             if not quiet:
@@ -160,7 +159,7 @@ class PartitionExtractor(object):
 
     def process_unassigned(self, outfp=None):
         """
-        Process unassigned reads
+        Process unassigned reads.
 
         Can optionally output said reads if outfp is given
         Also develops counts of partition IDs--necessary for further processing
@@ -175,7 +174,7 @@ class PartitionExtractor(object):
                         write_record(read, outfp)
 
     def output_histogram(self, dist_filename):
-        """OUtputs histogram of partition counts to the given filename"""
+        """Output histogram of partition counts to the given filename."""
         # develop histogram of partition sizes
         dist = {}
         for _, size in list(self.count.items()):
@@ -193,7 +192,7 @@ class PartitionExtractor(object):
         distfp.close()
 
     def develop_groups(self):
-        """Processing method that divides up the partitions into groups"""
+        """Processing method that divides up the partitions into groups."""
         if 0 in self.count:            # eliminate unpartitioned sequences
             del self.count[0]
 
@@ -224,7 +223,7 @@ class PartitionExtractor(object):
 
     class ReadGroupGenerator(object):
         """
-        Generator that yields partitioned reads and their group
+        Generator that yields partitioned reads and their group.
 
         Takes PartitionExtractor and PartitionedReadIterator objects
         """

--- a/scripts/extract-partitions.py
+++ b/scripts/extract-partitions.py
@@ -228,6 +228,7 @@ class PartitionExtractor(object):
 
         Takes PartitionExtractor and PartitionedReadIterator objects
         """
+
         def __init__(self, extractor):
             self.extractor = extractor
 

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -178,7 +178,7 @@ def clean_up_reads(reads):
 
 
 def trim_record(read, trim_at):
-    "Utility function: create a new record, trimmed at given location."
+    """Utility function: create a new record, trimmed at given location."""
     new_read = Record()
     new_read.name = read.name
     new_read.sequence = read.sequence[:trim_at]
@@ -189,7 +189,7 @@ def trim_record(read, trim_at):
 
 
 def do_trim_read(graph, read, cleaned_read, CUTOFF):
-    "Utility function: trim a read on abundance."
+    """Utility function: trim a read on abundance."""
     K = graph.ksize()
 
     # trim the 'N'-cleaned read
@@ -211,7 +211,9 @@ def do_trim_read(graph, read, cleaned_read, CUTOFF):
 
 class Trimmer(object):
     """
-    Core trimming object; the two utility functions are 'pass1' and 'pass2',
+    Core trimming object.
+
+    The two utility functions are 'pass1' and 'pass2',
     which execute the first and second pass across the data, respectively.
     """
 
@@ -237,7 +239,9 @@ class Trimmer(object):
 
     def pass1(self, reader, saver):
         """
-        The first pass across the read data does the following:
+        The first pass across the read data.
+
+        It does the following:
 
         1. If do_normalize is set, discard all read pairs with coverage
         above DIGINORM_COVERAGE.

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -69,7 +69,7 @@ def teardown():
 def test_count_1():
     hi = khmer._Countgraph(12, PRIMES_1m)
 
-    kmer = 'G'*12
+    kmer = 'G' * 12
     hashval = hi.hash('G' * 12)
 
     assert hi.get(kmer) == 0
@@ -83,7 +83,7 @@ def test_count_1():
     assert hi.get(kmer) == 2
     assert hi.get(hashval) == 2
 
-    kmer = 'G'*11
+    kmer = 'G' * 11
     try:
         hi.hash(kmer)
         assert 0, "incorrect kmer size should fail"
@@ -93,7 +93,7 @@ def test_count_1():
 
 def test_count_2():
     hi = khmer._Countgraph(12, PRIMES_1m)
-    kmer = 'G'*12
+    kmer = 'G' * 12
     hashval = hi.hash('G' * 12)
 
     assert hi.get(kmer) == 0
@@ -110,7 +110,7 @@ def test_count_2():
 
 def test_revhash_1():
     hi = khmer._Countgraph(12, [1])
-    kmer = 'C'*12
+    kmer = 'C' * 12
     hashval = hi.hash('C' * 12)
 
     assert hi.reverse_hash(hashval) == kmer

--- a/tests/test_hashset.py
+++ b/tests/test_hashset.py
@@ -166,4 +166,4 @@ def test_concat_2_fail():
         hs += hs2
         assert 0, "inplace concat should fail - different ksize"
     except ValueError:
-            pass
+        pass


### PR DESCRIPTION
After running `make format` for another PR I ended up with a clobbered `setup.py` and various other/unrelated files got modified. This is a PR that does nothing but execute those commands.

I also removed `setup.py` from the CPPSOURCES variable in `Makefile` otherwise `astyle` does its thing on it which leads to 😕.

Should jenkins be running `make format` and giving an error if it changes a file? Personally I prefer `pep8` as a guideline instead of hard rules, but then it is in the checklist for this project.

---

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
