### PR TITLE
Do not link against `gcov` on OSX when measuring coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ khmer-cov.tgz
 cppcheck-result.xml
 MANIFEST
 TAGS
-nosetests.xml
+pytests.xml
 pep8.out
 pylint.out
 .coverage

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-08-30  Tim Head  <betatim@gmail.com>
+
+   * Fix coverage reporting on OSX and rename nosetests.xml to pytests.xml
+
 2016-08-29  Daniel Standage  <daniel.standage@gmail.com>
 
    * doc/dev/getting-started.rst: updated dev environment setup instructions to

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ diff_pylint_report: pylint_report.txt
 .coverage: $(PYSOURCES) $(wildcard tests/*.py) $(EXTENSION_MODULE)
 	./setup.py develop
 	coverage run --branch --source=scripts,khmer,oxli \
-		--omit=khmer/_version.py -m pytest --junitxml=nosetests.xml \
+		--omit=khmer/_version.py -m pytest --junitxml=pytests.xml \
 		-m $(TESTATTR)
 
 coverage.xml: .coverage
@@ -252,7 +252,7 @@ diff-cover.html: coverage-gcovr.xml coverage.xml
 	diff-cover coverage-gcovr.xml coverage.xml \
 		--html-report diff-cover.html
 
-nosetests.xml: FORCE
+pytests.xml: FORCE
 	py.test --junitxml=$@ -m ${TESTATTR}
 
 ## doxygen     : generate documentation of the C++ and Python code

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PYSOURCES=$(filter-out khmer/_version.py, \
 	  $(wildcard khmer/*.py scripts/*.py oxli/*.py) )
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
 
-DEVPKGS=pep8==1.6.2 diff_cover autopep8 pylint coverage gcovr pytest \
+DEVPKGS=pep8==1.6.2 diff_cover autopep8 pylint coverage gcovr==3.2 pytest \
 	pydocstyle screed pyenchant
 GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PYSOURCES=$(filter-out khmer/_version.py, \
 	  $(wildcard khmer/*.py scripts/*.py oxli/*.py) )
 SOURCES=$(PYSOURCES) $(CPPSOURCES) setup.py
 
-DEVPKGS=pep8==1.6.2 diff_cover autopep8 pylint coverage gcovr==3.2 pytest \
+DEVPKGS=pep8==1.6.2 diff_cover autopep8 pylint coverage gcovr pytest \
 	pydocstyle screed pyenchant
 GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -52,10 +52,6 @@ virtualenv -p ${PYTHON_EXECUTABLE} .env
 pip install setuptools==3.4.1
 make install-dependencies
 
-# XXX temporary lines to debug coverage drop
-pip uninstall --yes gcovr
-pip install https://github.com/gcovr/gcovr/archive/master.zip
-
 if type ccache >/dev/null 2>&1
 then
         echo Enabling ccache

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -52,6 +52,10 @@ virtualenv -p ${PYTHON_EXECUTABLE} .env
 pip install setuptools==3.4.1
 make install-dependencies
 
+# XXX temporary lines to debug coverage drop
+pip uninstall --yes gcovr
+pip install https://github.com/gcovr/gcovr/archive/master.zip
+
 if type ccache >/dev/null 2>&1
 then
         echo Enabling ccache

--- a/jenkins-build.sh
+++ b/jenkins-build.sh
@@ -74,7 +74,7 @@ else
 	echo "gcov was not found (or we are on OSX), skipping coverage check"
 	./setup.py install
 	./setup.py develop
-	make nosetests.xml
+	make pytests.xml
 fi
 
 if type cppcheck >/dev/null 2>&1

--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,9 @@ class KhmerBuildExt(_build_ext):  # pylint: disable=R0904
             raise DistutilsPlatformError("%s require 64-bit operating system" %
                                          SETUP_METADATA["packages"])
 
+        if sys.platform == 'darwin' and 'gcov' in self.libraries:
+            self.libraries.remove('gcov')
+
         if "z" not in self.libraries:
             zcmd = ['bash', '-c', 'cd ' + ZLIBDIR + ' && ( test Makefile -nt'
                     ' configure || bash ./configure --static ) && make -f '


### PR DESCRIPTION
On OSX the `gcov` library doesn't exist. Modified the extension builder to strip out `gcov` from the list of libraries on OSX. With this change I am able to run `make diff-cover` on OSX and generate coverage reports 🎉 !

---

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report`, `git reset --hard` (see #1416),  `make doc pydocstyle` Is it well  formatted? `pydocstyle` reports some errors that already existed. Something to fix in a new PR.
- [x] Is it documented in the `ChangeLog`**?
- [x] Is the Copyright year up to date?
- [x] rename `nosetest.xml`

** should this be mentioned in the ChangeLog or is that for user facing changes only?