### PR TITLE
Swap murmurhash in as primary hash function.

### DIFF
--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -66,14 +66,10 @@ HashIntoType _hash_forward(const char * kmer, WordLength k)
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashIntoType h = 0;
-
-    h |= twobit_repr(kmer[0]);
-
-    for (WordLength i = 1; i < k; i++) {
-        h = h << 2;
-        h |= twobit_repr(kmer[i]);
-    }
+    HashIntoType out[2];
+    uint32_t seed = 0;
+    MurmurHash3_x64_128((void *)kmer, k, seed, &out);
+    HashIntoType h = out[0];
 
     return h;
 }


### PR DESCRIPTION
Starting from #1432 (simplification of hash function code), swap in murmurhash as the default hash function for khmer.

This will support k > 32.  cc #1426 

The tests that are broken are either checks on the exact hash values, OR are sensitive to collisions (a lot of the occupancy numbers are like this), OR are broken for unknown reasons - I'm not sure why the graph alignment code is broken, in particular.  Still, we're down to 15 broken tests which is pretty good...