### PR TITLE
PEP8 fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
-2016-08-26 Ryan Shean <rcs333@uw.edu>
+2016-08-26  Daniel Standage  <daniel.standage@gmail.com>
+
+   * tests/test_scripts.py: fix PEP8 errors missed with previous PR (due to CI
+   issues)
+   * Makefile: make the pep8 target less verbose by removing the --show-pep8
+   option
+
+2016-08-26  Ryan Shean  <rcs333@uw.edu>
 
    * tests/{test_countergraph.py, test_filter_abund.py,
    test_normalize_by_median.py, test_read_handling.py,

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ cppcheck-long: FORCE
 
 ## pep8        : check Python code style
 pep8: $(PYSOURCES) $(wildcard tests/*.py)
-	pep8 --exclude=_version.py  --show-source --show-pep8 setup.py khmer/ \
+	pep8 --exclude=_version.py  --show-source setup.py khmer/ \
 		scripts/ tests/ oxli/ || true
 
 pep8_report.txt: $(PYSOURCES) $(wildcard tests/*.py)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2335,7 +2335,6 @@ def test_trim_low_abund_2():
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile)
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fa'), infile2)
 
-
     args = ["-k", "17", "-x", "1e7", "-N", "2", '-C', '1', infile, infile2]
     utils.runscript('trim-low-abund.py', args, in_dir)
 
@@ -2375,7 +2374,6 @@ def test_trim_low_abund_3_fq_retained():
 
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fq'), infile)
     shutil.copyfile(utils.get_test_data('test-abund-read-2.fq'), infile2)
-
 
     args = ["-k", "17", "-x", "1e7", "-N", "2", '-C', '1', infile, infile2]
     utils.runscript('trim-low-abund.py', args, in_dir)


### PR DESCRIPTION
The last PR introduced some PEP8 violations that I missed due to CI issues. This PR fixes those, and makes the `pep8` target a bit less verbose.

----------

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

