### PR TITLE
Rename SeqAnParser

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-09-09  Daniel Standage  <daniel.standage@gmail.com>
+
+   * lib/read_parsers.{cc,hh}: rename SeqAnParser to FastxParser.
+
 2016-09-09  Tim Head  <betatim@gmail.com>
 
    * tests/test_filter_abund.py: remove for loops introduce to the test suite.

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2012-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -65,14 +65,14 @@ Read::write_to(std::ostream& output)
 }
 
 
-struct SeqAnParser::Handle {
+struct FastxParser::Handle {
     seqan::SequenceStream stream;
     uint32_t seqan_spin_lock;
 };
 
-SeqAnParser::SeqAnParser( char const * filename ) : IParser( )
+FastxParser::FastxParser( char const * filename ) : IParser( )
 {
-    _private = new SeqAnParser::Handle();
+    _private = new FastxParser::Handle();
     seqan::open(_private->stream, filename);
     if (!seqan::isGood(_private->stream)) {
         std::string message = "Could not open ";
@@ -87,12 +87,12 @@ SeqAnParser::SeqAnParser( char const * filename ) : IParser( )
     _private->seqan_spin_lock = 0;
 }
 
-bool SeqAnParser::is_complete()
+bool FastxParser::is_complete()
 {
     return !seqan::isGood(_private->stream) || seqan::atEnd(_private->stream);
 }
 
-void SeqAnParser::imprint_next_read(Read &the_read)
+void FastxParser::imprint_next_read(Read &the_read)
 {
     the_read.reset();
     int ret = -1;
@@ -137,7 +137,7 @@ void SeqAnParser::imprint_next_read(Read &the_read)
     }
 }
 
-SeqAnParser::~SeqAnParser()
+FastxParser::~FastxParser()
 {
     seqan::close(_private->stream);
     delete _private;
@@ -150,7 +150,7 @@ get_parser(
 )
 {
 
-    return new SeqAnParser(ifile_name.c_str());
+    return new FastxParser(ifile_name.c_str());
 }
 
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2012-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -172,12 +172,12 @@ protected:
 
 }; // struct IParser
 
-class SeqAnParser : public IParser
+class FastxParser : public IParser
 {
 
 public:
-    explicit SeqAnParser( const char * filename );
-    ~SeqAnParser( );
+    explicit FastxParser( const char * filename );
+    ~FastxParser( );
 
     bool is_complete( );
     void imprint_next_read(Read &the_read);


### PR DESCRIPTION
In anticipation of providing support for reading BAM files in addition to Fast[x] files, also using SeqAn, I propose renaming the `SeqAnParser` class as `FastxParser`. Substantial refactoring will be required, but I wanted to confirm that nothing would break by renaming the class.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] <strike>`make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?</strike>
- [ ] <strike>`make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?</strike>
- [ ] <strike>Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.</strike>
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] <strike>Do the changes respect streaming IO? (Are they
  tested for streaming IO?)</strike>
- [x] Is the Copyright year up to date?

