### PR TITLE
A type to store large hash values (>64bit)

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -1671,7 +1671,9 @@ hashtable_get_tags_and_positions(khmer_KHashtable_Object * me, PyObject * args)
 
     PyObject * posns_list = PyList_New(posns.size());
     for (size_t i = 0; i < posns.size(); i++) {
-        PyObject * tup = Py_BuildValue("IK", posns[i], tags[i]);
+        PyObject * tag = _PyLong_FromByteArray(tags[i].bytes.data(),
+                                               tags[i].bytes.size(), 0, 0);
+        PyObject * tup = Py_BuildValue("IO", posns[i], tag);
         PyList_SET_ITEM(posns_list, i, tup);
     }
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -1506,7 +1506,8 @@ hashtable_neighbors(khmer_KHashtable_Object * me, PyObject * args)
         HashIntoType h = node_q.front();
         node_q.pop();
         // type K for python unsigned long long
-        PyList_SET_ITEM(x, i, Py_BuildValue("K", h));
+        PyList_SET_ITEM(x, i, _PyLong_FromByteArray(h.bytes.data(),
+                                                    h.bytes.size(), 0, 0));
     }
 
     return x;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -5090,19 +5090,24 @@ static PyObject * forward_hash_no_rc(PyObject * self, PyObject * args)
 
 static PyObject * reverse_hash(PyObject * self, PyObject * args)
 {
-    HashIntoType val;
+    PyObject * val;
+    HashIntoType hash;
     WordLength ksize;
 
-    if (!PyArg_ParseTuple(args, "Kb", &val, &ksize)) {
+    if (!PyArg_ParseTuple(args, "Ob", &val, &ksize)) {
         return NULL;
     }
+    _PyLong_AsByteArray((PyLongObject *)val,
+                        hash.bytes.data(),
+                        hash.bytes.size(), 0, 0);
+    std::cout << hash.as_ull() << std::endl;
 
     if (ksize > KSIZE_MAX) {
         PyErr_Format(PyExc_ValueError, "k-mer size must be <= %u", KSIZE_MAX);
         return NULL;
     }
 
-    return PyUnicode_FromString(_revhash(val, ksize).c_str());
+    return PyUnicode_FromString(_revhash(hash, ksize).c_str());
 }
 
 static PyObject * murmur3_forward_hash(PyObject * self, PyObject * args)

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -1269,8 +1269,12 @@ hashtable_reverse_hash(khmer_KHashtable_Object * me, PyObject * args)
 {
     Hashtable * hashtable = me->hashtable;
 
+    PyObject * val_o;
     HashIntoType val;
-    if (!PyArg_ParseTuple(args, "K", &val)) {
+    if (!PyArg_ParseTuple(args, "O", &val_o)) {
+        return NULL;
+    }
+    if (!convert_PyObject_to_HashIntoType(val_o, val, 0)) {
         return NULL;
     }
 
@@ -4228,9 +4232,13 @@ labelhash_get_tag_labels(khmer_KGraphLabels_Object * me, PyObject * args)
 {
     LabelHash * labelhash = me->labelhash;
 
+    PyObject * tag_o;
     HashIntoType tag;
 
-    if (!PyArg_ParseTuple(args, "K", &tag)) {
+    if (!PyArg_ParseTuple(args, "O", &tag_o)) {
+        return NULL;
+    }
+    if (!convert_PyObject_to_HashIntoType(tag_o, tag, 0)) {
         return NULL;
     }
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -858,10 +858,9 @@ static PyObject * _HashSet_iternext(PyObject * self)
     _HashSet_iterobj * iter_obj = (_HashSet_iterobj *) self;
     SeenSet * hashes = iter_obj->parent->hashes;
     if (*iter_obj->it != hashes->end()) {
-        //PyObject * ret = PyLong_FromUnsignedLongLong(**iter_obj->it);
-
-        PyObject * ret = _PyLong_FromByteArray((unsigned char *)&(**iter_obj->it).bytes,
-                            (**iter_obj->it).bytes.size(), 0, 0);
+        PyObject * ret = _PyLong_FromByteArray((**iter_obj->it).bytes.data(),
+                                               (**iter_obj->it).bytes.size(),
+                                                0, 0);
         (*(iter_obj->it))++;
         return ret;
     }
@@ -1259,10 +1258,7 @@ hashtable_hash(khmer_KHashtable_Object * me, PyObject * args)
     try {
         PyObject * hash;
         HashIntoType h(_hash(kmer, hashtable->ksize()));
-        hash = _PyLong_FromByteArray((unsigned char *)&h.bytes,
-                            h.bytes.size(), 0, 0);
-        //hash = PyLong_FromUnsignedLongLong(_hash(kmer, hashtable->ksize()));
-
+        hash = _PyLong_FromByteArray(h.bytes.data(), h.bytes.size(), 0, 0);
         return hash;
     } catch (khmer_exception &e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -2842,9 +2838,8 @@ hashtable_get_kmer_hashes(khmer_KHashtable_Object * me, PyObject * args)
 
     PyObject * x = PyList_New(hashes.size());
     for (unsigned int i = 0; i < hashes.size(); i++) {
-        //PyObject * obj = PyLong_FromUnsignedLongLong(hashes[i]);
-        PyObject * obj = _PyLong_FromByteArray((unsigned char *)&hashes[i].bytes,
-                            hashes[i].bytes.size(), 0, 0);
+        PyObject * obj = _PyLong_FromByteArray(hashes[i].bytes.data(),
+                                               hashes[i].bytes.size(), 0, 0);
         PyList_SET_ITEM(x, i, obj);
     }
 
@@ -5057,10 +5052,8 @@ static PyObject * forward_hash(PyObject * self, PyObject * args)
 
     try {
         PyObject * hash;
-        //hash = PyLong_FromUnsignedLongLong(_hash(kmer, ksize));
         HashIntoType h(_hash(kmer, ksize));
-        hash = _PyLong_FromByteArray((unsigned char *)&h.bytes,
-                            h.bytes.size(), 0, 0);
+        hash = _PyLong_FromByteArray(h.bytes.data(), h.bytes.size(), 0, 0);
         return hash;
     } catch (khmer_exception &e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -5090,8 +5083,8 @@ static PyObject * forward_hash_no_rc(PyObject * self, PyObject * args)
     }
 
     HashIntoType h(_hash_forward(kmer, ksize));
-    PyObject * hash = _PyLong_FromByteArray((unsigned char *)&h.bytes,
-                                            h.bytes.size(), 0, 0);
+    PyObject * hash = _PyLong_FromByteArray(h.bytes.data(), h.bytes.size(),
+                                            0, 0);
     return hash;
 }
 
@@ -5121,8 +5114,8 @@ static PyObject * murmur3_forward_hash(PyObject * self, PyObject * args)
     }
 
     HashIntoType h(_hash_murmur(kmer));
-    PyObject * hash = _PyLong_FromByteArray((unsigned char *)&h.bytes,
-                                            h.bytes.size(), 0, 0);
+    PyObject * hash = _PyLong_FromByteArray(h.bytes.data(), h.bytes.size(),
+                                            0, 0);
     return hash;
 }
 
@@ -5135,7 +5128,7 @@ static PyObject * murmur3_forward_hash_no_rc(PyObject * self, PyObject * args)
     }
 
     HashIntoType h(_hash_murmur_forward(kmer));
-    PyObject * hash = _PyLong_FromByteArray((unsigned char *)&h.bytes,
+    PyObject * hash = _PyLong_FromByteArray(h.bytes.data(),
                                             h.bytes.size(), 0, 0);
     return hash;
 }

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -89,13 +89,13 @@ BoundedCounterType CountingHash::get_max_count(const std::string &s)
     return max_count;
 }
 
-HashIntoType *
+uint64_t *
 CountingHash::abundance_distribution(
     read_parsers::IParser * parser,
     Hashbits *          tracking)
 {
-    HashIntoType * dist = new HashIntoType[MAX_BIGCOUNT + 1];
-    HashIntoType i;
+    uint64_t * dist = new uint64_t[MAX_BIGCOUNT + 1];
+    uint64_t i;
 
     for (i = 0; i <= MAX_BIGCOUNT; i++) {
         dist[i] = 0;
@@ -142,13 +142,13 @@ CountingHash::abundance_distribution(
 }
 
 
-HashIntoType * CountingHash::abundance_distribution(
+uint64_t * CountingHash::abundance_distribution(
     std::string filename,
     Hashbits *  tracking)
 {
     IParser* parser = IParser::get_parser(filename.c_str());
 
-    HashIntoType * distribution = abundance_distribution(parser, tracking);
+    uint64_t * distribution = abundance_distribution(parser, tracking);
     delete parser;
     return distribution;
 }
@@ -403,11 +403,11 @@ CountingHashFileReader::CountingHashFileReader(
         }
 
         for (unsigned int i = 0; i < ht._n_tables; i++) {
-            HashIntoType tablesize;
+            uint64_t tablesize;
 
             infile.read((char *) &save_tablesize, sizeof(save_tablesize));
 
-            tablesize = (HashIntoType) save_tablesize;
+            tablesize = save_tablesize;
             ht._tablesizes.push_back(tablesize);
 
             ht._counts[i] = new Byte[tablesize];
@@ -419,7 +419,7 @@ CountingHashFileReader::CountingHashFileReader(
             }
         }
 
-        HashIntoType n_counts = 0;
+        uint64_t n_counts = 0;
         infile.read((char *) &n_counts, sizeof(n_counts));
 
         if (n_counts) {
@@ -428,7 +428,7 @@ CountingHashFileReader::CountingHashFileReader(
             HashIntoType kmer;
             BoundedCounterType count;
 
-            for (HashIntoType n = 0; n < n_counts; n++) {
+            for (uint64_t n = 0; n < n_counts; n++) {
                 infile.read((char *) &kmer, sizeof(kmer));
                 infile.read((char *) &count, sizeof(count));
                 ht._bigcounts[kmer] = count;
@@ -530,7 +530,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
 
     ht._counts = new Byte*[ht._n_tables];
     for (unsigned int i = 0; i < ht._n_tables; i++) {
-        HashIntoType tablesize;
+        uint64_t tablesize;
 
         read_b = gzread(infile, (char *) &save_tablesize,
                         sizeof(save_tablesize));
@@ -548,12 +548,12 @@ CountingHashGzFileReader::CountingHashGzFileReader(
             throw khmer_file_exception(err);
         }
 
-        tablesize = (HashIntoType) save_tablesize;
+        tablesize = save_tablesize;
         ht._tablesizes.push_back(tablesize);
 
         ht._counts[i] = new Byte[tablesize];
 
-        HashIntoType loaded = 0;
+        uint64_t loaded = 0;
         while (loaded != tablesize) {
             unsigned long long  to_read_ll = tablesize - loaded;
             unsigned int        to_read_int;
@@ -581,7 +581,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
         }
     }
 
-    HashIntoType n_counts = 0;
+    uint64_t n_counts = 0;
     read_b = gzread(infile, (char *) &n_counts, sizeof(n_counts));
     if (read_b <= 0) {
         std::string gzerr = gzerror(infile, &read_b);
@@ -601,7 +601,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
         HashIntoType kmer;
         BoundedCounterType count;
 
-        for (HashIntoType n = 0; n < n_counts; n++) {
+        for (uint64_t n = 0; n < n_counts; n++) {
             int read_k = gzread(infile, (char *) &kmer, sizeof(kmer));
             int read_c = gzread(infile, (char *) &count, sizeof(count));
 
@@ -664,7 +664,7 @@ CountingHashFileWriter::CountingHashFileWriter(
         outfile.write((const char *) ht._counts[i], save_tablesize);
     }
 
-    HashIntoType n_counts = ht._bigcounts.size();
+    uint64_t n_counts = ht._bigcounts.size();
     outfile.write((const char *) &n_counts, sizeof(n_counts));
 
     if (n_counts) {
@@ -765,7 +765,7 @@ CountingHashGzFileWriter::CountingHashGzFileWriter(
         }
     }
 
-    HashIntoType n_counts = ht._bigcounts.size();
+    uint64_t n_counts = ht._bigcounts.size();
     gzwrite(outfile, (const char *) &n_counts, sizeof(n_counts));
 
     if (n_counts) {

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -83,10 +83,10 @@ class CountingHash : public khmer::Hashtable
 protected:
     bool _use_bigcount;		// keep track of counts > Bloom filter hash count threshold?
     uint32_t _bigcount_spin_lock;
-    std::vector<HashIntoType> _tablesizes;
+    std::vector<uint64_t> _tablesizes;
     size_t _n_tables;
-    HashIntoType _n_unique_kmers;
-    HashIntoType _occupied_bins;
+    uint64_t _n_unique_kmers;
+    uint64_t _occupied_bins;
 
     Byte ** _counts;
 
@@ -103,7 +103,7 @@ protected:
 public:
     KmerCountMap _bigcounts;
 
-    CountingHash( WordLength ksize, HashIntoType single_tablesize ) :
+    CountingHash( WordLength ksize, uint64_t single_tablesize ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
         _bigcount_spin_lock(false), _n_unique_kmers(0), _occupied_bins(0)
     {
@@ -112,7 +112,7 @@ public:
         _allocate_counters();
     }
 
-    CountingHash( WordLength ksize, std::vector<HashIntoType>& tablesizes ) :
+    CountingHash( WordLength ksize, std::vector<uint64_t>& tablesizes ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
         _bigcount_spin_lock(false), _tablesizes(tablesizes),
         _n_unique_kmers(0), _occupied_bins(0)
@@ -159,12 +159,12 @@ public:
         return !x;
     }
 
-    std::vector<HashIntoType> get_tablesizes() const
+    std::vector<uint64_t> get_tablesizes() const
     {
         return _tablesizes;
     }
 
-    virtual const HashIntoType n_unique_kmers() const
+    virtual const uint64_t n_unique_kmers() const
     {
         return _n_unique_kmers;
     }
@@ -187,7 +187,7 @@ public:
     }
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const
+    virtual const uint64_t n_occupied() const
     {
         return _occupied_bins;
     }
@@ -204,7 +204,7 @@ public:
         unsigned int  n_full	  = 0;
 
         for (unsigned int i = 0; i < _n_tables; i++) {
-            const HashIntoType bin = khash % _tablesizes[i];
+            const uint64_t bin = khash % _tablesizes[i];
             Byte current_count = _counts[ i ][ bin ];
             if (!is_new_kmer) {
                 if (current_count == 0) {
@@ -288,9 +288,9 @@ public:
 
     BoundedCounterType get_max_count(const std::string &s);
 
-    HashIntoType * abundance_distribution(read_parsers::IParser * parser,
+    uint64_t * abundance_distribution(read_parsers::IParser * parser,
                                           Hashbits * tracking);
-    HashIntoType * abundance_distribution(std::string filename,
+    uint64_t * abundance_distribution(std::string filename,
                                           Hashbits * tracking);
 
     unsigned long trim_on_abundance(std::string seq,

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -163,12 +163,12 @@ void Hashbits::load(std::string infilename)
 
         _counts = new Byte*[_n_tables];
         for (unsigned int i = 0; i < _n_tables; i++) {
-            HashIntoType tablesize;
+            uint64_t tablesize;
             unsigned long long tablebytes;
 
             infile.read((char *) &save_tablesize, sizeof(save_tablesize));
 
-            tablesize = (HashIntoType) save_tablesize;
+            tablesize = save_tablesize;
             _tablesizes.push_back(tablesize);
 
             tablebytes = tablesize / 8 + 1;
@@ -204,10 +204,10 @@ void Hashbits::update_from(const Hashbits &other)
     for (unsigned int table_num = 0; table_num < _n_tables; table_num++) {
         Byte * me = _counts[table_num];
         Byte * ot = other._counts[table_num];
-        HashIntoType tablesize = _tablesizes[table_num];
-        HashIntoType tablebytes = tablesize / 8 + 1;
+        uint64_t tablesize = _tablesizes[table_num];
+        uint64_t tablebytes = tablesize / 8 + 1;
 
-        for (HashIntoType index = 0; index < tablebytes; index++) {
+        for (uint64_t index = 0; index < tablebytes; index++) {
             // Bloom filters can be unioned with bitwise OR.
             // First, get the new value
             tmp = me[index] | ot[index];

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -55,10 +55,10 @@ class LabelHash;
 class Hashbits : public khmer::Hashtable
 {
 protected:
-    std::vector<HashIntoType> _tablesizes;
+    std::vector<uint64_t> _tablesizes;
     size_t _n_tables;
-    HashIntoType _occupied_bins;
-    HashIntoType _n_unique_kmers;
+    uint64_t _occupied_bins;
+    uint64_t _n_unique_kmers;
     Byte ** _counts;
 
     virtual void _allocate_counters()
@@ -68,8 +68,8 @@ protected:
         _counts = new Byte*[_n_tables];
 
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType tablesize = _tablesizes[i];
-            HashIntoType tablebytes = tablesize / 8 + 1;
+            uint64_t tablesize = _tablesizes[i];
+            uint64_t tablebytes = tablesize / 8 + 1;
 
             _counts[i] = new Byte[tablebytes];
             memset(_counts[i], 0, tablebytes);
@@ -77,7 +77,7 @@ protected:
     }
 
 public:
-    Hashbits(WordLength ksize, std::vector<HashIntoType>& tablesizes)
+    Hashbits(WordLength ksize, std::vector<uint64_t>& tablesizes)
         : khmer::Hashtable(ksize),
           _tablesizes(tablesizes)
     {
@@ -103,7 +103,7 @@ public:
     }
 
     // Accessors for protected/private table info members
-    std::vector<HashIntoType> get_tablesizes() const
+    std::vector<uint64_t> get_tablesizes() const
     {
         return _tablesizes;
     }
@@ -117,12 +117,12 @@ public:
     virtual void load(std::string);
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const
+    virtual const uint64_t n_occupied() const
     {
         return _occupied_bins;
     }
 
-    virtual const HashIntoType n_unique_kmers() const
+    virtual const uint64_t n_unique_kmers() const
     {
         return _n_unique_kmers;
     }
@@ -150,8 +150,8 @@ public:
         bool is_new_kmer = false;
 
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType bin = khash % _tablesizes[i];
-            HashIntoType byte = bin / 8;
+            uint64_t bin = khash % _tablesizes[i];
+            uint64_t byte = bin / 8;
             unsigned char bit = (unsigned char)(1 << (bin % 8));
 
             unsigned char bits_orig = __sync_fetch_and_or( *(_counts + i) +
@@ -194,8 +194,8 @@ public:
     virtual const BoundedCounterType get_count(HashIntoType khash) const
     {
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType bin = khash % _tablesizes[i];
-            HashIntoType byte = bin / 8;
+            uint64_t bin = khash % _tablesizes[i];
+            uint64_t byte = bin / 8;
             unsigned char bit = bin % 8;
 
             if (!(_counts[i][byte] & (1 << bit))) {

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -163,7 +163,6 @@ unsigned int Hashtable::consume_string(const std::string &s)
 
     while(!kmers.done()) {
         HashIntoType kmer = kmers.next();
-
         count(kmer);
         n_consumed++;
     }
@@ -1080,4 +1079,3 @@ const
 }
 
 // vim: set sts=2 sw=2:
-

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -123,11 +123,13 @@ protected:
 
     void _init_bitstuff()
     {
-        bitmask = 0;
+      #if 1
+        //bitmask = 0;
         for (unsigned int i = 0; i < _ksize; i++) {
             bitmask = (bitmask << 2) | 3;
         }
         _nbits_sub_1 = (_ksize*2 - 2);
+        #endif
     }
 
     void _clear_all_partitions()
@@ -200,10 +202,10 @@ public:
                           float &stddev);
 
     // number of unique k-mers
-    virtual const HashIntoType n_unique_kmers() const = 0;
+    virtual const uint64_t n_unique_kmers() const = 0;
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const = 0;
+    virtual const uint64_t n_occupied() const = 0;
 
     // partitioning stuff
     void _validate_pmap()
@@ -287,7 +289,7 @@ public:
     virtual BoundedCounterType test_and_set_bits(const char * kmer) = 0;
     virtual BoundedCounterType test_and_set_bits(HashIntoType khash) = 0;
 
-    virtual std::vector<HashIntoType> get_tablesizes() const = 0;
+    virtual std::vector<uint64_t> get_tablesizes() const = 0;
     virtual const size_t n_tables() const = 0;
 
     size_t trim_on_stoptags(std::string sequence) const;

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -259,7 +259,7 @@ double ep_sum(double acc, int b)
 
 int get_rho(HashIntoType w, int max_width)
 {
-    return max_width - floor(log2(w));
+    return max_width - floor(log2(w.as_ull()));
 }
 
 HLLCounter::HLLCounter(double error_rate, WordLength ksize)
@@ -332,7 +332,7 @@ double HLLCounter::_Ep()
     return E;
 }
 
-HashIntoType HLLCounter::estimate_cardinality()
+uint64_t HLLCounter::estimate_cardinality()
 {
     long V = count(this->M.begin(), this->M.end(), 0);
 
@@ -348,7 +348,7 @@ HashIntoType HLLCounter::estimate_cardinality()
 void HLLCounter::add(const std::string &value)
 {
     HashIntoType x = khmer::_hash_murmur(value);
-    HashIntoType j = x & (this->m - 1);
+    uint64_t j = x.as_ull() & (this->m - 1);
     this->M[j] = std::max(this->M[j], get_rho(x >> this->p, 64 - this->p));
 }
 

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -75,7 +75,7 @@ public:
     unsigned int check_and_process_read(std::string &,
                                         bool &);
     bool check_and_normalize_read(std::string &) const;
-    HashIntoType estimate_cardinality();
+    uint64_t estimate_cardinality();
     void merge(HLLCounter &);
     virtual ~HLLCounter() {}
 

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,6 +99,7 @@ private:\
 
 namespace khmer
 {
+class HashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,13 +99,14 @@ private:\
 
 namespace khmer
 {
-class HashType;
+class BigHashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 typedef unsigned long long int HashIntoType;
-const unsigned char KSIZE_MAX = sizeof(HashIntoType)*4;
+//typedef BigHashType HashIntoType;
+const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,13 +99,13 @@ private:\
 
 namespace khmer
 {
-class BigHashType;
+template <typename T=uint8_t, std::size_t N=8> class BigHashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
-typedef unsigned long long int HashIntoType;
-//typedef BigHashType HashIntoType;
+//typedef unsigned long long int HashIntoType;
+typedef BigHashType<> HashIntoType;
 const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,13 +99,13 @@ private:\
 
 namespace khmer
 {
-template <typename T=uint8_t, std::size_t N=8> class BigHashType;
+class BigHashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 //typedef unsigned long long int HashIntoType;
-typedef BigHashType<> HashIntoType;
+typedef BigHashType HashIntoType;
 const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashType h, r;
+    BigHashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
@@ -80,7 +80,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
     _h = h.as_ull();
     _r = r.as_ull();
 
-    return uniqify_rc(h.as_ull(), r.as_ull());
+    return uniqify_rc(h, r).as_ull();
 }
 
 // _hash: return the maximum of the forward and reverse hash.

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -40,6 +40,7 @@ Contact: khmer-project@idyll.org
 #include <string.h>
 #include <algorithm>
 #include <string>
+#include <iostream>
 
 #include "MurmurHash3.h"
 #include "khmer.hh"
@@ -64,9 +65,14 @@ HashIntoType _hash(const char * kmer, const WordLength k,
     }
 
     HashIntoType h = 0, r = 0;
+    HashType hh;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
+
+    hh |= twobit_repr(kmer[0]);
+    HashIntoType xx(hh.as_ull());
+    std::cout << "h: " << h << " hh: " << xx <<std::endl;
 
     for (WordLength i = 1, j = k - 2; i < k; i++, j--) {
         h = h << 2;

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,15 +64,10 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashIntoType h = 0, r = 0;
-    HashType hh;
+    HashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
-
-    hh |= twobit_repr(kmer[0]);
-    HashIntoType xx(hh.as_ull());
-    std::cout << "h: " << h << " hh: " << xx <<std::endl;
 
     for (WordLength i = 1, j = k - 2; i < k; i++, j--) {
         h = h << 2;
@@ -82,10 +77,10 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         r |= twobit_comp(kmer[j]);
     }
 
-    _h = h;
-    _r = r;
+    _h = h.as_ull();
+    _r = r.as_ull();
 
-    return uniqify_rc(h, r);
+    return uniqify_rc(h.as_ull(), r.as_ull());
 }
 
 // _hash: return the maximum of the forward and reverse hash.

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    BigHashType<> h, r;
+    BigHashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -179,7 +179,7 @@ HashIntoType _hash_murmur(const std::string& kmer)
 HashIntoType _hash_murmur(const std::string& kmer,
                           HashIntoType& h, HashIntoType& r)
 {
-    HashIntoType out[2];
+    uint64_t out[2];
     uint32_t seed = 0;
     MurmurHash3_x64_128((void *)kmer.c_str(), kmer.size(), seed, &out);
     h = out[0];

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    BigHashType h, r;
+    BigHashType<> h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
@@ -77,18 +77,18 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         r |= twobit_comp(kmer[j]);
     }
 
-    _h = h.as_ull();
-    _r = r.as_ull();
+    _h = h;
+    _r = r;
 
-    return uniqify_rc(h, r).as_ull();
+    return uniqify_rc(h, r);
 }
 
 // _hash: return the maximum of the forward and reverse hash.
 
 HashIntoType _hash(const char * kmer, const WordLength k)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     return khmer::_hash(kmer, k, h, r);
 }
@@ -97,8 +97,8 @@ HashIntoType _hash(const char * kmer, const WordLength k)
 
 HashIntoType _hash_forward(const char * kmer, WordLength k)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
 
     khmer::_hash(kmer, k, h, r);
@@ -170,8 +170,8 @@ std::string _revcomp(const std::string& kmer)
 
 HashIntoType _hash_murmur(const std::string& kmer)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     return khmer::_hash_murmur(kmer, h, r);
 }
@@ -193,8 +193,8 @@ HashIntoType _hash_murmur(const std::string& kmer,
 
 HashIntoType _hash_murmur_forward(const std::string& kmer)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     khmer::_hash_murmur(kmer, h, r);
     return h;
@@ -204,7 +204,6 @@ KmerIterator::KmerIterator(const char * seq,
                            unsigned char k) :
     KmerFactory(k), _seq(seq)
 {
-    bitmask = 0;
     for (unsigned char i = 0; i < _ksize; i++) {
         bitmask = (bitmask << 2) | 3;
     }
@@ -212,8 +211,6 @@ KmerIterator::KmerIterator(const char * seq,
 
     index = _ksize - 1;
     length = strlen(_seq);
-    _kmer_f = 0;
-    _kmer_r = 0;
 
     initialized = false;
 }

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -38,6 +38,8 @@ Contact: khmer-project@idyll.org
 #ifndef KMER_HASH_HH
 #define KMER_HASH_HH
 
+#include <array>
+#include <iostream>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -112,6 +114,71 @@ HashIntoType _hash_murmur(const std::string& kmer);
 HashIntoType _hash_murmur(const std::string& kmer,
                           HashIntoType& h, HashIntoType& r);
 HashIntoType _hash_murmur_forward(const std::string& kmer);
+
+
+class HashType
+{
+	std::array<unsigned char, 8> bytes { {0, 0, 0, 0, 0, 0, 0, 0 } };
+public:
+	HashType() : bytes{{0, 0, 0, 0, 0, 0, 0, 0 }} {};
+	HashType(std::array<unsigned char, 8> const& bytes_) : bytes(bytes_) {};
+
+	unsigned long long int as_ull() {
+		unsigned long long int x(0);
+		for (int i = 0; i < 8; i++) {
+			x += pow(256, 8 - i - 1) * bytes[i];
+		}
+		return x;
+	}
+
+	HashType operator>>(int shift) {
+		HashType shifted;
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (int i = 0; i < 8; i++){
+				next_ = (bytes[i] & 1) ? 0x80 : 0;
+				shifted.bytes[i] = carry | (bytes[i] >> 1);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	HashType operator<<(int shift) {
+		HashType shifted;
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (int i = 8 - 1; i >= 0; i--){
+				next_ = (bytes[i] & 128) ? 1 : 0;
+				shifted.bytes[i] = carry | ((bytes[i] << 1) & 255);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	HashType operator<<=(int rhs){
+		*this = *this << rhs;
+		return *this;
+	}
+
+	HashType operator>>=(int rhs){
+		*this = *this >> rhs;
+		return *this;
+	}
+
+	HashType operator|(int rhs) {
+		bytes[7] |= rhs;
+		return *this;
+	}
+
+	HashType operator|=(int rhs){
+		*this = *this | rhs;
+		return *this;
+	}
+};
 
 /**
  * \class Kmer

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -132,13 +132,13 @@ public:
 	}
 
 	HashType operator>>(int shift) {
-		HashType shifted;
+		HashType shifted(bytes);
 		int next_(0);
 		for (int s = 0; s < shift; s++) {
 			int carry(0);
 			for (int i = 0; i < 8; i++){
-				next_ = (bytes[i] & 1) ? 0x80 : 0;
-				shifted.bytes[i] = carry | (bytes[i] >> 1);
+				next_ = (shifted.bytes[i] & 1) ? 0x80 : 0;
+				shifted.bytes[i] = carry | (shifted.bytes[i] >> 1);
 				carry = next_;
 			}
 		}
@@ -146,13 +146,13 @@ public:
 	}
 
 	HashType operator<<(int shift) {
-		HashType shifted;
+		HashType shifted(bytes);
 		int next_(0);
 		for (int s = 0; s < shift; s++) {
 			int carry(0);
 			for (int i = 8 - 1; i >= 0; i--){
-				next_ = (bytes[i] & 128) ? 1 : 0;
-				shifted.bytes[i] = carry | ((bytes[i] << 1) & 255);
+				next_ = (shifted.bytes[i] & 128) ? 1 : 0;
+				shifted.bytes[i] = carry | ((shifted.bytes[i] << 1) & 255);
 				carry = next_;
 			}
 		}

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -122,7 +122,7 @@ class BigHashType
 {
 public:
 	std::array<T, N> bytes;
-	BigHashType() {};
+	BigHashType() : bytes{{0}} {};
 	BigHashType(const std::array<T, N>& bytes_) : bytes(bytes_) {};
 
 	uint64_t as_ull() {

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -124,6 +124,11 @@ public:
 	std::array<T, N> bytes;
 	BigHashType() : bytes{{0}} {};
 	BigHashType(const std::array<T, N>& bytes_) : bytes(bytes_) {};
+	BigHashType(const uint64_t value) {
+		for (int i = 0; i < 8; i++) {
+			bytes[8 - 1 - i] = (value >> (i * 8));
+		}
+	}
 
 	uint64_t as_ull() {
 		uint64_t x(0);
@@ -131,6 +136,13 @@ public:
 			x+= ((uint64_t)bytes[i])<<((8-i-1)*8);
 		}
 		return x;
+	}
+
+	BigHashType& operator=(const uint64_t value) {
+		for (int i = 0; i < 8; i++) {
+			bytes[8 - 1 - i] = (value >> (i * 8));
+		}
+		return *this;
 	}
 
 	BigHashType operator>>(int shift) {
@@ -161,12 +173,12 @@ public:
 		return shifted;
 	}
 
-	BigHashType operator<<=(int rhs){
+	BigHashType& operator<<=(int rhs){
 		*this = *this << rhs;
 		return *this;
 	}
 
-	BigHashType operator>>=(int rhs){
+	BigHashType& operator>>=(int rhs){
 		*this = *this >> rhs;
 		return *this;
 	}
@@ -185,12 +197,12 @@ public:
 		return n;
 	}
 
-	BigHashType operator|=(T rhs){
+	BigHashType& operator|=(T rhs){
 		bytes[N - 1] |= rhs;
 		return *this;
 	}
 
-	BigHashType operator&=(const BigHashType& rhs) {
+	BigHashType& operator&=(const BigHashType& rhs) {
 		for (unsigned int i = 0; i < N; i++) {
 			bytes[i] &= rhs.bytes[i];
 		}

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -117,22 +117,23 @@ HashIntoType _hash_murmur(const std::string& kmer,
 HashIntoType _hash_murmur_forward(const std::string& kmer);
 
 
-template <typename T, std::size_t N>
+//template <typename T, std::size_t N>
 class BigHashType
 {
 public:
-	std::array<T, N> bytes;
-	BigHashType() : bytes{{0}} {};
-	BigHashType(const std::array<T, N>& bytes_) : bytes(bytes_) {};
-	BigHashType(const uint64_t value) {
-		for (int i = 0; i < 8; i++) {
+	std::size_t N;
+	std::array<uint8_t, 8> bytes;
+	BigHashType() : N(8), bytes{{0}} {};
+	BigHashType(const std::array<uint8_t, 8>& bytes_) : N(8), bytes(bytes_) {};
+	BigHashType(const uint64_t value) : N(8) {
+		for (std::size_t i = 0; i < 8; i++) {
 			bytes[8 - 1 - i] = (value >> (i * 8));
 		}
 	}
 
-	uint64_t as_ull() {
+	uint64_t as_ull() const {
 		uint64_t x(0);
-		for (int i = 0; i < 8; i++) {
+		for (std::size_t i = 0; i < N; i++) {
 			x+= ((uint64_t)bytes[i])<<((8-i-1)*8);
 		}
 		return x;
@@ -191,14 +192,20 @@ public:
 		return tmp;
 	}
 
-	BigHashType operator|(T rhs) {
-		BigHashType<T, N> n(bytes);
-		n.bytes[N - 1] |= rhs;
+	BigHashType operator|(uint64_t rhs) {
+		BigHashType n(bytes);
+		BigHashType rhs_(rhs);
+		for (unsigned int i = 0; i < N; i++) {
+			n.bytes[i] = bytes[i] | rhs_.bytes[i];
+		}
 		return n;
 	}
 
-	BigHashType& operator|=(T rhs){
-		bytes[N - 1] |= rhs;
+	BigHashType& operator|=(uint64_t rhs) {
+		BigHashType rhs_(rhs);
+		for (unsigned int i = 0; i < N; i++) {
+			bytes[i] |= rhs_.bytes[i];
+		}
 		return *this;
 	}
 
@@ -217,7 +224,7 @@ public:
 		return tmp;
 	}
 
-	T operator&(T rhs) {
+	uint8_t operator&(uint8_t rhs) {
 		return bytes[N - 1] & rhs;
 	}
 

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -127,21 +127,23 @@ public:
 	BigHashType(const std::array<uint8_t, 8>& bytes_) : N(8), bytes(bytes_) {};
 	BigHashType(const uint64_t value) : N(8) {
 		for (std::size_t i = 0; i < 8; i++) {
-			bytes[8 - 1 - i] = (value >> (i * 8));
+			bytes[N - 1 - i] = (value >> (i * 8));
 		}
 	}
 
 	uint64_t as_ull() const {
 		uint64_t x(0);
-		for (std::size_t i = 0; i < N; i++) {
-			x+= ((uint64_t)bytes[i])<<((8-i-1)*8);
+		int offset(N-8);
+		for (std::size_t i = offset; i < N; i++) {
+			x+= ((uint64_t)bytes[i])<<((N-i-1)*8);
 		}
 		return x;
 	}
 
 	BigHashType& operator=(const uint64_t value) {
-		for (int i = 0; i < 8; i++) {
-			bytes[8 - 1 - i] = (value >> (i * 8));
+		unsigned int offset(N-8);
+		for (unsigned int i = 0; i < N - offset; i++) {
+			bytes[N - 1 - i] = (value >> (i * 8));
 		}
 		return *this;
 	}
@@ -195,6 +197,7 @@ public:
 	BigHashType operator|(uint64_t rhs) {
 		BigHashType n(bytes);
 		BigHashType rhs_(rhs);
+
 		for (unsigned int i = 0; i < N; i++) {
 			n.bytes[i] = bytes[i] | rhs_.bytes[i];
 		}
@@ -202,10 +205,21 @@ public:
 	}
 
 	BigHashType& operator|=(uint64_t rhs) {
+		// The RHS only has the last 8 bytes set
+		unsigned int offset(N - 8);
 		BigHashType rhs_(rhs);
-		for (unsigned int i = 0; i < N; i++) {
+		//std::copy(bytes.begin(), bytes.end(),
+		//					std::ostream_iterator<uint64_t>(std::cout, " "));
+		//std::cout << std::endl;
+		//std::copy(rhs_.bytes.begin(), rhs_.bytes.end(),
+		//					std::ostream_iterator<uint64_t>(std::cout, " "));
+		//std::cout << std::endl;
+		for (unsigned int i = offset; i < N; i++) {
 			bytes[i] |= rhs_.bytes[i];
 		}
+		//std::copy(bytes.begin(), bytes.end(),
+		//					std::ostream_iterator<uint64_t>(std::cout, " "));
+		//std::cout << std::endl;
 		return *this;
 	}
 

--- a/lib/read_aligner.cc
+++ b/lib/read_aligner.cc
@@ -531,7 +531,7 @@ Alignment* ReadAligner::Align(const std::string& read)
         return _empty_alignment();
     }
 
-    HashIntoType fhash = 0, rhash = 0;
+    HashIntoType fhash, rhash;
     _hash(start.kmer, k, fhash, rhash);
 
 #if READ_ALIGNER_DEBUG
@@ -609,7 +609,7 @@ Alignment* ReadAligner::AlignForward(const std::string& read)
         return _empty_alignment();
     }
 
-    HashIntoType fhash = 0, rhash = 0;
+    HashIntoType fhash, rhash;
     _hash(start.kmer, k, fhash, rhash);
 
 #if READ_ALIGNER_DEBUG

--- a/lib/read_aligner.hh
+++ b/lib/read_aligner.hh
@@ -234,7 +234,7 @@ private:
 
     HashIntoType comp_bitmask(WordLength k)
     {
-        HashIntoType ret = 0;
+        HashIntoType ret;
         for (size_t i = 0; i < k; i++) {
             ret = (ret << 2) | 3;
         }

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -132,7 +132,7 @@ size_t SubsetPartition::output_partitioned_file(
     Read read;
     string seq;
 
-    HashIntoType kmer = 0;
+    HashIntoType kmer;
 
     const unsigned int ksize = _ht->ksize();
 
@@ -515,17 +515,18 @@ void SubsetPartition::do_partition(
     CallbackFn		callback,
     void *		callback_data)
 {
+    HashIntoType empty;
     unsigned int total_reads = 0;
 
     SeenSet tagged_kmers;
     SeenSet::const_iterator si, end;
 
-    if (first_kmer) {
+    if (first_kmer != empty) {
         si = _ht->all_tags.find(first_kmer);
     } else {
         si = _ht->all_tags.begin();
     }
-    if (last_kmer) {
+    if (last_kmer != empty) {
         end = _ht->all_tags.find(last_kmer);
     } else {
         end = _ht->all_tags.end();
@@ -546,7 +547,7 @@ void SubsetPartition::do_partition(
 
         // run callback, if specified
         if (total_reads % CALLBACK_PERIOD == 0 && callback) {
-            cout << "...subset-part " << first_kmer << "-" << last_kmer << ": "
+            cout << "...subset-part " << first_kmer.as_ull() << "-" << last_kmer.as_ull() << ": "
                  << total_reads << " <- " << next_partition_id << "\n";
 #if 0 // @CTB
             try {
@@ -574,16 +575,17 @@ void SubsetPartition::do_partition_with_abundance(
     void *		callback_data)
 {
     unsigned int total_reads = 0;
+    HashIntoType empty;
 
     SeenSet tagged_kmers;
     SeenSet::const_iterator si, end;
 
-    if (first_kmer) {
+    if (first_kmer != empty) {
         si = _ht->all_tags.find(first_kmer);
     } else {
         si = _ht->all_tags.begin();
     }
-    if (last_kmer) {
+    if (last_kmer != empty) {
         end = _ht->all_tags.find(last_kmer);
     } else {
         end = _ht->all_tags.end();
@@ -606,7 +608,7 @@ void SubsetPartition::do_partition_with_abundance(
 
         // run callback, if specified
         if (total_reads % CALLBACK_PERIOD == 0 && callback) {
-            cout << "...subset-part " << first_kmer << "-" << last_kmer << ": "
+            cout << "...subset-part " << first_kmer.as_ull() << "-" << last_kmer.as_ull() << ": "
                  << total_reads << " <- " << next_partition_id << "\n";
 #if 0 // @CTB
             try {

--- a/lib/traversal.cc
+++ b/lib/traversal.cc
@@ -43,7 +43,7 @@ using namespace std;
 Traverser::Traverser(const Hashtable * ht) :
     KmerFactory(ht->ksize()), graph(ht)
 {
-    bitmask = 0;
+    bitmask;
     for (unsigned int i = 0; i < _ksize; i++) {
         bitmask = (bitmask << 2) | 3;
     }

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -56,6 +56,9 @@ def test_forward_hash():
     assert khmer.forward_hash('CCCC', 4) == 170
     assert khmer.forward_hash('GGGG', 4) == 170
 
+    h = 13607885392109549066
+    assert khmer.forward_hash('GGTTGACGGGGCTCAGGGGGCGGCTGACTCCG', 32) == h
+
 
 def test_get_file_writer_fail():
     somefile = utils.get_temp_filename("potato")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -40,6 +40,7 @@ import khmer
 import os
 import sys
 import collections
+import pytest
 from . import khmer_tst_utils as utils
 from khmer.utils import (check_is_pair, broken_paired_reader, check_is_left,
                          check_is_right)
@@ -99,6 +100,13 @@ def test_reverse_hash():
 
     s = khmer.reverse_hash(255, 4)
     assert s == "GGGG"
+
+
+def test_reverse_hash_raises():
+    with pytest.raises(ValueError) as excinfo:
+        s = khmer.reverse_hash('2345', 4)
+
+    assert 'must be an integer' in str(excinfo.value)
 
 
 def test_hash_murmur3():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -102,6 +102,26 @@ def test_reverse_hash():
     assert s == "GGGG"
 
 
+def test_reverse_hash_longs():
+    # test explicitly with long integers, only needed for python2
+    # the builtin `long` exists in the global scope
+    global long
+    if sys.version_info > (3,):
+        long = int
+
+    s = khmer.reverse_hash(long(0), 4)
+    assert s == "AAAA"
+
+    s = khmer.reverse_hash(long(85), 4)
+    assert s == "TTTT"
+
+    s = khmer.reverse_hash(long(170), 4)
+    assert s == "CCCC"
+
+    s = khmer.reverse_hash(long(255), 4)
+    assert s == "GGGG"
+
+
 def test_reverse_hash_raises():
     with pytest.raises(ValueError) as excinfo:
         s = khmer.reverse_hash('2345', 4)


### PR DESCRIPTION
Exploratory surgery for #1442 

This uses a byte array to store the hash value. We can template or similar to support "arbitrarily" large hash values.

At the moment trying to make it work and get some tests to pass. After that speeding up the code. it currently also contains various stuff that is useful for development but you might want to remove later.
- [ ] benchmark `bits` vs `bytes` vs `uint64` as type of the array
- [ ] clean up spurious `#include`s
- [ ] asserts or other protection when users try and `|` or `&` values larger than one byte
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?
