### PR TITLE
Support for different read parsers using functor templates

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -4017,7 +4017,7 @@ labelhash_consume_fasta_and_tag_with_labels(khmer_KGraphLabels_Object * me,
 
     //Py_BEGIN_ALLOW_THREADS
     try {
-        hb->consume_fasta_and_tag_with_labels(filename, total_reads,
+        hb->consume_fasta_and_tag_with_labels<FastxParser>(filename, total_reads,
                                               n_consumed);
     } catch (khmer_file_exception &exc) {
         exc_string = exc.what();
@@ -4059,7 +4059,7 @@ labelhash_consume_partitioned_fasta_and_tag_with_labels(
     unsigned int        total_reads = 0;
 
     try {
-        labelhash->consume_partitioned_fasta_and_tag_with_labels(filename,
+        labelhash->consume_partitioned_fasta_and_tag_with_labels<FastxParser>(filename,
                 total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -1327,7 +1327,7 @@ hashtable_consume_fasta(khmer_KHashtable_Object * me, PyObject * args)
     unsigned long long  n_consumed    = 0;
     unsigned int          total_reads   = 0;
     try {
-        hashtable->consume_fasta(filename, total_reads, n_consumed);
+        hashtable->consume_fasta<FastxParser>(filename, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;
@@ -1712,7 +1712,7 @@ hashtable_consume_fasta_and_tag(khmer_KHashtable_Object * me, PyObject * args)
     unsigned int total_reads;
 
     try {
-        hashtable->consume_fasta_and_tag(filename, total_reads, n_consumed);
+        hashtable->consume_fasta_and_tag<FastxParser>(filename, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -618,7 +618,7 @@ static PyTypeObject khmer_ReadParser_Type
 CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_ReadParser_Object")
 = {
     PyVarObject_HEAD_INIT(NULL, 0)             /* init & ob_size */
-    "_khmer.ReadParser",                        /* tp_name */
+    "_khmer.ReadParser",                       /* tp_name */
     sizeof(khmer_ReadParser_Object),           /* tp_basicsize */
     0,                                         /* tp_itemsize */
     (destructor)_ReadParser_dealloc,           /* tp_dealloc */
@@ -2293,7 +2293,7 @@ hashtable_output_partitions(khmer_KHashtable_Object * me, PyObject * args)
 
     try {
         SubsetPartition * subset_p = hashtable->partition;
-        n_partitions = subset_p->output_partitioned_file<FastxReader>(filename,
+        n_partitions = subset_p->output_partitioned_file(filename,
                        output,
                        output_unassigned);
     } catch (khmer_file_exception &e) {
@@ -3340,7 +3340,7 @@ count_abundance_distribution_with_reads_parser(khmer_KCountingHash_Object * me,
 
     Py_BEGIN_ALLOW_THREADS
     try {
-        dist = counting->abundance_distribution(rparser, hashbits);
+        dist = counting->abundance_distribution<FastxReader>(rparser, hashbits);
     } catch (khmer_file_exception &exc) {
         exc_string = exc.what();
         file_exception = exc_string.c_str();
@@ -4772,7 +4772,7 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
     unsigned long long  n_consumed    = 0;
     unsigned int        total_reads   = 0;
     try {
-        me->hllcounter->consume_fasta<FastxReader>(filename, stream_records, total_reads,
+        me->hllcounter->consume_fasta(filename, stream_records, total_reads,
                                       n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -151,8 +151,7 @@ HashIntoType * CountingHash::abundance_distribution(
 {
     ParseFunctor reader(filename);
     ReadParser<ParseFunctor> parser(reader);
-    HashIntoType * distribution = abundance_distribution<ParseFunctor>(&parser, tracking);
-    return distribution;
+    return abundance_distribution<ParseFunctor>(&parser, tracking);
 }
 
 void CountingHash::save(std::string outfilename)

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -51,7 +51,7 @@ Contact: khmer-project@idyll.org
 
 using namespace std;
 using namespace khmer;
-using namespace khmer:: read_parsers;
+using namespace khmer::read_parsers;
 
 BoundedCounterType CountingHash::get_min_count(const std::string &s)
 {
@@ -784,4 +784,11 @@ CountingHashGzFileWriter::CountingHashGzFileWriter(
     gzclose(outfile);
 }
 
-/* vim: set ft=cpp ts=8 sts=4 sw=4 et tw=79 */
+template HashIntoType * CountingHash::abundance_distribution<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    Hashbits * tracking
+);
+template HashIntoType * CountingHash::abundance_distribution<read_parsers::FastxReader>(
+    std::string filename,
+    Hashbits * tracking
+);

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -89,9 +89,9 @@ BoundedCounterType CountingHash::get_max_count(const std::string &s)
     return max_count;
 }
 
-HashIntoType *
-CountingHash::abundance_distribution(
-    read_parsers::IParser * parser,
+template<typename ParseFunctor>
+HashIntoType * CountingHash::abundance_distribution(
+    read_parsers::ReadParser<ParseFunctor> * parser,
     Hashbits *          tracking)
 {
     HashIntoType * dist = new HashIntoType[MAX_BIGCOUNT + 1];
@@ -141,15 +141,14 @@ CountingHash::abundance_distribution(
     return dist;
 }
 
-
+template<typename ParseFunctor>
 HashIntoType * CountingHash::abundance_distribution(
     std::string filename,
     Hashbits *  tracking)
 {
-    IParser* parser = IParser::get_parser(filename.c_str());
-
-    HashIntoType * distribution = abundance_distribution(parser, tracking);
-    delete parser;
+    ParseFunctor reader(filename);
+    ReadParser<ParseFunctor> parser(reader);
+    HashIntoType * distribution = abundance_distribution(&parser, tracking);
     return distribution;
 }
 

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -148,7 +148,7 @@ HashIntoType * CountingHash::abundance_distribution(
 {
     ParseFunctor reader(filename);
     ReadParser<ParseFunctor> parser(reader);
-    HashIntoType * distribution = abundance_distribution(&parser, tracking);
+    HashIntoType * distribution = abundance_distribution<ParseFunctor>(&parser, tracking);
     return distribution;
 }
 

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -53,6 +53,9 @@ using namespace std;
 using namespace khmer;
 using namespace khmer::read_parsers;
 
+namespace khmer
+{
+
 BoundedCounterType CountingHash::get_min_count(const std::string &s)
 {
     KmerIterator kmers(s.c_str(), _ksize);
@@ -792,3 +795,5 @@ template HashIntoType * CountingHash::abundance_distribution<read_parsers::Fastx
     std::string filename,
     Hashbits * tracking
 );
+
+}

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -291,6 +291,7 @@ public:
     template<typename ParseFunctor>
     HashIntoType * abundance_distribution(read_parsers::ReadParser<ParseFunctor> * parser,
                                           Hashbits * tracking);
+    template<typename ParseFunctor>
     HashIntoType * abundance_distribution(std::string filename,
                                           Hashbits * tracking);
 

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -57,6 +57,7 @@ namespace khmer
     namespace read_parsers
     {
         template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
     }
 }
 

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -52,13 +52,13 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-class Hashbits;
+    class Hashbits;
 
-namespace read_parsers
-{
-struct IParser;
-}  // namespace read_parsers
-}  // namespace khmer
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+    }
+}
 
 namespace khmer
 {
@@ -288,7 +288,8 @@ public:
 
     BoundedCounterType get_max_count(const std::string &s);
 
-    HashIntoType * abundance_distribution(read_parsers::IParser * parser,
+    template<typename ParseFunctor>
+    HashIntoType * abundance_distribution(read_parsers::ReadParser<ParseFunctor> * parser,
                                           Hashbits * tracking);
     HashIntoType * abundance_distribution(std::string filename,
                                           Hashbits * tracking);

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -443,12 +443,9 @@ void Hashtable::consume_fasta_and_tag(
     unsigned int	      &total_reads, unsigned long long	&n_consumed
 )
 {
-    ParseFunctor pf(filename);
-    ReadParser<ParseFunctor> parser(pf);
-    consume_fasta_and_tag(
-        parser,
-        total_reads, n_consumed
-    );
+    ParseFunctor pf((std::string&)filename);
+    read_parsers::ReadParser<ParseFunctor> parser(pf);
+    consume_fasta_and_tag<ParseFunctor>(&parser, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
@@ -1079,6 +1076,14 @@ template void Hashtable::consume_fasta<read_parsers::FastxReader>(
     read_parsers::ReadParser<read_parsers::FastxReader> * parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed
+);
+template void Hashtable::consume_fasta_and_tag<read_parsers::FastxReader>(
+    std::string const &filename,
+    unsigned int &total_reads, unsigned long long &n_consumed
+);
+template void Hashtable::consume_fasta_and_tag<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    unsigned int &total_reads, unsigned long long &n_consumed
 );
 
 } // namespace khmer

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -510,6 +510,7 @@ void Hashtable::divide_tags_into_subsets(unsigned int subset_size,
 // consume_partitioned_fasta: consume a FASTA file of reads
 //
 
+template<typename ParseFunctor>
 void Hashtable::consume_partitioned_fasta(const std::string &filename,
         unsigned int &total_reads,
         unsigned long long &n_consumed)
@@ -517,8 +518,8 @@ void Hashtable::consume_partitioned_fasta(const std::string &filename,
     total_reads = 0;
     n_consumed = 0;
 
-    FastxParser fp((std::string&)filename);
-    ReadParser<FastxParser> parser(fp);
+    ParseFunctor reader((std::string&)filename);
+    ReadParser<ParseFunctor> parser(reader);
     Read read;
 
     string seq = "";

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -52,7 +52,10 @@ Contact: khmer-project@idyll.org
 
 using namespace std;
 using namespace khmer;
-using namespace khmer:: read_parsers;
+using namespace khmer::read_parsers;
+
+namespace khmer
+{
 
 //
 // check_and_process_read: checks for non-ACGT characters before consuming
@@ -1077,3 +1080,5 @@ template void Hashtable::consume_fasta<read_parsers::FastxReader>(
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
+
+} // namespace khmer

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -104,15 +104,14 @@ bool Hashtable::check_and_normalize_read(std::string &read) const
 //
 
 // TODO? Inline in header.
-void
-Hashtable::
-consume_fasta(
-    std:: string const  &filename,
-    unsigned int	      &total_reads, unsigned long long	&n_consumed
+template<typename ParseFunctor>
+void Hashtable::consume_fasta(
+    std::string const &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
 )
 {
-    IParser *	  parser =
-        IParser::get_parser( filename );
+    ReadParser<ParseFunctor> * parser = ReadParser<ParseFunctor>::get_parser( filename );
 
     consume_fasta(
         parser,
@@ -122,10 +121,9 @@ consume_fasta(
     delete parser;
 }
 
-void
-Hashtable::
-consume_fasta(
-    read_parsers:: IParser *  parser,
+template<typename ParseFunctor>
+void Hashtable::consume_fasta(
+    read_parsers::ReadParser<ParseFunctor> * parser,
     unsigned int		    &total_reads, unsigned long long  &n_consumed
 )
 {
@@ -441,28 +439,23 @@ void Hashtable::consume_sequence_and_tag(const std::string& seq,
 //
 
 // TODO? Inline in header.
-void
-Hashtable::
-consume_fasta_and_tag(
+template<typename ParseFunctor>
+void Hashtable::consume_fasta_and_tag(
     std:: string const  &filename,
     unsigned int	      &total_reads, unsigned long long	&n_consumed
 )
 {
-    IParser *	  parser =
-        IParser::get_parser( filename );
-
+    ParseFunctor pf(filename);
+    ReadParser<ParseFunctor> parser(pf);
     consume_fasta_and_tag(
         parser,
         total_reads, n_consumed
     );
-
-    delete parser;
 }
 
-void
-Hashtable::
-consume_fasta_and_tag(
-    read_parsers:: IParser *  parser,
+template<typename ParseFunctor>
+void Hashtable::consume_fasta_and_tag(
+    read_parsers::ReadParser<ParseFunctor> * parser,
     unsigned int		    &total_reads,   unsigned long long	&n_consumed
 )
 {
@@ -524,7 +517,8 @@ void Hashtable::consume_partitioned_fasta(const std::string &filename,
     total_reads = 0;
     n_consumed = 0;
 
-    IParser* parser = IParser::get_parser(filename.c_str());
+    FastxParser fp((std::string&)filename);
+    ReadParser<FastxParser> parser(fp);
     Read read;
 
     string seq = "";
@@ -537,9 +531,9 @@ void Hashtable::consume_partitioned_fasta(const std::string &filename,
     // iterate through the FASTA file & consume the reads.
     //
 
-    while(!parser->is_complete())  {
+    while(!parser.is_complete())  {
         try {
-            read = parser->get_next_read();
+            read = parser.get_next_read();
         } catch (NoMoreReadsAvailable &exc) {
             break;
         }
@@ -563,8 +557,6 @@ void Hashtable::consume_partitioned_fasta(const std::string &filename,
         // reset the sequence info, increment read number
         total_reads++;
     }
-
-    delete parser;
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1080,4 +1072,3 @@ const
 }
 
 // vim: set sts=2 sw=2:
-

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -111,14 +111,9 @@ void Hashtable::consume_fasta(
     unsigned long long &n_consumed
 )
 {
-    ReadParser<ParseFunctor> * parser = ReadParser<ParseFunctor>::get_parser( filename );
-
-    consume_fasta(
-        parser,
-        total_reads, n_consumed
-    );
-
-    delete parser;
+    ParseFunctor reader((std::string&)filename);
+    ReadParser<ParseFunctor> parser(reader);
+    consume_fasta(&parser, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
@@ -1072,4 +1067,13 @@ const
     return size;
 }
 
-// vim: set sts=2 sw=2:
+template void Hashtable::consume_fasta<read_parsers::FastxReader>(
+    std::string const &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
+);
+template void Hashtable::consume_fasta<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
+);

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -283,6 +283,7 @@ public:
                                   unsigned long long& n_consumed,
                                   SeenSet * new_tags = 0);
 
+    template<typename ParseFunctor>
     void consume_partitioned_fasta(const std::string &filename,
                                    unsigned int &total_reads,
                                    unsigned long long &n_consumed);

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -67,6 +67,7 @@ namespace khmer
     namespace read_parsers
     {
         template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
     }
 }
 

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -61,14 +61,14 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-class CountingHash;
-class Hashtable;
+    class CountingHash;
+    class Hashtable;
 
-namespace read_parsers
-{
-struct IParser;
-}  // namespace read_parsers
-}  // namespace khmer
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+    }
+}
 
 #define MAX_KEEPER_SIZE int(1e6)
 
@@ -185,8 +185,9 @@ public:
     );
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
+    template<typename ReadFunctor>
     void consume_fasta(
-        read_parsers:: IParser *	    parser,
+        read_parsers::ReadParser<ReadFunctor>* parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed
     );
@@ -269,8 +270,9 @@ public:
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
     // Tag certain ones on the connectivity graph.
+    template<typename ParseFunctor>
     void consume_fasta_and_tag(
-        read_parsers:: IParser *	    parser,
+        read_parsers::ReadParser<ParseFunctor> * parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed
     );

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -349,7 +349,8 @@ public:
                                       SeenSet &nodes, Hashtable& bf,
                                       SeenSet &high_degree_nodes) const;
 };
-}
+
+} // namespace khmer
 
 
 

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -178,6 +178,7 @@ public:
     // Note: Yes, the name 'consume_fasta' is a bit misleading,
     //	     but the FASTA format is effectively a subset of the FASTQ format
     //	     and the FASTA portion is what we care about in this case.
+    template<typename ParseFunctor>
     void consume_fasta(
         std::string const   &filename,
         unsigned int	    &total_reads,
@@ -261,6 +262,7 @@ public:
 
     // Count every k-mer in a FASTA or FASTQ file.
     // Tag certain ones on the connectivity graph.
+    template<typename ParseFunctor>
     void consume_fasta_and_tag(
         std::string const	  &filename,
         unsigned int	  &total_reads,
@@ -280,7 +282,6 @@ public:
     void consume_sequence_and_tag(const std::string& seq,
                                   unsigned long long& n_consumed,
                                   SeenSet * new_tags = 0);
-
 
     void consume_partitioned_fasta(const std::string &filename,
                                    unsigned int &total_reads,

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -187,9 +187,9 @@ public:
     );
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
-    template<typename ReadFunctor>
+    template<typename ParseFunctor>
     void consume_fasta(
-        read_parsers::ReadParser<ReadFunctor>* parser,
+        read_parsers::ReadParser<ParseFunctor>* parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed
     );

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2014-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -429,7 +429,7 @@ void HLLCounter::consume_fasta(
                 }
 
                 if (stream_records) {
-                    read.write_to(std::cout);
+                    read.write_fastx(std::cout);
                 }
 
                 #pragma omp task default(none) firstprivate(read) \

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -375,21 +375,19 @@ unsigned int HLLCounter::consume_string(const std::string &inp)
     return n_consumed;
 }
 
-template<typename ParseFunctor>
 void HLLCounter::consume_fasta(
     std::string const &filename,
     bool stream_records,
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
-    ParseFunctor reader(filename);
-    read_parsers::ReadParser<ParseFunctor> parser(reader);
+    read_parsers::FastxReader reader((std::string&)filename);
+    read_parsers::ReadParser<read_parsers::FastxReader> parser(reader);
     consume_fasta(&parser, stream_records, total_reads, n_consumed);
 }
 
-template<typename ParseFunctor>
 void HLLCounter::consume_fasta(
-    read_parsers::ReadParser<ParseFunctor> *parser,
+    read_parsers::ReadParser<read_parsers::FastxReader> *parser,
     bool stream_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -375,21 +375,21 @@ unsigned int HLLCounter::consume_string(const std::string &inp)
     return n_consumed;
 }
 
+template<typename ParseFunctor>
 void HLLCounter::consume_fasta(
     std::string const &filename,
     bool stream_records,
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
-    read_parsers::IParser * parser = read_parsers::IParser::get_parser(filename);
-
-    consume_fasta(parser, stream_records, total_reads, n_consumed);
-
-    delete parser;
+    ParseFunctor reader(filename);
+    read_parsers::ReadParser<ParseFunctor> parser(reader);
+    consume_fasta(&parser, stream_records, total_reads, n_consumed);
 }
 
+template<typename ParseFunctor>
 void HLLCounter::consume_fasta(
-    read_parsers::IParser *parser,
+    read_parsers::ReadParser<ParseFunctor> *parser,
     bool stream_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -46,15 +46,11 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
+
 namespace read_parsers
 {
-struct IParser;
-}  // namespace read_parsers
-}  // namespace khmer
-
-
-namespace khmer
-{
+    template<typename ParseFunctor> class ReadParser;
+}
 
 class HLLCounter
 {
@@ -64,13 +60,11 @@ public:
 
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
-    template<typename ParseFunctor>
     void consume_fasta(std::string const &,
                        bool,
                        unsigned int &,
                        unsigned long long &);
-    template<typename ParseFunctor>
-    void consume_fasta(read_parsers::ReadParser<ParseFunctor> *,
+    void consume_fasta(read_parsers::ReadParser<read_parsers::FastxReader> *,
                        bool,
                        unsigned int &,
                        unsigned long long &);

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -64,11 +64,13 @@ public:
 
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
+    template<typename ParseFunctor>
     void consume_fasta(std::string const &,
                        bool,
                        unsigned int &,
                        unsigned long long &);
-    void consume_fasta(read_parsers::IParser *,
+    template<typename ParseFunctor>
+    void consume_fasta(read_parsers::ReadParser<ParseFunctor> *,
                        bool,
                        unsigned int &,
                        unsigned long long &);

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2014-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -46,11 +46,6 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-
-namespace read_parsers
-{
-    template<typename ParseFunctor> class ReadParser;
-}
 
 class HLLCounter
 {

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -548,3 +548,18 @@ void LabelHash::load_labels_and_tags(std::string filename)
 
     delete[] buf;
 }
+
+template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxReader>(
+    std:: string const &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed,
+    CallbackFn callback,
+    void * callback_data
+);
+template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed,
+    CallbackFn callback,
+    void * callback_data
+);

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -55,7 +55,10 @@ Contact: khmer-project@idyll.org
 
 using namespace std;
 using namespace khmer;
-using namespace khmer:: read_parsers;
+using namespace khmer::read_parsers;
+
+namespace khmer
+{
 
 /*
  * @camillescott
@@ -563,3 +566,5 @@ template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxRe
     CallbackFn callback,
     void * callback_data
 );
+
+}

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -56,6 +56,7 @@ namespace khmer
     namespace read_parsers
     {
         template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
     }
 }
 

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -191,7 +191,8 @@ public:
     void load_labels_and_tags(std::string);
 
 };
-}
+
+} // namespace khmer
 
 #define ACQUIRE_TAG_COLORS_SPIN_LOCK \
   while(!__sync_bool_compare_and_swap( &_tag_labels_spin_lock, 0, 1));

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -51,13 +51,13 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-class Hashtable;
+    class Hashtable;
 
-namespace read_parsers
-{
-struct IParser;
-}  // namespace read_parsers
-}  // namespace khmer
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+    }
+}
 
 namespace khmer
 {
@@ -145,7 +145,7 @@ public:
         return all_labels.size();
     }
 
-
+    template<typename ParseFunctor>
     void consume_fasta_and_tag_with_labels(
         std::string const	  &filename,
         unsigned int	  &total_reads,
@@ -153,13 +153,15 @@ public:
         CallbackFn	  callback	  = NULL,
         void *		  callback_data	  = NULL);
 
+    template<typename ParseFunctor>
     void consume_fasta_and_tag_with_labels(
-        read_parsers:: IParser *	    parser,
+        read_parsers::ReadParser<ParseFunctor> * parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed,
         CallbackFn	    callback	    = NULL,
         void *		    callback_data   = NULL);
 
+    template<typename ParseFunctor>
     void consume_partitioned_fasta_and_tag_with_labels(const std::string &filename,
             unsigned int &total_reads,
             unsigned long long &n_consumed,

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -257,6 +257,15 @@ FastxReader::FastxReader(std::string& infile)
     _init();
 }
 
+FastxReader::FastxReader(FastxReader& other)
+        : _filename(other._filename),
+          _spin_lock(other._spin_lock),
+          _num_reads(other._num_reads),
+          _have_qualities(other._have_qualities)
+{
+    _stream = std::move(other._stream);
+}
+
 FastxReader::~FastxReader()
 {
     seqan::close(_stream);

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -127,7 +127,7 @@ void ReadParser<ParseFunctor>::imprint_next_read_pair(ReadPair &pair, uint8_t mo
 template<typename ParseFunctor>
 size_t ReadParser<ParseFunctor>::get_num_reads()
 {
-    return _parser._num_reads;
+    return _parser.get_num_reads();
 }
 
 template<typename ParseFunctor>
@@ -227,7 +227,7 @@ bool ReadParser<ParseFunctor>::_is_valid_read_pair(
 }
 
 
-void FastxParser::_init()
+void FastxReader::_init()
 {
     seqan::open(_stream, _filename.c_str());
     if (!seqan::isGood(_stream)) {
@@ -242,13 +242,13 @@ void FastxParser::_init()
     __asm__ __volatile__ ("" ::: "memory");
 }
 
-FastxParser::FastxParser()
+FastxReader::FastxReader()
         : _filename("-"), _spin_lock(0), _num_reads(0), _have_qualities(false)
 {
     _init();
 }
 
-FastxParser::FastxParser(std::string& infile)
+FastxReader::FastxReader(std::string& infile)
         : _filename(infile),
           _spin_lock(0),
           _num_reads(0),
@@ -257,17 +257,22 @@ FastxParser::FastxParser(std::string& infile)
     _init();
 }
 
-FastxParser::~FastxParser()
+FastxReader::~FastxReader()
 {
     seqan::close(_stream);
 }
 
-bool FastxParser::is_complete()
+bool FastxReader::is_complete()
 {
     return !seqan::isGood(_stream) || seqan::atEnd(_stream);
 }
 
-void FastxParser::operator()(Read& read)
+size_t FastxReader::get_num_reads()
+{
+    return _num_reads;
+}
+
+void FastxReader::operator()(Read& read)
 {
     read.reset();
     int ret = -1;
@@ -310,6 +315,9 @@ void FastxParser::operator()(Read& read)
         throw StreamReadError();
     }
 }
+
+// All template instantiations used in the codebase must be declared here.
+template class ReadParser<FastxReader>;
 
 } // namespace read_parsers
 

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -35,113 +35,18 @@ LICENSE (END)
 
 Contact: khmer-project@idyll.org
 */
-#include <seqan/seq_io.h> // IWYU pragma: keep
-#include <seqan/sequence.h> // IWYU pragma: keep
-#include <seqan/stream.h> // IWYU pragma: keep
-#include <fstream>
 
+#include <fstream>
 #include "khmer_exception.hh"
 #include "read_parsers.hh"
 
 namespace khmer
 {
 
-
 namespace read_parsers
 {
 
-struct FastxParser::Handle {
-    seqan::SequenceStream stream;
-    uint32_t seqan_spin_lock;
-};
-
-FastxParser::FastxParser( char const * filename ) : IParser( )
-{
-    _private = new FastxParser::Handle();
-    seqan::open(_private->stream, filename);
-    if (!seqan::isGood(_private->stream)) {
-        std::string message = "Could not open ";
-        message = message + filename + " for reading.";
-        throw InvalidStream(message);
-    } else if (seqan::atEnd(_private->stream)) {
-        std::string message = "File ";
-        message = message + filename + " does not contain any sequences!";
-        throw InvalidStream(message);
-    }
-    __asm__ __volatile__ ("" ::: "memory");
-    _private->seqan_spin_lock = 0;
-}
-
-bool FastxParser::is_complete()
-{
-    return !seqan::isGood(_private->stream) || seqan::atEnd(_private->stream);
-}
-
-void FastxParser::imprint_next_read(Read &the_read)
-{
-    the_read.reset();
-    int ret = -1;
-    const char *invalid_read_exc = NULL;
-    while (!__sync_bool_compare_and_swap(& _private->seqan_spin_lock, 0, 1));
-    bool atEnd = seqan::atEnd(_private->stream);
-    if (!atEnd) {
-        ret = seqan::readRecord(the_read.name, the_read.sequence,
-                                the_read.quality, _private->stream);
-        if (ret == 0) {
-            // Detect if we're parsing something w/ qualities on the first read
-            // only
-            if (_num_reads == 0 && the_read.quality.length() != 0) {
-                _have_qualities = true;
-            }
-
-            // Handle error cases, or increment number of reads on success
-            if (the_read.sequence.length() == 0) {
-                invalid_read_exc = "Sequence is empty";
-            } else if (_have_qualities && (the_read.sequence.length() != \
-                                           the_read.quality.length())) {
-                invalid_read_exc = "Sequence and quality lengths differ";
-            } else {
-                _num_reads++;
-            }
-        }
-    }
-    __asm__ __volatile__ ("" ::: "memory");
-    _private->seqan_spin_lock = 0;
-    // Throw any error in the read, even if we're at the end
-    if (invalid_read_exc != NULL) {
-        throw InvalidRead(invalid_read_exc);
-    }
-    // Throw NoMoreReadsAvailable if none of the above errors were raised, even
-    // if ret == 0
-    if (atEnd) {
-        throw NoMoreReadsAvailable();
-    }
-    // Catch-all error in readRecord that isn't one of the above
-    if (ret != 0) {
-        throw StreamReadError();
-    }
-}
-
-FastxParser::~FastxParser()
-{
-    seqan::close(_private->stream);
-    delete _private;
-}
-
-IParser * const
-IParser::
-get_parser(
-    std:: string const	    &ifile_name
-)
-{
-
-    return new FastxParser(ifile_name.c_str());
-}
-
-
-IParser::
-IParser(
-)
+void ReadParser::_init()
 {
     int regex_rc =
         regcomp(
@@ -169,46 +74,68 @@ IParser(
     if (regex_rc) {
         throw khmer_exception("Could not compile R2 regex");
     }
-    _num_reads = 0;
-    _have_qualities = false;
 }
 
-IParser::
-~IParser( )
+template<typename ParseFunctor>
+ReadParser::ReadParser(ParseFunctor pf)
+        : _parser(pf), _num_reads(0), _have_qualities(false)
 {
-    regfree( &_re_read_2_nosub );
-    regfree( &_re_read_1 );
-    regfree( &_re_read_2 );
+    _init();
 }
 
-void
-IParser::
-imprint_next_read_pair( ReadPair &the_read_pair, uint8_t mode )
+ReadParser::ReadParser(ReadParser& other)
+        : _parser(other._parser),
+          _num_reads(other._num_reads),
+          _have_qualities(other._have_qualities)
 {
-    switch (mode) {
+    _init();
+}
+
+ReadParser::~ReadParser()
+{
+    regfree(&_re_read_2_nosub);
+    regfree(&_re_read_1);
+    regfree(&_re_read_2);
+}
+
+void ReadParser::imprint_next_read(Read &read)
+{
+    parser(read);
+}
+
+void ReadParser::imprint_next_read_pair(ReadPair &pair, uint8_t mode)
+{
+    if (mode == IParser::PAIR_MODE_IGNORE_UNPAIRED) {
+        _imprint_next_read_pair_in_ignore_mode(pair);
+    }
+    else if (mode == IParser::PAIR_MODE_ERROR_ON_UNPAIRED) {
+        _imprint_next_read_pair_in_error_mode(pair);
+    }
 #if (0)
-    case IParser:: PAIR_MODE_ALLOW_UNPAIRED:
-        _imprint_next_read_pair_in_allow_mode( the_read_pair );
-        break;
+    else if (mode == IParser::PAIR_MODE_ALLOW_UNPAIRED) {
+        _imprint_next_read_pair_in_allow_mode(pair);
+    }
 #endif
-    case IParser:: PAIR_MODE_IGNORE_UNPAIRED:
-        _imprint_next_read_pair_in_ignore_mode( the_read_pair );
-        break;
-    case IParser:: PAIR_MODE_ERROR_ON_UNPAIRED:
-        _imprint_next_read_pair_in_error_mode( the_read_pair );
-        break;
-    default:
+    else {
         std::ostringstream oss;
         oss << "Unknown pair reading mode: " << mode;
         throw UnknownPairReadingMode(oss.str());
     }
 }
 
+size_t ReadParser::get_num_reads()
+{
+    return _num_reads;
+}
+
+bool ReadParser::is_complete()
+{
+    return parser.is_complete();
+}
 
 #if (0)
 void
-IParser::
-_imprint_next_read_pair_in_allow_mode( ReadPair &the_read_pair )
+ReadParser::_imprint_next_read_pair_in_allow_mode(ReadPair& pair)
 {
     // TODO: Implement.
     //	     Probably need caching of reads between invocations
@@ -216,14 +143,11 @@ _imprint_next_read_pair_in_allow_mode( ReadPair &the_read_pair )
 }
 #endif
 
-
-void
-IParser::
-_imprint_next_read_pair_in_ignore_mode( ReadPair &the_read_pair )
+void ReadParser::_imprint_next_read_pair_in_ignore_mode(ReadPair& pair)
 {
-    Read	    &read_1		= the_read_pair.first;
-    Read	    &read_2		= the_read_pair.second;
-    regmatch_t	    match_1, match_2;
+    Read& read_1 = pair.first;
+    Read& read_2 = pair.second;
+    regmatch_t match_1, match_2;
 
     // Hunt for a read pair until one is found or end of reads is reached.
     while (true) {
@@ -232,10 +156,8 @@ _imprint_next_read_pair_in_ignore_mode( ReadPair &the_read_pair )
         // Note: We let any exception, which flies out of the following,
         //	 pass through unhandled.
         while (true) {
-            imprint_next_read( read_1 );
-            if (!regexec(
-                        &_re_read_1, read_1.name.c_str( ), 1, &match_1, 0
-                    )) {
+            imprint_next_read(read_1);
+            if (!regexec(&_re_read_1, read_1.name.c_str(), 1, &match_1, 0)) {
                 break;
             }
         }
@@ -244,11 +166,9 @@ _imprint_next_read_pair_in_ignore_mode( ReadPair &the_read_pair )
         // If not found, then restart search for pair.
         // If found, then validate match.
         // If invalid pair, then restart search for pair.
-        imprint_next_read( read_2 );
-        if (!regexec(
-                    &_re_read_2, read_2.name.c_str( ), 1, &match_2, 0
-                )) {
-            if (_is_valid_read_pair( the_read_pair, match_1, match_2 )) {
+        imprint_next_read(read_2);
+        if (!regexec(&_re_read_2, read_2.name.c_str(), 1, &match_2, 0)) {
+            if (_is_valid_read_pair(pair, match_1, match_2)) {
                 break;
             }
         }
@@ -257,56 +177,129 @@ _imprint_next_read_pair_in_ignore_mode( ReadPair &the_read_pair )
 
 } // _imprint_next_read_pair_in_ignore_mode
 
-
-void
-IParser::
-_imprint_next_read_pair_in_error_mode( ReadPair &the_read_pair )
+void ReadParser:: _imprint_next_read_pair_in_error_mode(ReadPair& pair)
 {
-    Read	    &read_1		= the_read_pair.first;
-    Read	    &read_2		= the_read_pair.second;
-    regmatch_t	    match_1, match_2;
+    Read & read_1 = the_read_pair.first;
+    Read & read_2 = the_read_pair.second;
+    regmatch_t match_1, match_2;
 
     // Note: We let any exception, which flies out of the following,
     //	     pass through unhandled.
-    imprint_next_read( read_1 );
-    imprint_next_read( read_2 );
+    imprint_next_read(read_1);
+    imprint_next_read(read_2);
 
     // Is the first read really the first member of a pair?
     if (REG_NOMATCH == regexec(
-                &_re_read_1, read_1.name.c_str( ), 1, &match_1, 0
+                &_re_read_1, read_1.name.c_str(), 1, &match_1, 0
             )) {
-        throw InvalidReadPair( );
+        throw InvalidReadPair();
     }
     // Is the second read really the second member of a pair?
     if (REG_NOMATCH == regexec(
-                &_re_read_2, read_2.name.c_str( ), 1, &match_2, 0
+                &_re_read_2, read_2.name.c_str(), 1, &match_2, 0
             )) {
-        throw InvalidReadPair( );
+        throw InvalidReadPair();
     }
 
     // Is the pair valid?
     if (!_is_valid_read_pair( the_read_pair, match_1, match_2 )) {
-        throw InvalidReadPair( );
+        throw InvalidReadPair();
     }
 
 } // _imprint_next_read_pair_in_error_mode
 
-
-bool
-IParser::
-_is_valid_read_pair(
-    ReadPair &the_read_pair, regmatch_t &match_1, regmatch_t &match_2
+bool ReadParser::_is_valid_read_pair(
+    ReadPair& pair,
+    regmatch_t &match_1,
+    regmatch_t &match_2
 )
 {
-    return	(match_1.rm_so == match_2.rm_so)
-            &&	(match_1.rm_eo == match_2.rm_eo)
-            &&	(	the_read_pair.first.name.substr( 0, match_1.rm_so )
-                    ==	the_read_pair.second.name.substr( 0, match_1.rm_so ));
+    return (match_1.rm_so == match_2.rm_so)
+            && (match_1.rm_eo == match_2.rm_eo)
+            && (the_read_pair.first.name.substr(0, match_1.rm_so)
+                    ==	the_read_pair.second.name.substr(0, match_1.rm_so));
+}
+
+
+void FastxParser::_init()
+{
+    seqan::open(_stream, filename);
+    if (!seqan::isGood(_private->stream)) {
+        std::string message = "Could not open ";
+        message = message + filename + " for reading.";
+        throw InvalidStream(message);
+    } else if (seqan::atEnd(_private->stream)) {
+        std::string message = "File ";
+        message = message + filename + " does not contain any sequences!";
+        throw InvalidStream(message);
+    }
+    __asm__ __volatile__ ("" ::: "memory");
+}
+
+FastxParser::FastxParser() : _filename("-"), _spin_lock(0)
+{
+    _init();
+}
+
+FastxParser::FastxParser(std::string& infile) : _filename(infile), _spin_lock(0)
+{
+    _init();
+}
+
+FastxParser::~FastxParser()
+{
+    seqan::close(_stream);
+}
+
+bool FastxParser::is_complete()
+{
+    return !seqan::isGood(_private->stream) || seqan::atEnd(_private->stream);
+}
+
+void FastxParser::imprint_next_read(Read& read)
+{
+    read.reset();
+    int ret = -1;
+    const char *invalid_read_exc = NULL;
+    while (!__sync_bool_compare_and_swap(&_spin_lock, 0, 1));
+    bool atEnd = seqan::atEnd(_stream);
+    if (!atEnd) {
+        ret = seqan::readRecord(read.name, read.sequence, read.quality, _stream);
+        if (ret == 0) {
+            // Detect if we're parsing something w/ qualities on the first read
+            // only
+            if (_num_reads == 0 && read.quality.length() != 0) {
+                _have_qualities = true;
+            }
+
+            // Handle error cases, or increment number of reads on success
+            if (read.sequence.length() == 0) {
+                invalid_read_exc = "Sequence is empty";
+            } else if (_have_qualities && (read.sequence.length() != \
+                                           read.quality.length())) {
+                invalid_read_exc = "Sequence and quality lengths differ";
+            } else {
+                _num_reads++;
+            }
+        }
+    }
+    __asm__ __volatile__ ("" ::: "memory");
+    _spin_lock = 0;
+    // Throw any error in the read, even if we're at the end
+    if (invalid_read_exc != NULL) {
+        throw InvalidRead(invalid_read_exc);
+    }
+    // Throw NoMoreReadsAvailable if none of the above errors were raised, even
+    // if ret == 0
+    if (atEnd) {
+        throw NoMoreReadsAvailable();
+    }
+    // Catch-all error in readRecord that isn't one of the above
+    if (ret != 0) {
+        throw StreamReadError();
+    }
 }
 
 } // namespace read_parsers
 
-
 } // namespace khmer
-
-// vim: set ft=cpp sts=4 sw=4 tw=80:

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -50,21 +50,6 @@ namespace khmer
 namespace read_parsers
 {
 
-void
-Read::write_to(std::ostream& output)
-{
-    if (quality.length() != 0) {
-        output << "@" << name << std::endl
-               << sequence << std::endl
-               << "+" << std::endl
-               << quality << std::endl;
-    } else {
-        output << ">" << name << std::endl
-               << sequence << std::endl;
-    }
-}
-
-
 struct FastxParser::Handle {
     seqan::SequenceStream stream;
     uint32_t seqan_spin_lock;

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -38,6 +38,10 @@ Contact: khmer-project@idyll.org
 #ifndef READ_PARSERS_HH
 #define READ_PARSERS_HH
 
+#include <seqan/seq_io.h> // IWYU pragma: keep
+#include <seqan/sequence.h> // IWYU pragma: keep
+#include <seqan/stream.h> // IWYU pragma: keep
+
 #include <regex.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -114,16 +118,17 @@ public:
 };
 typedef std::pair<Read, Read> ReadPair;
 
-template <typename ParseFunctor>
+template<typename ParseFunctor>
 class ReadParser
 {
 protected:
-    ParseFunctor parser;
+    ParseFunctor _parser;
     size_t _num_reads;
     bool _have_qualities;
     regex_t _re_read_2_nosub;
     regex_t _re_read_1;
     regex_t _re_read_2;
+    void _init();
 
 #if (0)
     void  _imprint_next_read_pair_in_allow_mode(ReadPair& pair);
@@ -144,9 +149,8 @@ public:
     };
 
     // Constructors / destructors
-    explicit ReadParser(ParseFunctor parser);
+    explicit ReadParser(ParseFunctor pf);
     explicit ReadParser(ReadParser& other);
-    ReadParser& operator=(const ReadParser& other);
     virtual ~ReadParser();
 
     // Class methods
@@ -175,19 +179,19 @@ public:
 class FastxParser
 {
 private:
-    std::string filename;
-    seqan::SequenceStream stream;
-    uint32_t seqan_spin_lock;
+    std::string _filename;
+    seqan::SequenceStream _stream;
+    uint32_t _spin_lock;
+    void _init();
 
 public:
     FastxParser();
     FastxParser(std::string& infile);
     FastxParser(FastxParser& other);
-    FastxParser& operator=(const FastxParser& other);
 
     void operator()(Read &read);
     bool is_complete();
-}
+};
 
 inline PartitionID _parse_partition_id(std::string name)
 {

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -174,7 +174,7 @@ public:
     }
 }; // struct ReadParser
 
-class FastxParser
+class FastxReader
 {
 private:
     std::string _filename;
@@ -185,13 +185,14 @@ private:
     void _init();
 
 public:
-    FastxParser();
-    FastxParser(std::string& infile);
-    FastxParser(FastxParser& other);
-    ~FastxParser();
+    FastxReader();
+    FastxReader(std::string& infile);
+    FastxReader(FastxReader& other);
+    ~FastxReader();
 
     void operator()(Read &read);
     bool is_complete();
+    size_t get_num_reads();
 };
 
 inline PartitionID _parse_partition_id(std::string name)

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -52,8 +52,6 @@ Contact: khmer-project@idyll.org
 namespace khmer
 {
 
-
-
 namespace read_parsers
 {
 
@@ -85,109 +83,111 @@ struct InvalidReadPair : public  khmer_value_exception {
         khmer_value_exception("Invalid read pair detected.") {}
 };
 
-struct Read {
-    std:: string    name;
-    std:: string    annotations;
-    std:: string    sequence;
-    std:: string    quality;
-    // TODO? Add description field.
+class Read
+{
+public:
+    std::string name;
+    std::string annotations;
+    std::string sequence;
+    std::string quality;
 
-    inline void reset ( )
+    inline void reset()
     {
-        name.clear( );
-        annotations.clear( );
-        sequence.clear( );
-        quality.clear( );
+        name.clear();
+        annotations.clear();
+        sequence.clear();
+        quality.clear();
     }
 
-    void write_to(std::ostream&);
+    inline void write_fastx(std::ostream& output)
+    {
+        if (quality.length() != 0) {
+            output << "@" << name << '\n'
+                   << sequence << '\n'
+                   << "+" << '\n'
+                   << quality << '\n';
+        } else {
+            output << ">" << name << '\n'
+                   << sequence << '\n';
+        }
+    }
 };
+typedef std::pair<Read, Read> ReadPair;
 
-typedef std:: pair< Read, Read >	ReadPair;
+template <typename ParseFunctor>
+class ReadParser
+{
+protected:
+    ParseFunctor parser;
+    size_t _num_reads;
+    bool _have_qualities;
+    regex_t _re_read_2_nosub;
+    regex_t _re_read_1;
+    regex_t _re_read_2;
 
-struct IParser {
+#if (0)
+    void  _imprint_next_read_pair_in_allow_mode(ReadPair& pair);
+#endif
+    void  _imprint_next_read_pair_in_ignore_mode(ReadPair& pair);
+    void  _imprint_next_read_pair_in_error_mode(ReadPair& pair);
+    bool  _is_valid_read_pair(
+        ReadPair& pair,
+        regmatch_t &match_1,
+        regmatch_t &match_2
+    );
 
+public:
     enum {
         PAIR_MODE_ALLOW_UNPAIRED = 0,
         PAIR_MODE_IGNORE_UNPAIRED,
         PAIR_MODE_ERROR_ON_UNPAIRED
     };
 
-    static IParser * const  get_parser(
-        std:: string const 	&ifile_name
-    );
+    // Constructors / destructors
+    explicit ReadParser(ParseFunctor parser);
+    explicit ReadParser(ReadParser& other);
+    ReadParser& operator=(const ReadParser& other);
+    virtual ~ReadParser();
 
-    IParser( );
-    virtual ~IParser( );
-
-    virtual bool		is_complete( ) = 0;
-
-    // Note: 'get_next_read' exists for legacy reasons.
-    //	     In the long term, it should be eliminated in favor of direct use of
-    //	     'imprint_next_read'. A potentially costly copy-by-value happens
-    //	     upon return.
-    // TODO: Eliminate all calls to 'get_next_read'.
-    // Or switch to C++11 w/ move constructors
-    inline Read		get_next_read( )
-    {
-        Read the_read;
-        imprint_next_read( the_read );
-        return the_read;
-    }
-    virtual void	imprint_next_read( Read &the_read ) = 0;
-
-    virtual void	imprint_next_read_pair(
-        ReadPair &the_read_pair,
+    // Class methods
+    void imprint_next_read(Read &read);
+    void imprint_next_read_pair(
+        ReadPair &pair,
         uint8_t mode = PAIR_MODE_ERROR_ON_UNPAIRED
     );
+    size_t get_num_reads();
+    virtual bool is_complete();
 
-    size_t		    get_num_reads()
+    // Note: 'get_next_read' exists for legacy reasons.
+    //       In the long term, it should be eliminated in favor of direct use of
+    //       'imprint_next_read'. A potentially costly copy-by-value happens
+    //       upon return.
+    // TODO: Eliminate all calls to 'get_next_read'.
+    // Or switch to C++11 w/ move constructors
+    inline Read get_next_read()
     {
-        return _num_reads;
+        Read read;
+        imprint_next_read(read);
+        return read;
     }
+}; // struct ReadParser
 
-protected:
-
-    size_t		_num_reads;
-    bool        _have_qualities;
-    regex_t		_re_read_2_nosub;
-    regex_t		_re_read_1;
-    regex_t		_re_read_2;
-
-#if (0)
-    void		_imprint_next_read_pair_in_allow_mode(
-        ReadPair &the_read_pair
-    );
-#endif
-
-    void		_imprint_next_read_pair_in_ignore_mode(
-        ReadPair &the_read_pair
-    );
-    void		_imprint_next_read_pair_in_error_mode(
-        ReadPair &the_read_pair
-    );
-    bool		_is_valid_read_pair(
-        ReadPair &the_read_pair, regmatch_t &match_1, regmatch_t &match_2
-    );
-
-}; // struct IParser
-
-class FastxParser : public IParser
+class FastxParser
 {
+private:
+    std::string filename;
+    seqan::SequenceStream stream;
+    uint32_t seqan_spin_lock;
 
 public:
-    explicit FastxParser( const char * filename );
-    ~FastxParser( );
+    FastxParser();
+    FastxParser(std::string& infile);
+    FastxParser(FastxParser& other);
+    FastxParser& operator=(const FastxParser& other);
 
-    bool is_complete( );
-    void imprint_next_read(Read &the_read);
-
-private:
-    struct Handle;
-
-    Handle* _private;
-
-};
+    void operator()(Read &read);
+    bool is_complete();
+}
 
 inline PartitionID _parse_partition_id(std::string name)
 {
@@ -204,21 +204,16 @@ inline PartitionID _parse_partition_id(std::string name)
     if (*s == '\t') {
         p = (PartitionID) atoi(s + 1);
     } else {
-        std::cerr << "consume_partitioned_fasta barfed on read "  << name << "\n";
+        std::cerr << "consume_partitioned_fasta barfed on read "
+                  << name << "\n";
         throw khmer_exception();
     }
 
     return p;
 }
 
-
-
 } // namespace read_parsers
-
 
 } // namespace khmer
 
-
 #endif // READ_PARSERS_HH
-
-// vim: set ft=cpp sts=4 sw=4 tw=80:

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -123,8 +123,6 @@ class ReadParser
 {
 protected:
     ParseFunctor _parser;
-    size_t _num_reads;
-    bool _have_qualities;
     regex_t _re_read_2_nosub;
     regex_t _re_read_1;
     regex_t _re_read_2;
@@ -182,12 +180,15 @@ private:
     std::string _filename;
     seqan::SequenceStream _stream;
     uint32_t _spin_lock;
+    size_t _num_reads;
+    bool _have_qualities;
     void _init();
 
 public:
     FastxParser();
     FastxParser(std::string& infile);
     FastxParser(FastxParser& other);
+    ~FastxParser();
 
     void operator()(Read &read);
     bool is_complete();

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -112,7 +112,7 @@ void SubsetPartition::count_partitions(
     n_partitions = partitions.size();
 }
 
-
+template<typename ParseFunctor>
 size_t SubsetPartition::output_partitioned_file(
     const std::string	&infilename,
     const std::string	&outputfile,
@@ -120,7 +120,8 @@ size_t SubsetPartition::output_partitioned_file(
     CallbackFn		callback,
     void *		callback_data)
 {
-    IParser* parser = IParser::get_parser(infilename);
+    ParseFunctor reader(infilename);
+    ReadParser<ParseFunctor> parser(reader);
     ofstream outfile(outputfile.c_str());
 
     unsigned int total_reads = 0;
@@ -141,9 +142,9 @@ size_t SubsetPartition::output_partitioned_file(
     // and output them.
     //
 
-    while(!parser->is_complete()) {
+    while(!parser.is_complete()) {
         try {
-            read = parser->get_next_read();
+            read = parser.get_next_read();
         } catch (NoMoreReadsAvailable &exc) {
             break;
         }
@@ -208,9 +209,6 @@ size_t SubsetPartition::output_partitioned_file(
             }
         }
     }
-
-    delete parser;
-    parser = NULL;
 
     return partitions.size() + n_singletons;
 }

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -112,7 +112,6 @@ void SubsetPartition::count_partitions(
     n_partitions = partitions.size();
 }
 
-template<typename ParseFunctor>
 size_t SubsetPartition::output_partitioned_file(
     const std::string	&infilename,
     const std::string	&outputfile,
@@ -120,8 +119,8 @@ size_t SubsetPartition::output_partitioned_file(
     CallbackFn		callback,
     void *		callback_data)
 {
-    ParseFunctor reader(infilename);
-    ReadParser<ParseFunctor> parser(reader);
+    FastxReader reader((std::string&)infilename);
+    ReadParser<FastxReader> parser(reader);
     ofstream outfile(outputfile.c_str());
 
     unsigned int total_reads = 0;
@@ -201,8 +200,6 @@ size_t SubsetPartition::output_partitioned_file(
                     callback("output_partitions", callback_data,
                              total_reads, reads_kept);
                 } catch (...) {
-                    delete parser;
-                    parser = NULL;
                     outfile.close();
                     throw;
                 }

--- a/lib/subset.hh
+++ b/lib/subset.hh
@@ -145,6 +145,7 @@ public:
     void count_partitions(size_t& n_partitions,
                           size_t& n_unassigned);
 
+    template<typename ParseFunctor>
     size_t output_partitioned_file(const std::string &infilename,
                                    const std::string &outputfilename,
                                    bool output_unassigned=false,

--- a/lib/subset.hh
+++ b/lib/subset.hh
@@ -145,7 +145,6 @@ public:
     void count_partitions(size_t& n_partitions,
                           size_t& n_unassigned);
 
-    template<typename ParseFunctor>
     size_t output_partitioned_file(const std::string &infilename,
                                    const std::string &outputfilename,
                                    bool output_unassigned=false,


### PR DESCRIPTION
Working branch. Will replace the `IParser` abstract class with a concrete class `ReadParser`. Imprinting reads in various formats (Fast[a,q] and BAM, initiallly) will be delegated by functor classes, which are declared in the `ReadParser` class using templates.
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?
