### PR TITLE
Refactor uint64_t vs HashIntoType

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2016-09-23  Tim Head  <betatim@gmail.com>
+
+   * khmer/_khmer.cc, lib/counting.{cc,hh}, lib/hashbits.{cc,hh},
+     lib/hashtable.hh, lib/hllcounter.{cc,hh}, lib/kmer_hash.cc,
+     tests/khmer_tst_utils.py, tests/test_functions.py: move away from using
+     HashIntoType as synonym to uint64.
+
 2016-09-21  Tim Head  <betatim@gmail.com>
 
    * .travis.yml: add python 3.5 to the build matrix and allow fast finishing

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -956,9 +956,9 @@ static int khmer_HashSet_contains(khmer_HashSet_Object * o, PyObject * val)
 {
     HashIntoType v;
     if (convert_PyObject_to_HashIntoType(val, v, 0)) {
-      if (set_contains(*o->hashes, v)) {
-          return 1;
-      }
+        if (set_contains(*o->hashes, v)) {
+            return 1;
+        }
     }
     return 0;
 }
@@ -3582,7 +3582,7 @@ static PyObject* _new_counting_hash(PyTypeObject * type, PyObject * args,
             } else if (PyInt_Check(size_o)) {
                 sizes.push_back(PyInt_AsLong(size_o));
             } else if (PyFloat_Check(size_o)) {
-              // XXX really? should be Float_AS_INT?
+                // XXX really? should be Float_AS_INT?
                 sizes.push_back(PyFloat_AS_DOUBLE(size_o));
             } else {
                 Py_DECREF(self);

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -3582,7 +3582,6 @@ static PyObject* _new_counting_hash(PyTypeObject * type, PyObject * args,
             } else if (PyInt_Check(size_o)) {
                 sizes.push_back(PyInt_AsLong(size_o));
             } else if (PyFloat_Check(size_o)) {
-                // XXX really? should be Float_AS_INT?
                 sizes.push_back(PyFloat_AS_DOUBLE(size_o));
             } else {
                 Py_DECREF(self);

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -89,13 +89,13 @@ BoundedCounterType CountingHash::get_max_count(const std::string &s)
     return max_count;
 }
 
-HashIntoType *
+uint64_t *
 CountingHash::abundance_distribution(
     read_parsers::IParser * parser,
     Hashbits *          tracking)
 {
-    HashIntoType * dist = new HashIntoType[MAX_BIGCOUNT + 1];
-    HashIntoType i;
+    uint64_t * dist = new uint64_t[MAX_BIGCOUNT + 1];
+    uint64_t i;
 
     for (i = 0; i <= MAX_BIGCOUNT; i++) {
         dist[i] = 0;
@@ -142,13 +142,13 @@ CountingHash::abundance_distribution(
 }
 
 
-HashIntoType * CountingHash::abundance_distribution(
+uint64_t * CountingHash::abundance_distribution(
     std::string filename,
     Hashbits *  tracking)
 {
     IParser* parser = IParser::get_parser(filename.c_str());
 
-    HashIntoType * distribution = abundance_distribution(parser, tracking);
+    uint64_t * distribution = abundance_distribution(parser, tracking);
     delete parser;
     return distribution;
 }
@@ -403,11 +403,11 @@ CountingHashFileReader::CountingHashFileReader(
         }
 
         for (unsigned int i = 0; i < ht._n_tables; i++) {
-            HashIntoType tablesize;
+            uint64_t tablesize;
 
             infile.read((char *) &save_tablesize, sizeof(save_tablesize));
 
-            tablesize = (HashIntoType) save_tablesize;
+            tablesize = save_tablesize;
             ht._tablesizes.push_back(tablesize);
 
             ht._counts[i] = new Byte[tablesize];
@@ -419,7 +419,7 @@ CountingHashFileReader::CountingHashFileReader(
             }
         }
 
-        HashIntoType n_counts = 0;
+        uint64_t n_counts = 0;
         infile.read((char *) &n_counts, sizeof(n_counts));
 
         if (n_counts) {

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -428,7 +428,7 @@ CountingHashFileReader::CountingHashFileReader(
             HashIntoType kmer;
             BoundedCounterType count;
 
-            for (HashIntoType n = 0; n < n_counts; n++) {
+            for (uint64_t n = 0; n < n_counts; n++) {
                 infile.read((char *) &kmer, sizeof(kmer));
                 infile.read((char *) &count, sizeof(count));
                 ht._bigcounts[kmer] = count;
@@ -530,7 +530,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
 
     ht._counts = new Byte*[ht._n_tables];
     for (unsigned int i = 0; i < ht._n_tables; i++) {
-        HashIntoType tablesize;
+        uint64_t tablesize;
 
         read_b = gzread(infile, (char *) &save_tablesize,
                         sizeof(save_tablesize));
@@ -548,12 +548,12 @@ CountingHashGzFileReader::CountingHashGzFileReader(
             throw khmer_file_exception(err);
         }
 
-        tablesize = (HashIntoType) save_tablesize;
+        tablesize = save_tablesize;
         ht._tablesizes.push_back(tablesize);
 
         ht._counts[i] = new Byte[tablesize];
 
-        HashIntoType loaded = 0;
+        uint64_t loaded = 0;
         while (loaded != tablesize) {
             unsigned long long  to_read_ll = tablesize - loaded;
             unsigned int        to_read_int;
@@ -581,7 +581,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
         }
     }
 
-    HashIntoType n_counts = 0;
+    uint64_t n_counts = 0;
     read_b = gzread(infile, (char *) &n_counts, sizeof(n_counts));
     if (read_b <= 0) {
         std::string gzerr = gzerror(infile, &read_b);
@@ -601,7 +601,7 @@ CountingHashGzFileReader::CountingHashGzFileReader(
         HashIntoType kmer;
         BoundedCounterType count;
 
-        for (HashIntoType n = 0; n < n_counts; n++) {
+        for (uint64_t n = 0; n < n_counts; n++) {
             int read_k = gzread(infile, (char *) &kmer, sizeof(kmer));
             int read_c = gzread(infile, (char *) &count, sizeof(count));
 
@@ -664,7 +664,7 @@ CountingHashFileWriter::CountingHashFileWriter(
         outfile.write((const char *) ht._counts[i], save_tablesize);
     }
 
-    HashIntoType n_counts = ht._bigcounts.size();
+    uint64_t n_counts = ht._bigcounts.size();
     outfile.write((const char *) &n_counts, sizeof(n_counts));
 
     if (n_counts) {
@@ -765,7 +765,7 @@ CountingHashGzFileWriter::CountingHashGzFileWriter(
         }
     }
 
-    HashIntoType n_counts = ht._bigcounts.size();
+    uint64_t n_counts = ht._bigcounts.size();
     gzwrite(outfile, (const char *) &n_counts, sizeof(n_counts));
 
     if (n_counts) {

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -83,10 +83,10 @@ class CountingHash : public khmer::Hashtable
 protected:
     bool _use_bigcount;		// keep track of counts > Bloom filter hash count threshold?
     uint32_t _bigcount_spin_lock;
-    std::vector<HashIntoType> _tablesizes;
+    std::vector<uint64_t> _tablesizes;
     size_t _n_tables;
-    HashIntoType _n_unique_kmers;
-    HashIntoType _occupied_bins;
+    uint64_t _n_unique_kmers;
+    uint64_t _occupied_bins;
 
     Byte ** _counts;
 
@@ -103,7 +103,7 @@ protected:
 public:
     KmerCountMap _bigcounts;
 
-    CountingHash( WordLength ksize, HashIntoType single_tablesize ) :
+    CountingHash( WordLength ksize, uint64_t single_tablesize ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
         _bigcount_spin_lock(false), _n_unique_kmers(0), _occupied_bins(0)
     {
@@ -112,7 +112,7 @@ public:
         _allocate_counters();
     }
 
-    CountingHash( WordLength ksize, std::vector<HashIntoType>& tablesizes ) :
+    CountingHash( WordLength ksize, std::vector<uint64_t>& tablesizes ) :
         khmer::Hashtable(ksize), _use_bigcount(false),
         _bigcount_spin_lock(false), _tablesizes(tablesizes),
         _n_unique_kmers(0), _occupied_bins(0)
@@ -159,12 +159,12 @@ public:
         return !x;
     }
 
-    std::vector<HashIntoType> get_tablesizes() const
+    std::vector<uint64_t> get_tablesizes() const
     {
         return _tablesizes;
     }
 
-    virtual const HashIntoType n_unique_kmers() const
+    virtual const uint64_t n_unique_kmers() const
     {
         return _n_unique_kmers;
     }
@@ -187,7 +187,7 @@ public:
     }
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const
+    virtual const uint64_t n_occupied() const
     {
         return _occupied_bins;
     }
@@ -204,7 +204,7 @@ public:
         unsigned int  n_full	  = 0;
 
         for (unsigned int i = 0; i < _n_tables; i++) {
-            const HashIntoType bin = khash % _tablesizes[i];
+            const uint64_t bin = khash % _tablesizes[i];
             Byte current_count = _counts[ i ][ bin ];
             if (!is_new_kmer) {
                 if (current_count == 0) {
@@ -288,9 +288,9 @@ public:
 
     BoundedCounterType get_max_count(const std::string &s);
 
-    HashIntoType * abundance_distribution(read_parsers::IParser * parser,
+    uint64_t * abundance_distribution(read_parsers::IParser * parser,
                                           Hashbits * tracking);
-    HashIntoType * abundance_distribution(std::string filename,
+    uint64_t * abundance_distribution(std::string filename,
                                           Hashbits * tracking);
 
     unsigned long trim_on_abundance(std::string seq,

--- a/lib/counting.hh
+++ b/lib/counting.hh
@@ -289,9 +289,9 @@ public:
     BoundedCounterType get_max_count(const std::string &s);
 
     uint64_t * abundance_distribution(read_parsers::IParser * parser,
-                                          Hashbits * tracking);
+                                      Hashbits * tracking);
     uint64_t * abundance_distribution(std::string filename,
-                                          Hashbits * tracking);
+                                      Hashbits * tracking);
 
     unsigned long trim_on_abundance(std::string seq,
                                     BoundedCounterType min_abund) const;

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -163,12 +163,12 @@ void Hashbits::load(std::string infilename)
 
         _counts = new Byte*[_n_tables];
         for (unsigned int i = 0; i < _n_tables; i++) {
-            HashIntoType tablesize;
+            uint64_t tablesize;
             unsigned long long tablebytes;
 
             infile.read((char *) &save_tablesize, sizeof(save_tablesize));
 
-            tablesize = (HashIntoType) save_tablesize;
+            tablesize = save_tablesize;
             _tablesizes.push_back(tablesize);
 
             tablebytes = tablesize / 8 + 1;
@@ -204,10 +204,10 @@ void Hashbits::update_from(const Hashbits &other)
     for (unsigned int table_num = 0; table_num < _n_tables; table_num++) {
         Byte * me = _counts[table_num];
         Byte * ot = other._counts[table_num];
-        HashIntoType tablesize = _tablesizes[table_num];
-        HashIntoType tablebytes = tablesize / 8 + 1;
+        uint64_t tablesize = _tablesizes[table_num];
+        uint64_t tablebytes = tablesize / 8 + 1;
 
-        for (HashIntoType index = 0; index < tablebytes; index++) {
+        for (uint64_t index = 0; index < tablebytes; index++) {
             // Bloom filters can be unioned with bitwise OR.
             // First, get the new value
             tmp = me[index] | ot[index];

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2010-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -55,10 +55,10 @@ class LabelHash;
 class Hashbits : public khmer::Hashtable
 {
 protected:
-    std::vector<HashIntoType> _tablesizes;
+    std::vector<uint64_t> _tablesizes;
     size_t _n_tables;
-    HashIntoType _occupied_bins;
-    HashIntoType _n_unique_kmers;
+    uint64_t _occupied_bins;
+    uint64_t _n_unique_kmers;
     Byte ** _counts;
 
     virtual void _allocate_counters()
@@ -68,8 +68,8 @@ protected:
         _counts = new Byte*[_n_tables];
 
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType tablesize = _tablesizes[i];
-            HashIntoType tablebytes = tablesize / 8 + 1;
+            uint64_t tablesize = _tablesizes[i];
+            uint64_t tablebytes = tablesize / 8 + 1;
 
             _counts[i] = new Byte[tablebytes];
             memset(_counts[i], 0, tablebytes);
@@ -77,7 +77,7 @@ protected:
     }
 
 public:
-    Hashbits(WordLength ksize, std::vector<HashIntoType>& tablesizes)
+    Hashbits(WordLength ksize, std::vector<uint64_t>& tablesizes)
         : khmer::Hashtable(ksize),
           _tablesizes(tablesizes)
     {
@@ -103,7 +103,7 @@ public:
     }
 
     // Accessors for protected/private table info members
-    std::vector<HashIntoType> get_tablesizes() const
+    std::vector<uint64_t> get_tablesizes() const
     {
         return _tablesizes;
     }
@@ -117,12 +117,12 @@ public:
     virtual void load(std::string);
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const
+    virtual const uint64_t n_occupied() const
     {
         return _occupied_bins;
     }
 
-    virtual const HashIntoType n_unique_kmers() const
+    virtual const uint64_t n_unique_kmers() const
     {
         return _n_unique_kmers;
     }
@@ -150,8 +150,8 @@ public:
         bool is_new_kmer = false;
 
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType bin = khash % _tablesizes[i];
-            HashIntoType byte = bin / 8;
+            uint64_t bin = khash % _tablesizes[i];
+            uint64_t byte = bin / 8;
             unsigned char bit = (unsigned char)(1 << (bin % 8));
 
             unsigned char bits_orig = __sync_fetch_and_or( *(_counts + i) +
@@ -194,8 +194,8 @@ public:
     virtual const BoundedCounterType get_count(HashIntoType khash) const
     {
         for (size_t i = 0; i < _n_tables; i++) {
-            HashIntoType bin = khash % _tablesizes[i];
-            HashIntoType byte = bin / 8;
+            uint64_t bin = khash % _tablesizes[i];
+            uint64_t byte = bin / 8;
             unsigned char bit = bin % 8;
 
             if (!(_counts[i][byte] & (1 << bit))) {

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -200,10 +200,10 @@ public:
                           float &stddev);
 
     // number of unique k-mers
-    virtual const HashIntoType n_unique_kmers() const = 0;
+    virtual const uint64_t n_unique_kmers() const = 0;
 
     // count number of occupied bins
-    virtual const HashIntoType n_occupied() const = 0;
+    virtual const uint64_t n_occupied() const = 0;
 
     // partitioning stuff
     void _validate_pmap()
@@ -287,7 +287,7 @@ public:
     virtual BoundedCounterType test_and_set_bits(const char * kmer) = 0;
     virtual BoundedCounterType test_and_set_bits(HashIntoType khash) = 0;
 
-    virtual std::vector<HashIntoType> get_tablesizes() const = 0;
+    virtual std::vector<uint64_t> get_tablesizes() const = 0;
     virtual const size_t n_tables() const = 0;
 
     size_t trim_on_stoptags(std::string sequence) const;

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -332,7 +332,7 @@ double HLLCounter::_Ep()
     return E;
 }
 
-HashIntoType HLLCounter::estimate_cardinality()
+uint64_t HLLCounter::estimate_cardinality()
 {
     long V = count(this->M.begin(), this->M.end(), 0);
 
@@ -348,7 +348,7 @@ HashIntoType HLLCounter::estimate_cardinality()
 void HLLCounter::add(const std::string &value)
 {
     HashIntoType x = khmer::_hash_murmur(value);
-    HashIntoType j = x & (this->m - 1);
+    uint64_t j = x & (this->m - 1);
     this->M[j] = std::max(this->M[j], get_rho(x >> this->p, 64 - this->p));
 }
 

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2014-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -75,7 +75,7 @@ public:
     unsigned int check_and_process_read(std::string &,
                                         bool &);
     bool check_and_normalize_read(std::string &) const;
-    HashIntoType estimate_cardinality();
+    uint64_t estimate_cardinality();
     void merge(HLLCounter &);
     virtual ~HLLCounter() {}
 

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -1,7 +1,7 @@
 /*
 This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 Copyright (C) 2014-2015, Michigan State University.
-Copyright (C) 2015, The Regents of the University of California.
+Copyright (C) 2015-2016, The Regents of the University of California.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -178,7 +178,7 @@ HashIntoType _hash_murmur(const std::string& kmer)
 HashIntoType _hash_murmur(const std::string& kmer,
                           HashIntoType& h, HashIntoType& r)
 {
-    HashIntoType out[2];
+    uint64_t out[2];
     uint32_t seed = 0;
     MurmurHash3_x64_128((void *)kmer.c_str(), kmer.size(), seed, &out);
     h = out[0];

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -131,8 +131,8 @@ def _runscript(scriptname, sandbox=False):
     if os.path.isfile(scriptfile):
         if os.path.isfile(scriptfile):
             exec(  # pylint: disable=exec-used
-                 compile(open(scriptfile).read(), scriptfile, 'exec'),
-                 namespace)
+                compile(open(scriptfile).read(), scriptfile, 'exec'),
+                namespace)
             return 0
     elif sandbox:
         pytest.skip("sandbox tests are only run in a repository.")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -126,7 +126,7 @@ def test_reverse_hash_raises():
     with pytest.raises(TypeError) as excinfo:
         khmer.reverse_hash('2345', 4)
 
-    assert 'must be int' in str(excinfo.value)
+    assert 'int' in str(excinfo.value)
 
 
 def test_hash_murmur3():

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -104,8 +104,8 @@ def test_reverse_hash():
 
 def test_reverse_hash_longs():
     # test explicitly with long integers, only needed for python2
-    # the builtin `long` exists in the global scope
-    global long
+    # the builtin `long` exists in the global scope only
+    global long # pylint: disable=global-variable-undefined
     if sys.version_info > (3,):
         long = int
 
@@ -124,7 +124,7 @@ def test_reverse_hash_longs():
 
 def test_reverse_hash_raises():
     with pytest.raises(TypeError) as excinfo:
-        s = khmer.reverse_hash('2345', 4)
+        khmer.reverse_hash('2345', 4)
 
     assert 'must be int' in str(excinfo.value)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -40,6 +40,7 @@ import khmer
 import os
 import sys
 import collections
+import pytest
 from . import khmer_tst_utils as utils
 from khmer.utils import (check_is_pair, broken_paired_reader, check_is_left,
                          check_is_right)
@@ -55,6 +56,9 @@ def test_forward_hash():
     assert khmer.forward_hash('TTTT', 4) == 0
     assert khmer.forward_hash('CCCC', 4) == 170
     assert khmer.forward_hash('GGGG', 4) == 170
+
+    h = 13607885392109549066
+    assert khmer.forward_hash('GGTTGACGGGGCTCAGGGGGCGGCTGACTCCG', 32) == h
 
 
 def test_get_file_writer_fail():
@@ -96,6 +100,33 @@ def test_reverse_hash():
 
     s = khmer.reverse_hash(255, 4)
     assert s == "GGGG"
+
+
+def test_reverse_hash_longs():
+    # test explicitly with long integers, only needed for python2
+    # the builtin `long` exists in the global scope
+    global long
+    if sys.version_info > (3,):
+        long = int
+
+    s = khmer.reverse_hash(long(0), 4)
+    assert s == "AAAA"
+
+    s = khmer.reverse_hash(long(85), 4)
+    assert s == "TTTT"
+
+    s = khmer.reverse_hash(long(170), 4)
+    assert s == "CCCC"
+
+    s = khmer.reverse_hash(long(255), 4)
+    assert s == "GGGG"
+
+
+def test_reverse_hash_raises():
+    with pytest.raises(TypeError) as excinfo:
+        s = khmer.reverse_hash('2345', 4)
+
+    assert 'must be int' in str(excinfo.value)
 
 
 def test_hash_murmur3():


### PR DESCRIPTION
In some places `HashIntoType` was used instead of a larger integer. This PR fixes that. While it makes no difference in the current stage as the two are synonyms in the future we will have a special type for hash values which is not equal to `uint64_t` anymore.

Prep work for #1444 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
