### PR TITLE
Switching to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ script:
   - make test
   # coverage needs a clean build, generate coverage on all ARCHs,
   # running it here means it will fail the build if it fails
-  - make clean coverage-gcovr.xml coverage.xml
+  - PYTEST_ADDOPTS=-qqq make clean coverage-gcovr.xml coverage.xml
 
 # generate all the diagnostic reports
 after_success:
-  - make clean diff-cover
+  - PYTEST_ADDOPTS=-qqq make clean diff-cover
   - make format
   - make diff_pylint_report cppcheck doc
   - make cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+# Tell travis we want Ubuntu 14.04
+sudo: required
+dist: trusty
+
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       # Tell travis we want debian trusty
       sudo: required
       dist: trusty
+      env:
+        - TESTATTR="'not huge and not known_failing'"
       addons:
         apt:
           packages:
@@ -21,6 +23,8 @@ matrix:
     - os: osx
       language: generic
       osx_image: xcode7.3
+      env:
+        - TESTATTR="'not linux and not known_failing and not huge'"
       before_install:
         - source ci_scripts/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,16 @@ script:
 
 # generate all the diagnostic reports
 after_success:
-  - make pylint
-  - make pep8
+  - make clean diff-cover
+  - make format
+  - make diff_pylint_report cppcheck doc
   - make cppcheck
+  - make pydocstyle
   # do the docs build?
   - make doc
+  # XXX Do not upload results from travis yet. Currently jenkins is considered
+  # XXX the source of truth about coverage
   # only upload the linux coverage report to codecov as it merges all reports
   # from all builds into one
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install codecov; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi
+  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install codecov; fi
+  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
 # command to run tests
 script:
   - make test
-  # coverage needs a clean build, generate coverage for all ARCHs
+  # coverage needs a clean build, generate coverage on all ARCHs,
   # running it here means it will fail the build if it fails
   - make clean coverage-gcovr.xml coverage.xml
 
@@ -47,6 +47,7 @@ script:
 after_success:
   - make pylint
   - make pep8
+  - make cppcheck
   # do the docs build?
   - make doc
   # only upload the linux coverage report to codecov as it merges all reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,14 @@ install:
 # command to run tests
 script:
   - make test
+
+# generate all the diagnostic reports
+after_success:
+  - make pylint
+  - make pep8
+  # do the docs build?
+  - make doc
+  # coverage needs a clean build
+  - make clean coverage-gcovr.xml coverage.xml
+  - pip install codecov
+  - codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,15 @@ install:
 # command to run tests
 script:
   - make test
-  # coverage needs a clean build, generate coverage on all ARCHs,
-  # running it here means it will fail the build if it fails
-  - PYTEST_ADDOPTS=-qqq make clean coverage-gcovr.xml coverage.xml
 
 # generate all the diagnostic reports
 after_success:
-  - PYTEST_ADDOPTS=-qqq make clean diff-cover
+  - PYTEST_ADDOPTS=-qqq make coverage-gcovr.xml coverage.xml
+  # Fix suggested by http://diff-cover.readthedocs.io/en/latest/#troubleshooting
+  - git fetch origin master:refs/remotes/origin/master
+  - PYTEST_ADDOPTS=-qqq make diff-cover
   - make format
-  - make diff_pylint_report cppcheck doc
+  - make diff_pylint_report
   - make cppcheck
   - make pydocstyle
   # do the docs build?

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,18 @@ matrix:
             - cppcheck
             - enchant
 
+    - os: osx
+      language: generic
+      osx_image: xcode7.3
+      before_install:
+        - source ci_scripts/install.sh
+
 # command to install common dependencies
 install:
+  - python --version
+  - which python
   - gcc --version
+  - which gcc
   - make install-dependencies
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+notifications:
+  email: false
+
+
+matrix:
+  include:
+    - os: linux
+      python: "2.7"
+      # Tell travis we want debian trusty
+      sudo: required
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - astyle
+            - cppcheck
+            - enchant
+
+# command to install common dependencies
+install:
+  - gcc --version
+  - make install-dependencies
+
+# command to run tests
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ install:
 # command to run tests
 script:
   - make test
+  # coverage needs a clean build, generate coverage for all ARCHs
+  # running it here means it will fail the build if it fails
+  - make clean coverage-gcovr.xml coverage.xml
 
 # generate all the diagnostic reports
 after_success:
@@ -46,7 +49,7 @@ after_success:
   - make pep8
   # do the docs build?
   - make doc
-  # coverage needs a clean build
-  - make clean coverage-gcovr.xml coverage.xml
-  - pip install codecov
-  - codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml
+  # only upload the linux coverage report to codecov as it merges all reports
+  # from all builds into one
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install codecov; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -1,0 +1,31 @@
+# Used to prepare OSX builds
+
+if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+  echo "This is not a OSX build"
+  exit 1
+fi
+
+brew update;
+brew install astyle;
+brew install enchant;
+brew install cppcheck;
+
+pushd .
+cd
+mkdir -p download
+cd download
+wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh \
+  -O miniconda.sh
+chmod +x miniconda.sh && ./miniconda.sh -b
+cd ..
+export PATH=/Users/travis/miniconda3/bin:$PATH
+conda update --yes conda
+popd
+
+# Create a fresh environment
+conda create -n testenv --yes python=2.7
+
+source activate testenv
+
+# Without this `make install-dependencies` fails
+pip install --ignore-installed setuptools

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -190,8 +190,6 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
         threads.append(cur_thread)
         cur_thread.start()
 
-    assert threading.active_count() == args.threads + 1
-
     print('done starting threads', file=sys.stderr)
 
     # wait for threads


### PR DESCRIPTION
Closes #1419.

First attempt to switch to travis for linux and OSX. Enabled travis on my fork and [it builds](https://travis-ci.org/betatim/khmer/builds/152684414)!

There are some failures on OSX that need investigating. And the whole set of diagnostic stuff needs adding as well.

---

- [x] re-introduce `assert` removed in 77cd1bb? No
- [x] ~~split `make test` into two commands so the build output gets folded when successful instead of cluttering up the page~~
- [x] investigate OSX test failures
- [x] codecov
- [x] `pep8` and `make format`
- [x] other diagnostics/reporting
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Is the Copyright year up to date?
