### PR TITLE
A fix for a bug with require_paired & min_length in broken_paired_reader

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-09-20  Titus Brown  <titus@idyll.org>
+
+   * khmer/utils.py: fixed bug in broken_paired_reader when short reads
+   are discarded and require_paired is set; improved read pair error reporting.
+   * tests/test_functions.py: added tests for broken_paired_reader fix.
+   * tests/khmer_tst_utils.py: de-nested exceptions for better error reporting
+   from tests.
+
 2016-09-09  Daniel Standage  <daniel.standage@gmail.com>
 
    * lib/read_parsers.{cc,hh}: rename SeqAnParser to FastxParser.

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -1,6 +1,6 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -144,7 +144,7 @@ class UnpairedReadsError(ValueError):
         if r2:
             r2_name = r2.name
 
-        msg = msg + '\n"%s"\n"%s"' % (r1_name, r2_name)
+        msg = msg + '\n"{0}"\n"{1}"'.format(r1_name, r2_name)
         ValueError.__init__(self, msg)
         self.read1 = r1
         self.read2 = r2

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -137,6 +137,14 @@ class UnpairedReadsError(ValueError):
     """ValueError with refs to the read pair in question."""
 
     def __init__(self, msg, r1, r2):
+        r1_name = "<no read>"
+        r2_name = "<no read>"
+        if r1:
+            r1_name = r1.name
+        if r2:
+            r2_name = r2.name
+
+        msg = msg + '\n"%s"\n"%s"' % (r1_name, r2_name)
         ValueError.__init__(self, msg)
         self.read1 = r1
         self.read2 = r2
