### PR TITLE
Adapt to new py.test recommendation for yielding tests

### DIFF
--- a/tests/test_sandbox_scripts.py
+++ b/tests/test_sandbox_scripts.py
@@ -62,15 +62,16 @@ def teardown():
     utils.cleanup()
 
 
-sandbox_path = os.path.join(os.path.dirname(__file__), "../sandbox")
-if not os.path.exists(sandbox_path):
-    pytest.skip("sandbox scripts are only tested in a repository")
+def _sandbox_scripts():
+    sandbox_path = os.path.join(os.path.dirname(__file__), "../sandbox")
+    if not os.path.exists(sandbox_path):
+        pytest.skip("sandbox scripts are only tested in a repository")
 
-path = os.path.join(sandbox_path, "*.py")
-scripts = glob.glob(path)
+    path = os.path.join(sandbox_path, "*.py")
+    return [os.path.normpath(s) for s in glob.glob(path)]
 
 
-@pytest.mark.parametrize("filename", [os.path.normpath(s) for s in scripts])
+@pytest.mark.parametrize("filename", _sandbox_scripts())
 def test_import_succeeds(filename):
     try:
         mod = imp.load_source('__zzz', filename)

--- a/tests/test_sandbox_scripts.py
+++ b/tests/test_sandbox_scripts.py
@@ -68,6 +68,8 @@ if not os.path.exists(sandbox_path):
 
 path = os.path.join(sandbox_path, "*.py")
 scripts = glob.glob(path)
+
+
 @pytest.mark.parametrize("filename", [os.path.normpath(s) for s in scripts])
 def test_import_succeeds(filename):
     try:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2794,22 +2794,18 @@ def test_unique_kmers_multiple_inputs():
     assert 'Total estimated number of unique 20-mers: 4170' in err
 
 
-def check_version_and_basic_citation(scriptname):
-    version = re.compile("^khmer .*$", re.MULTILINE)
-    status, out, err = utils.runscript(scriptname, ["--version"])
-    assert status == 0, status
-    print(out)
-    print(err)
-    # assert "publication" in err, err
-    assert version.search(err) is not None, err
-
-
-def test_version():
-    for entry in os.listdir(utils.scriptpath()):
-        if entry.endswith(".py"):
-            with open(os.path.join(utils.scriptpath(), entry)) as script:
-                line = script.readline()
-                line = script.readline()
-                if 'khmer' in line:  # simple check of copyright line.
-                    yield check_version_and_basic_citation, entry
-                    # emit test for each script
+@pytest.mark.parametrize("scriptname",
+                         [entry for entry in os.listdir(utils.scriptpath())
+                          if entry.endswith('.py')])
+def test_version_and_basic_citation(scriptname):
+    with open(os.path.join(utils.scriptpath(), scriptname)) as script:
+        line = script.readline()
+        line = script.readline()
+        if 'khmer' in line:
+            version = re.compile("^khmer .*$", re.MULTILINE)
+            status, out, err = utils.runscript(scriptname, ["--version"])
+            assert status == 0, status
+            print(out)
+            print(err)
+            # assert "publication" in err, err
+            assert version.search(err) is not None, err


### PR DESCRIPTION
Fixes #1423.

Seems a bit ugly to have the code to generate the list of scripts at the top level.

- [ ] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?

