### PR TITLE
twobit_repr as lookup table

### DIFF
--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -61,6 +61,18 @@ khmer::HashIntoType twobit_repr(const char ch)
     throw khmer::khmer_exception("Sequence contains invalid DNA symbol.");
   }
 }
+const khmer::HashIntoType
+twobit_values_comp[256] = {['A'] = 1+1, ['T'] = 0+1, ['C'] = 3+1, ['G'] = 2+1,
+                           ['a'] = 1+1, ['t'] = 0+1, ['c'] = 3+1, ['g'] = 2+1};
+khmer::HashIntoType twobit_comp(const char ch)
+{
+  const khmer::HashIntoType v(twobit_values_comp[ch]);
+  if (v > 0) {
+    return v - 1;
+  } else {
+    throw khmer::khmer_exception("Sequence contains invalid DNA symbol.");
+  }
+}
 
 
 //

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -49,12 +49,17 @@ Contact: khmer-project@idyll.org
 using namespace std;
 
 
-const unsigned long long
-twobit_values[256] = {['A'] = 0, ['T'] = 1, ['C'] = 2, ['G'] = 3,
-                      ['a'] = 0, ['t'] = 1, ['c'] = 2, ['g'] = 3};
-khmer::HashIntoType twobit_repr(char ch)
+const khmer::HashIntoType
+twobit_values[256] = {['A'] = 0+1, ['T'] = 1+1, ['C'] = 2+1, ['G'] = 3+1,
+                      ['a'] = 0+1, ['t'] = 1+1, ['c'] = 2+1, ['g'] = 3+1};
+khmer::HashIntoType twobit_repr(const char ch)
 {
-  return twobit_values[ch];
+  const khmer::HashIntoType v(twobit_values[ch]);
+  if (v > 0) {
+    return v - 1;
+  } else {
+    throw khmer::khmer_exception("Sequence contains invalid DNA symbol.");
+  }
 }
 
 

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -66,12 +66,9 @@ twobit_values_comp[256] = {['A'] = 1+1, ['T'] = 0+1, ['C'] = 3+1, ['G'] = 2+1,
                            ['a'] = 1+1, ['t'] = 0+1, ['c'] = 3+1, ['g'] = 2+1};
 khmer::HashIntoType twobit_comp(const char ch)
 {
-  const khmer::HashIntoType v(twobit_values_comp[ch]);
-  if (v > 0) {
-    return v - 1;
-  } else {
-    throw khmer::khmer_exception("Sequence contains invalid DNA symbol.");
-  }
+  return twobit_values_comp[ch] - 1;
+  // this should not get called without twobit_repr() having been called
+  // first so no need to check for invalid DNA characters
 }
 
 

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -48,6 +48,16 @@ Contact: khmer-project@idyll.org
 
 using namespace std;
 
+
+const unsigned long long
+twobit_values[256] = {['A'] = 0, ['T'] = 1, ['C'] = 2, ['G'] = 3,
+                      ['a'] = 0, ['t'] = 1, ['c'] = 2, ['g'] = 3};
+khmer::HashIntoType twobit_repr(char ch)
+{
+  return twobit_values[ch];
+}
+
+
 //
 // _hash: hash a k-length DNA sequence into a 64-bit number.
 //

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -58,22 +58,11 @@ Contact: khmer-project@idyll.org
 #endif
 
 khmer::HashIntoType twobit_repr(char ch);
+khmer::HashIntoType twobit_comp(char ch);
 
 #define revtwobit_repr(n) ((n) == 0 ? 'A' : \
                            (n) == 1 ? 'T' : \
                            (n) == 2 ? 'C' : 'G')
-
-#ifdef KHMER_EXTRA_SANITY_CHECKS
-#   define twobit_comp(ch) ((toupper(ch)) == 'A' ? 1LL : \
-			    (toupper(ch)) == 'T' ? 0LL : \
-			    (toupper(ch)) == 'C' ? 3LL : 2LL)
-#else
-// NOTE: Assumes data is already sanitized as it should be by parsers.
-//	     This assumption eliminates 4 function calls.
-#   define twobit_comp(ch) ((ch) == 'A' ? 1LL : \
-			    (ch) == 'T' ? 0LL : \
-			    (ch) == 'C' ? 3LL : 2LL)
-#endif
 
 // choose wisely between forward and rev comp.
 #ifndef NO_UNIQUE_RC

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -57,18 +57,7 @@ Contact: khmer-project@idyll.org
 			     (ch) == 'G' || (ch) == 'T')
 #endif
 
-// bit representation of A/T/C/G.
-#ifdef KHMER_EXTRA_SANITY_CHECKS
-#   define twobit_repr(ch) ((toupper(ch)) == 'A' ? 0LL : \
-			    (toupper(ch)) == 'T' ? 1LL : \
-			    (toupper(ch)) == 'C' ? 2LL : 3LL)
-#else
-// NOTE: Assumes data is already sanitized as it should be by parsers.
-//	     This assumption eliminates 4 function calls.
-#   define twobit_repr(ch) ((ch) == 'A' ? 0LL : \
-			    (ch) == 'T' ? 1LL : \
-			    (ch) == 'C' ? 2LL : 3LL)
-#endif
+khmer::HashIntoType twobit_repr(char ch);
 
 #define revtwobit_repr(n) ((n) == 0 ? 'A' : \
                            (n) == 1 ? 'T' : \


### PR DESCRIPTION
Exploratory branch for #1434. Use a lookup table and a function instead of a macro.

This is a bit naughty (it generate compiler warnings) but using a lookup table to turn
characters into integers has some advantages as well. You don't have to upper case
things anymore and you can have as many comparisons as you want. Not checked
but I assume that the compiler figures out how to inline this kind of function (or do other magic). 

Another unchecked thing is how this goes in terms of SIMD instructions. Having a long sequence of characters which you iterate over with a `for` loop should be a prime target for the compiler (but sometimes it needs (a lot of) help to figure that out).

The bench from #1436 suggests that this is marginally (sometimes I see 0.16 or even 0.15 c.f. 0.17) faster than the macro.

Opinions?

---

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?
