### PR TITLE
Add sliding window optimization back in w/irreversible hashing

### DIFF
--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -55,7 +55,7 @@ using namespace khmer:: read_parsers;
 
 BoundedCounterType CountingHash::get_min_count(const std::string &s)
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
 
     BoundedCounterType min_count = MAX_KCOUNT;
 
@@ -73,7 +73,7 @@ BoundedCounterType CountingHash::get_min_count(const std::string &s)
 
 BoundedCounterType CountingHash::get_max_count(const std::string &s)
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
 
     BoundedCounterType max_count = 0;
 
@@ -121,7 +121,7 @@ CountingHash::abundance_distribution(
         seq = read.sequence;
 
         if (check_and_normalize_read(seq)) {
-            KmerIterator kmers(seq.c_str(), _ksize);
+            StringToHashIterator kmers(seq.c_str(), _ksize);
 
             while(!kmers.done()) {
                 HashIntoType kmer = kmers.next();
@@ -172,7 +172,7 @@ const
         return 0;
     }
 
-    KmerIterator kmers(seq.c_str(), _ksize);
+    StringToHashIterator kmers(seq.c_str(), _ksize);
 
     HashIntoType kmer;
 
@@ -207,7 +207,7 @@ const
         return 0;
     }
 
-    KmerIterator kmers(seq.c_str(), _ksize);
+    StringToHashIterator kmers(seq.c_str(), _ksize);
 
     HashIntoType kmer;
 
@@ -243,7 +243,7 @@ const
         throw khmer_exception("invalid read");
     }
 
-    KmerIterator kmers(seq.c_str(), _ksize);
+    StringToHashIterator kmers(seq.c_str(), _ksize);
 
     HashIntoType kmer = kmers.first();
     if (kmers.done()) {

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -159,7 +159,7 @@ unsigned int Hashtable::consume_string(const std::string &s)
     const char * sp = s.c_str();
     unsigned int n_consumed = 0;
 
-    KmerIterator kmers(sp, _ksize);
+    StringToHashIterator kmers(sp, _ksize);
 
     while(!kmers.done()) {
         HashIntoType kmer = kmers.next();
@@ -211,7 +211,7 @@ void Hashtable::get_median_count(const std::string &s,
 bool Hashtable::median_at_least(const std::string &s,
                                 unsigned int cutoff)
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
     unsigned int min_req = 0.5 + float(s.size() - _ksize + 1) / 2;
     unsigned int num_cutoff_kmers = 0;
 
@@ -332,7 +332,7 @@ void Hashtable::get_kmers(const std::string &s,
 void Hashtable::get_kmer_hashes(const std::string &s,
                                 std::vector<HashIntoType> &kmers_vec) const
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
 
     while(!kmers.done()) {
         HashIntoType kmer = kmers.next();
@@ -344,7 +344,7 @@ void Hashtable::get_kmer_hashes(const std::string &s,
 void Hashtable::get_kmer_hashes_as_hashset(const std::string &s,
         SeenSet& hashes) const
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
 
     while(!kmers.done()) {
         HashIntoType kmer = kmers.next();
@@ -356,7 +356,7 @@ void Hashtable::get_kmer_hashes_as_hashset(const std::string &s,
 void Hashtable::get_kmer_counts(const std::string &s,
                                 std::vector<BoundedCounterType> &counts) const
 {
-    KmerIterator kmers(s.c_str(), _ksize);
+    StringToHashIterator kmers(s.c_str(), _ksize);
 
     while(!kmers.done()) {
         HashIntoType kmer = kmers.next();
@@ -379,6 +379,7 @@ const
             std::cout << "... find_high_degree_nodes: " << n << "\n";
             std::cout << std::flush;
         }
+
         Kmer kmer = kmers.next();
         if ((traverser.degree(kmer)) > 2) {
             high_degree_nodes.insert(kmer);

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -317,7 +317,7 @@ public:
             throw khmer_exception();
         }
 
-        char ch = _seq[index];
+        char ch = _seq[index - 1];
 
         // left-shift the previous hash over
         _kmer_f = _kmer_f << 2;


### PR DESCRIPTION
This PR is on top of #1432, and isn't going to be suitable for merging; it's a test PR.

Here, I add back in the sliding window optimization for calculating Kmer and HashIntoType from strings.  I split the use cases so that KmerIterator calculations are distinct from HashIntoType calculations; the former need to have full Kmer information for things like traversal, while the latter can lose information as they are simply used for one-way hashing.

On the benchmark in #1436, this PR performs equivalently to (or a bit better than) the current master code base.  On the flip side, the KmerIterator is about 100 times slower, which is largely because of the string manipulations around tracking exact k-mers.  See discussion in #1426 for more on next steps.