@@ -176,24 +184,30 @@ def broken_paired_reader(screed_iter, min_length=None,
 
     # handle the majority of the stream.
     for record in screed_iter:
-        # ignore short reads
-        if min_length and len(record.sequence) < min_length:
-            record = None
-            continue
 
         if prev_record:
             if check_is_pair(prev_record, record) and not force_single:
-                yield num, True, prev_record, record  # it's a pair!
-                num += 2
-                record = None
+                if min_length and (len(prev_record.sequence) < min_length or
+                                   len(record.sequence) < min_length):
+                    if require_paired:
+                        record = None
+                else:
+                    yield num, True, prev_record, record  # it's a pair!
+                    num += 2
+                    record = None
             else:                                   # orphan.
                 if require_paired:
                     err = UnpairedReadsError(
                         "Unpaired reads when require_paired is set!",
                         prev_record, record)
                     raise err
-                yield num, False, prev_record, None
-                num += 1
+
+                # ignore short reads
+                if min_length and len(prev_record.sequence) < min_length:
+                    pass
+                else:
+                    yield num, False, prev_record, None
+                    num += 1
 
         prev_record = record
         record = None
@@ -203,7 +217,10 @@ def broken_paired_reader(screed_iter, min_length=None,
         if require_paired:
             raise UnpairedReadsError("Unpaired reads when require_paired "
                                      "is set!", prev_record, None)
-        yield num, False, prev_record, None
+        if min_length and len(prev_record.sequence) < min_length:
+            pass
+        else:
+            yield num, False, prev_record, None
 
 
 def write_record(record, fileobj):

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -120,20 +120,22 @@ def _runscript(scriptname, sandbox=False):
             scriptname, namespace)
         return 0
     except pkg_resources.ResolutionError:
-        if sandbox:
-            path = os.path.join(os.path.dirname(__file__), "../sandbox")
-        else:
-            path = scriptpath()
+        pass
 
-        scriptfile = os.path.join(path, scriptname)
+    if sandbox:
+        path = os.path.join(os.path.dirname(__file__), "../sandbox")
+    else:
+        path = scriptpath()
+
+    scriptfile = os.path.join(path, scriptname)
+    if os.path.isfile(scriptfile):
         if os.path.isfile(scriptfile):
-            if os.path.isfile(scriptfile):
-                exec(  # pylint: disable=exec-used
-                    compile(open(scriptfile).read(), scriptfile, 'exec'),
-                    namespace)
-                return 0
-        elif sandbox:
-            pytest.skip("sandbox tests are only run in a repository.")
+            exec(# pylint: disable=exec-used
+                 compile(open(scriptfile).read(), scriptfile, 'exec'),
+                 namespace)
+            return 0
+    elif sandbox:
+        pytest.skip("sandbox tests are only run in a repository.")
 
     return -1
 

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -130,7 +130,7 @@ def _runscript(scriptname, sandbox=False):
     scriptfile = os.path.join(path, scriptname)
     if os.path.isfile(scriptfile):
         if os.path.isfile(scriptfile):
-            exec(# pylint: disable=exec-used
+            exec(  # pylint: disable=exec-used
                  compile(open(scriptfile).read(), scriptfile, 'exec'),
                  namespace)
             return 0

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,6 +1,6 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2010-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -352,6 +352,7 @@ def gather(stream, **kw):
 
     return x, num, m
 
+
 class Test_BrokenPairedReader(object):
     stream = [FakeFastaRead(name='seq1/1', sequence='A' * 5),
               FakeFastaRead(name='seq1/2', sequence='A' * 4),
@@ -455,7 +456,7 @@ def test_BrokenPairedReader_OnPairs_3():
 
 
 def test_BrokenPairedReader_OnPairs_4():
-    stream = [FakeFastaRead(name='seq1/1', sequence='A' * 3), # too short
+    stream = [FakeFastaRead(name='seq1/1', sequence='A' * 3),  # too short
               FakeFastaRead(name='seq1/2', sequence='A' * 4),
               FakeFastaRead(name='seq3/1', sequence='A' * 4),
               FakeFastaRead(name='seq3/2', sequence='A' * 5)]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -389,14 +389,6 @@ class Test_BrokenPairedReader(object):
         assert m == 3
         assert n == 3, n
 
-    def testMinLength_with_paired(self):
-        x, n, m = self.gather(min_length=4, require_paired=True)
-
-        expected = [('seq1/1', 'seq1/2')]
-        assert x == expected, x
-        assert m == 3
-        assert n == 3, n
-
     def testForceSingle(self):
         x, n, m = self.gather(force_single=True)
 
@@ -418,3 +410,44 @@ class Test_BrokenPairedReader(object):
         assert x == expected, x
         assert m == 3, m
         assert n == 2, n
+
+
+class Test_BrokenPairedReader_OnPairs(object):
+    stream = [FakeFastaRead(name='seq1/1', sequence='A' * 5),
+              FakeFastaRead(name='seq1/2', sequence='A' * 4),
+              FakeFastaRead(name='seq3/1', sequence='A' * 3),
+              FakeFastaRead(name='seq3/2', sequence='A' * 5)]
+
+    def gather(self, **kw):
+        itr = broken_paired_reader(self.stream, **kw)
+
+        x = []
+        m = 0
+        num = 0
+        for num, is_pair, read1, read2 in itr:
+            if is_pair:
+                x.append((read1.name, read2.name))
+            else:
+                x.append((read1.name, None))
+            m += 1
+
+        return x, num, m
+
+    def testMinLength_with_paired(self):
+        x, n, m = self.gather(min_length=4, require_paired=True)
+
+        expected = [('seq1/1', 'seq1/2')]
+        assert x == expected, x
+        assert m == 1
+        assert n == 0, n
+
+    def testForceSingle(self):
+        x, n, m = self.gather(force_single=True)
+
+        expected = [('seq1/1', None),
+                    ('seq1/2', None),
+                    ('seq3/1', None),
+                    ('seq3/2', None)]
+        assert x == expected, x
+        assert m == 4
+        assert n == 3, n


### PR DESCRIPTION
Fixes #1338.

This PR silently drops both reads if require_paired is set and one read is shorter than min_length.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?
