### PR TITLE
Implement support for loading read sequences from BAM files

### DIFF
--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -217,13 +217,17 @@ SeqAnBamParser::~SeqAnBamParser()
     delete _private;
 }
 
+IParser * const IParser::get_bam_parser(std::string const& ifile_name)
+{
+    return new SeqAnBamParser(ifile_name.c_str());
+}
+
 IParser * const
 IParser::
 get_parser(
     std:: string const	    &ifile_name
 )
 {
-
     return new SeqAnParser(ifile_name.c_str());
 }
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -189,6 +189,20 @@ private:
 
 };
 
+class SeqAnBamParser : public IParser
+{
+public:
+    explicit SeqAnBamParser( const char * filename );
+    ~SeqAnBamParser( );
+
+    bool is_complete( );
+    void imprint_next_read(Read &the_read);
+
+private:
+    struct Handle;
+    Handle* _private;
+};
+
 inline PartitionID _parse_partition_id(std::string name)
 {
     PartitionID p = 0;


### PR DESCRIPTION
See #523. Work in progress. I have some pretty huge .bam files that I need to load into countgraphs, and it would be great if I didn't have to convert to .fastq first.

I haven't taken the time to grok SeqAn _or_ the khmer read parser objects, so this is me mostly copy/pasting and just making it up as I go.
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?
