### PR TITLE
Beyond 64bit hash values

### DIFF
--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -259,7 +259,7 @@ double ep_sum(double acc, int b)
 
 int get_rho(HashIntoType w, int max_width)
 {
-    return max_width - floor(log2(w));
+    return max_width - floor(log2(w.as_ull()));
 }
 
 HLLCounter::HLLCounter(double error_rate, WordLength ksize)
@@ -348,7 +348,7 @@ uint64_t HLLCounter::estimate_cardinality()
 void HLLCounter::add(const std::string &value)
 {
     HashIntoType x = khmer::_hash_murmur(value);
-    uint64_t j = x & (this->m - 1);
+    uint64_t j = x.as_ull() & (this->m - 1);
     this->M[j] = std::max(this->M[j], get_rho(x >> this->p, 64 - this->p));
 }
 

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -106,7 +106,7 @@ typedef unsigned long long int ExactCounterType;
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 //typedef unsigned long long int HashIntoType;
 typedef BigHashType HashIntoType;
-const unsigned char KSIZE_MAX = 40;//sizeof(HashIntoType)*4;
+const unsigned char KSIZE_MAX = 64;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -106,7 +106,7 @@ typedef unsigned long long int ExactCounterType;
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 //typedef unsigned long long int HashIntoType;
 typedef BigHashType HashIntoType;
-const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
+const unsigned char KSIZE_MAX = 40;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,12 +99,14 @@ private:\
 
 namespace khmer
 {
+class BigHashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
-typedef unsigned long long int HashIntoType;
-const unsigned char KSIZE_MAX = sizeof(HashIntoType)*4;
+//typedef unsigned long long int HashIntoType;
+typedef BigHashType HashIntoType;
+const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    BigHashType h, r;
+    HashIntoType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -40,6 +40,7 @@ Contact: khmer-project@idyll.org
 #include <string.h>
 #include <algorithm>
 #include <string>
+#include <iostream>
 
 #include "MurmurHash3.h"
 #include "khmer.hh"
@@ -63,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashIntoType h = 0, r = 0;
+    BigHashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
@@ -86,8 +87,8 @@ HashIntoType _hash(const char * kmer, const WordLength k,
 
 HashIntoType _hash(const char * kmer, const WordLength k)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     return khmer::_hash(kmer, k, h, r);
 }
@@ -96,8 +97,8 @@ HashIntoType _hash(const char * kmer, const WordLength k)
 
 HashIntoType _hash_forward(const char * kmer, WordLength k)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
 
     khmer::_hash(kmer, k, h, r);
@@ -169,8 +170,8 @@ std::string _revcomp(const std::string& kmer)
 
 HashIntoType _hash_murmur(const std::string& kmer)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     return khmer::_hash_murmur(kmer, h, r);
 }
@@ -192,8 +193,8 @@ HashIntoType _hash_murmur(const std::string& kmer,
 
 HashIntoType _hash_murmur_forward(const std::string& kmer)
 {
-    HashIntoType h = 0;
-    HashIntoType r = 0;
+    HashIntoType h;
+    HashIntoType r;
 
     khmer::_hash_murmur(kmer, h, r);
     return h;

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -38,11 +38,14 @@ Contact: khmer-project@idyll.org
 #ifndef KMER_HASH_HH
 #define KMER_HASH_HH
 
+#include <array>
+#include <iostream>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+#include <tuple>
 
 #include "khmer.hh"
 
@@ -113,6 +116,146 @@ HashIntoType _hash_murmur(const std::string& kmer);
 HashIntoType _hash_murmur(const std::string& kmer,
                           HashIntoType& h, HashIntoType& r);
 HashIntoType _hash_murmur_forward(const std::string& kmer);
+
+
+//template <typename T, std::size_t N>
+class BigHashType
+{
+public:
+	std::array<uint8_t, 8> bytes{{0}};
+	constexpr static std::size_t N{8};
+
+	BigHashType() = default;
+	BigHashType(const BigHashType &) = default;
+	BigHashType &operator=(const BigHashType &) = default;
+	BigHashType(BigHashType &&) = default;
+	BigHashType &operator=(BigHashType &&) = default;
+
+	BigHashType(const uint64_t value) {
+		for (std::size_t i = 0; i < 8; i++) {
+			bytes[N - 1 - i] = (value >> (i * 8));
+		}
+	}
+
+	uint64_t as_ull() const {
+		uint64_t x(0);
+		int offset(N-8);
+		for (std::size_t i = offset; i < N; i++) {
+			x+= ((uint64_t)bytes[i])<<((N-i-1)*8);
+		}
+		return x;
+	}
+
+	BigHashType& operator=(const uint64_t value) {
+		unsigned int offset(N-8);
+		for (unsigned int i = 0; i < N - offset; i++) {
+			bytes[N - 1 - i] = (value >> (i * 8));
+		}
+		return *this;
+	}
+
+	BigHashType operator>>(int shift) {
+		BigHashType shifted{*this};
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (unsigned int i = 0; i < N; i++){
+				next_ = (shifted.bytes[i] & 1) ? 0x80 : 0;
+				shifted.bytes[i] = carry | (shifted.bytes[i] >> 1);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	BigHashType operator<<(int shift) {
+		BigHashType shifted{*this};
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (int i = N - 1; i >= 0; i--){
+				next_ = (shifted.bytes[i] & 128) ? 1 : 0;
+				shifted.bytes[i] = carry | ((shifted.bytes[i] << 1) & 255);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	BigHashType& operator<<=(int rhs){
+		*this = *this << rhs;
+		return *this;
+	}
+
+	BigHashType& operator>>=(int rhs){
+		*this = *this >> rhs;
+		return *this;
+	}
+
+	BigHashType operator^(const BigHashType& rhs){
+		BigHashType tmp;
+		for (unsigned int i = 0; i < N; i++) {
+			tmp.bytes[i] = bytes[i] ^ rhs.bytes[i];
+		}
+		return tmp;
+	}
+
+	BigHashType operator|(const uint64_t rhs) {
+		BigHashType tmp;
+		const BigHashType rhs_{rhs};
+
+		for (unsigned int i = 0; i < N; i++) {
+			tmp.bytes[i] = bytes[i] | rhs_.bytes[i];
+		}
+		return tmp;
+	}
+
+	BigHashType& operator|=(const uint64_t rhs) {
+		// The RHS only has the last 8 bytes set
+		const unsigned int offset(N - 8);
+		const BigHashType rhs_{rhs};
+		for (unsigned int i = offset; i < N; i++) {
+			bytes[i] |= rhs_.bytes[i];
+		}
+		return *this;
+	}
+
+	BigHashType& operator&=(const BigHashType& rhs) {
+		for (unsigned int i = 0; i < N; i++) {
+			bytes[i] &= rhs.bytes[i];
+		}
+		return *this;
+	}
+
+	BigHashType operator&(const BigHashType& rhs) {
+		BigHashType tmp;
+		for (unsigned int i = 0; i < N; i++) {
+			tmp.bytes[i] = bytes[i] & rhs.bytes[i];
+		}
+		return tmp;
+	}
+
+	uint8_t operator&(const uint8_t rhs) {
+		return bytes[N - 1] & rhs;
+	}
+
+	uint64_t operator%(const uint64_t mod) {
+		uint64_t ull(as_ull());
+		return ull % mod;
+	}
+
+	friend bool operator<(const BigHashType& lhs, const BigHashType& rhs) {
+		return std::tie(lhs.bytes) < std::tie(rhs.bytes);
+	}
+
+	friend bool operator==(const BigHashType& lhs, const BigHashType& rhs){
+		return lhs.bytes == rhs.bytes;
+	}
+
+	friend bool operator!=(const BigHashType& lhs, const BigHashType& rhs){
+		return lhs.bytes != rhs.bytes;
+	}
+};
 
 /**
  * \class Kmer

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -120,8 +120,8 @@ HashIntoType _hash_murmur_forward(const std::string& kmer);
 
 class BigHashType {
 public:
-  std::array<uint8_t, 10> bytes{};
-  constexpr static std::size_t N{10};
+  std::array<uint8_t, 16> bytes{};
+  constexpr static std::size_t N{16};
 
   BigHashType() = default;
   BigHashType(const BigHashType &) = default;

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -118,9 +118,7 @@ HashIntoType _hash_murmur(const std::string& kmer,
 HashIntoType _hash_murmur_forward(const std::string& kmer);
 
 
-//template <typename T, std::size_t N>
-class BigHashType
-{
+class BigHashType {
 public:
   std::array<uint8_t, 10> bytes{{0}};
   constexpr static std::size_t N{10};
@@ -139,122 +137,120 @@ public:
 
   uint64_t as_ull() const {
     uint64_t x(0);
-    int offset(N-8);
+    int offset(N - 8);
     for (std::size_t i = offset; i < N; i++) {
-      x+= ((uint64_t)bytes[i])<<((N-i-1)*8);
+      x += ((uint64_t)bytes[i]) << ((N - i - 1) * 8);
     }
     return x;
   }
 
-  BigHashType& operator=(const uint64_t value) {
-    unsigned int offset(N-8);
+  BigHashType &operator=(const uint64_t value) {
+    unsigned int offset(N - 8);
     for (unsigned int i = 0; i < N - offset; i++) {
       bytes[N - 1 - i] = (value >> (i * 8));
     }
     return *this;
   }
 
-	BigHashType operator>>(int shift) {
-		BigHashType shifted{*this};
-		int next_(0);
-		for (int s = 0; s < shift; s++) {
-			int carry(0);
-			for (unsigned int i = 0; i < N; i++){
-				next_ = (shifted.bytes[i] & 1) ? 0x80 : 0;
-				shifted.bytes[i] = carry | (shifted.bytes[i] >> 1);
-				carry = next_;
-			}
-		}
-		return shifted;
-	}
+  BigHashType operator>>(int shift) {
+    BigHashType shifted{*this};
+    int next_(0);
+    for (int s = 0; s < shift; s++) {
+      int carry(0);
+      for (unsigned int i = 0; i < N; i++) {
+        next_ = (shifted.bytes[i] & 1) ? 0x80 : 0;
+        shifted.bytes[i] = carry | (shifted.bytes[i] >> 1);
+        carry = next_;
+      }
+    }
+    return shifted;
+  }
 
-	BigHashType operator<<(int shift) {
-		BigHashType shifted{*this};
-		int next_(0);
-		for (int s = 0; s < shift; s++) {
-			int carry(0);
-			for (int i = N - 1; i >= 0; i--){
-				next_ = (shifted.bytes[i] & 128) ? 1 : 0;
-				shifted.bytes[i] = carry | ((shifted.bytes[i] << 1) & 255);
-				carry = next_;
-			}
-		}
-		return shifted;
-	}
+  BigHashType operator<<(int shift) {
+    BigHashType shifted{*this};
+    int next_(0);
+    for (int s = 0; s < shift; s++) {
+      int carry(0);
+      for (int i = N - 1; i >= 0; i--) {
+        next_ = (shifted.bytes[i] & 128) ? 1 : 0;
+        shifted.bytes[i] = carry | ((shifted.bytes[i] << 1) & 255);
+        carry = next_;
+      }
+    }
+    return shifted;
+  }
 
-	BigHashType& operator<<=(int rhs){
-		*this = *this << rhs;
-		return *this;
-	}
+  BigHashType &operator<<=(int rhs) {
+    *this = *this << rhs;
+    return *this;
+  }
 
-	BigHashType& operator>>=(int rhs){
-		*this = *this >> rhs;
-		return *this;
-	}
+  BigHashType &operator>>=(int rhs) {
+    *this = *this >> rhs;
+    return *this;
+  }
 
-	BigHashType operator^(const BigHashType& rhs){
-		BigHashType tmp;
-		for (unsigned int i = 0; i < N; i++) {
-			tmp.bytes[i] = bytes[i] ^ rhs.bytes[i];
-		}
-		return tmp;
-	}
+  BigHashType operator^(const BigHashType &rhs) {
+    BigHashType tmp;
+    for (unsigned int i = 0; i < N; i++) {
+      tmp.bytes[i] = bytes[i] ^ rhs.bytes[i];
+    }
+    return tmp;
+  }
 
-	BigHashType operator|(const uint64_t rhs) {
-		BigHashType tmp;
-		const BigHashType rhs_{rhs};
+  BigHashType operator|(const uint64_t rhs) {
+    BigHashType tmp;
+    const BigHashType rhs_{rhs};
 
-		for (unsigned int i = 0; i < N; i++) {
-			tmp.bytes[i] = bytes[i] | rhs_.bytes[i];
-		}
-		return tmp;
-	}
+    for (unsigned int i = 0; i < N; i++) {
+      tmp.bytes[i] = bytes[i] | rhs_.bytes[i];
+    }
+    return tmp;
+  }
 
-	BigHashType& operator|=(const uint64_t rhs) {
-		// The RHS only has the last 8 bytes set
-		const unsigned int offset(N - 8);
-		const BigHashType rhs_{rhs};
-		for (unsigned int i = offset; i < N; i++) {
-			bytes[i] |= rhs_.bytes[i];
-		}
-		return *this;
-	}
+  BigHashType &operator|=(const uint64_t rhs) {
+    // The RHS only has the last 8 bytes set
+    const unsigned int offset(N - 8);
+    const BigHashType rhs_{rhs};
+    for (unsigned int i = offset; i < N; i++) {
+      bytes[i] |= rhs_.bytes[i];
+    }
+    return *this;
+  }
 
-	BigHashType& operator&=(const BigHashType& rhs) {
-		for (unsigned int i = 0; i < N; i++) {
-			bytes[i] &= rhs.bytes[i];
-		}
-		return *this;
-	}
+  BigHashType &operator&=(const BigHashType &rhs) {
+    for (unsigned int i = 0; i < N; i++) {
+      bytes[i] &= rhs.bytes[i];
+    }
+    return *this;
+  }
 
-	BigHashType operator&(const BigHashType& rhs) {
-		BigHashType tmp;
-		for (unsigned int i = 0; i < N; i++) {
-			tmp.bytes[i] = bytes[i] & rhs.bytes[i];
-		}
-		return tmp;
-	}
+  BigHashType operator&(const BigHashType &rhs) {
+    BigHashType tmp;
+    for (unsigned int i = 0; i < N; i++) {
+      tmp.bytes[i] = bytes[i] & rhs.bytes[i];
+    }
+    return tmp;
+  }
 
-	uint8_t operator&(const uint8_t rhs) {
-		return bytes[N - 1] & rhs;
-	}
+  uint8_t operator&(const uint8_t rhs) { return bytes[N - 1] & rhs; }
 
-	uint64_t operator%(const uint64_t mod) {
-		uint64_t ull(as_ull());
-		return ull % mod;
-	}
+  uint64_t operator%(const uint64_t mod) {
+    uint64_t ull(as_ull());
+    return ull % mod;
+  }
 
-	friend bool operator<(const BigHashType& lhs, const BigHashType& rhs) {
-		return std::tie(lhs.bytes) < std::tie(rhs.bytes);
-	}
+  friend bool operator<(const BigHashType &lhs, const BigHashType &rhs) {
+    return std::tie(lhs.bytes) < std::tie(rhs.bytes);
+  }
 
-	friend bool operator==(const BigHashType& lhs, const BigHashType& rhs){
-		return lhs.bytes == rhs.bytes;
-	}
+  friend bool operator==(const BigHashType &lhs, const BigHashType &rhs) {
+    return lhs.bytes == rhs.bytes;
+  }
 
-	friend bool operator!=(const BigHashType& lhs, const BigHashType& rhs){
-		return lhs.bytes != rhs.bytes;
-	}
+  friend bool operator!=(const BigHashType &lhs, const BigHashType &rhs) {
+    return lhs.bytes != rhs.bytes;
+  }
 };
 
 /**

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -122,37 +122,37 @@ HashIntoType _hash_murmur_forward(const std::string& kmer);
 class BigHashType
 {
 public:
-	std::array<uint8_t, 8> bytes{{0}};
-	constexpr static std::size_t N{8};
+  std::array<uint8_t, 10> bytes{{0}};
+  constexpr static std::size_t N{10};
 
-	BigHashType() = default;
-	BigHashType(const BigHashType &) = default;
-	BigHashType &operator=(const BigHashType &) = default;
-	BigHashType(BigHashType &&) = default;
-	BigHashType &operator=(BigHashType &&) = default;
+  BigHashType() = default;
+  BigHashType(const BigHashType &) = default;
+  BigHashType &operator=(const BigHashType &) = default;
+  BigHashType(BigHashType &&) = default;
+  BigHashType &operator=(BigHashType &&) = default;
 
-	BigHashType(const uint64_t value) {
-		for (std::size_t i = 0; i < 8; i++) {
-			bytes[N - 1 - i] = (value >> (i * 8));
-		}
-	}
+  BigHashType(const uint64_t value) {
+    for (std::size_t i = 0; i < 8; i++) {
+      bytes[N - 1 - i] = (value >> (i * 8));
+    }
+  }
 
-	uint64_t as_ull() const {
-		uint64_t x(0);
-		int offset(N-8);
-		for (std::size_t i = offset; i < N; i++) {
-			x+= ((uint64_t)bytes[i])<<((N-i-1)*8);
-		}
-		return x;
-	}
+  uint64_t as_ull() const {
+    uint64_t x(0);
+    int offset(N-8);
+    for (std::size_t i = offset; i < N; i++) {
+      x+= ((uint64_t)bytes[i])<<((N-i-1)*8);
+    }
+    return x;
+  }
 
-	BigHashType& operator=(const uint64_t value) {
-		unsigned int offset(N-8);
-		for (unsigned int i = 0; i < N - offset; i++) {
-			bytes[N - 1 - i] = (value >> (i * 8));
-		}
-		return *this;
-	}
+  BigHashType& operator=(const uint64_t value) {
+    unsigned int offset(N-8);
+    for (unsigned int i = 0; i < N - offset; i++) {
+      bytes[N - 1 - i] = (value >> (i * 8));
+    }
+    return *this;
+  }
 
 	BigHashType operator>>(int shift) {
 		BigHashType shifted{*this};

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -120,7 +120,7 @@ HashIntoType _hash_murmur_forward(const std::string& kmer);
 
 class BigHashType {
 public:
-  std::array<uint8_t, 10> bytes{{0}};
+  std::array<uint8_t, 10> bytes{};
   constexpr static std::size_t N{10};
 
   BigHashType() = default;

--- a/lib/read_aligner.cc
+++ b/lib/read_aligner.cc
@@ -531,7 +531,7 @@ Alignment* ReadAligner::Align(const std::string& read)
         return _empty_alignment();
     }
 
-    HashIntoType fhash = 0, rhash = 0;
+    HashIntoType fhash, rhash;
     _hash(start.kmer, k, fhash, rhash);
 
 #if READ_ALIGNER_DEBUG
@@ -609,7 +609,7 @@ Alignment* ReadAligner::AlignForward(const std::string& read)
         return _empty_alignment();
     }
 
-    HashIntoType fhash = 0, rhash = 0;
+    HashIntoType fhash, rhash;
     _hash(start.kmer, k, fhash, rhash);
 
 #if READ_ALIGNER_DEBUG

--- a/lib/read_aligner.hh
+++ b/lib/read_aligner.hh
@@ -234,7 +234,7 @@ private:
 
     HashIntoType comp_bitmask(WordLength k)
     {
-        HashIntoType ret = 0;
+        HashIntoType ret;
         for (size_t i = 0; i < k; i++) {
             ret = (ret << 2) | 3;
         }

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -132,7 +132,7 @@ size_t SubsetPartition::output_partitioned_file(
     Read read;
     string seq;
 
-    HashIntoType kmer = 0;
+    HashIntoType kmer;
 
     const unsigned int ksize = _ht->ksize();
 
@@ -515,17 +515,18 @@ void SubsetPartition::do_partition(
     CallbackFn		callback,
     void *		callback_data)
 {
+    HashIntoType empty;
     unsigned int total_reads = 0;
 
     SeenSet tagged_kmers;
     SeenSet::const_iterator si, end;
 
-    if (first_kmer) {
+    if (first_kmer != empty) {
         si = _ht->all_tags.find(first_kmer);
     } else {
         si = _ht->all_tags.begin();
     }
-    if (last_kmer) {
+    if (last_kmer != empty) {
         end = _ht->all_tags.find(last_kmer);
     } else {
         end = _ht->all_tags.end();
@@ -546,7 +547,7 @@ void SubsetPartition::do_partition(
 
         // run callback, if specified
         if (total_reads % CALLBACK_PERIOD == 0 && callback) {
-            cout << "...subset-part " << first_kmer << "-" << last_kmer << ": "
+            cout << "...subset-part " << first_kmer.as_ull() << "-" << last_kmer.as_ull() << ": "
                  << total_reads << " <- " << next_partition_id << "\n";
 #if 0 // @CTB
             try {
@@ -574,16 +575,17 @@ void SubsetPartition::do_partition_with_abundance(
     void *		callback_data)
 {
     unsigned int total_reads = 0;
+    HashIntoType empty;
 
     SeenSet tagged_kmers;
     SeenSet::const_iterator si, end;
 
-    if (first_kmer) {
+    if (first_kmer != empty) {
         si = _ht->all_tags.find(first_kmer);
     } else {
         si = _ht->all_tags.begin();
     }
-    if (last_kmer) {
+    if (last_kmer != empty) {
         end = _ht->all_tags.find(last_kmer);
     } else {
         end = _ht->all_tags.end();
@@ -606,7 +608,7 @@ void SubsetPartition::do_partition_with_abundance(
 
         // run callback, if specified
         if (total_reads % CALLBACK_PERIOD == 0 && callback) {
-            cout << "...subset-part " << first_kmer << "-" << last_kmer << ": "
+            cout << "...subset-part " << first_kmer.as_ull() << "-" << last_kmer.as_ull() << ": "
                  << total_reads << " <- " << next_partition_id << "\n";
 #if 0 // @CTB
             try {

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -100,6 +100,27 @@ def test_forward_hash_no_rc_33mer():
         h = khmer.forward_hash_no_rc(kmer32 + base, 33)
         assert h == h33, base
 
+        kmer33 = kmer32 + base
+        for twobit, base in ((0, 'A'), (1, 'T'), (2, 'C'), (3, 'G')):
+            h34 = (h33 << 2) | twobit
+            h = khmer.forward_hash_no_rc(kmer33 + base, 34)
+            assert kmer33 + base == khmer.reverse_hash(h, 34)
+            assert h == h34, base
+
+            kmer34 = kmer33 + base
+            for twobit, base in ((0, 'A'), (1, 'T'), (2, 'C'), (3, 'G')):
+                h35 = (h34 << 2) | twobit
+                h = khmer.forward_hash_no_rc(kmer34 + base, 35)
+                assert kmer34 + base == khmer.reverse_hash(h, 35)
+                assert h == h35, base
+
+                kmer35 = kmer34 + base
+                for twobit, base in ((0, 'A'), (1, 'T'), (2, 'C'), (3, 'G')):
+                    h36 = (h35 << 2) | twobit
+                    h = khmer.forward_hash_no_rc(kmer35 + base, 36)
+                    assert kmer35 + base == khmer.reverse_hash(h, 36)
+                    assert h == h36, base
+
 
 def test_reverse_hash():
     s = khmer.reverse_hash(0, 4)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -89,6 +89,18 @@ def test_forward_hash_no_rc():
     assert h == 255, h
 
 
+def test_forward_hash_no_rc_33mer():
+    # check that k-mers with k=33 are dealt with correctly
+    # a 33-mer is magic as it is the first to go beyond 64bit
+    kmer32 = 'GGTTGACGGGGCTCAGGGGGCGGCTGACTCCG'
+    h32 = khmer.forward_hash_no_rc(kmer32, 32)
+
+    for twobit, base in ((0, 'A'), (1, 'T'), (2, 'C'), (3, 'G')):
+        h33 = (h32 << 2) | twobit
+        h = khmer.forward_hash_no_rc(kmer32 + base, 33)
+        assert h == h33, base
+
+
 def test_reverse_hash():
     s = khmer.reverse_hash(0, 4)
     assert s == "AAAA"
@@ -101,6 +113,18 @@ def test_reverse_hash():
 
     s = khmer.reverse_hash(255, 4)
     assert s == "GGGG"
+
+
+def test_reverse_hash_33mer():
+    # check that k-mers with k=33 are dealt with correctly
+    # a 33-mer is magic as it is the first to go beyond 64bit
+    kmer32 = 'GGTTGACGGGGCTCAGGGGGCGGCTGACTCCG'
+    h32 = khmer.forward_hash_no_rc(kmer32, 32)
+
+    for twobit, base in ((0, 'A'), (1, 'T'), (2, 'C'), (3, 'G')):
+        h33 = (h32 << 2) | twobit
+        kmer33 = khmer.reverse_hash(h33, 33)
+        assert kmer32 + base == kmer33, base
 
 
 def test_reverse_hash_longs():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -432,7 +432,7 @@ def test_save_load_tagset():
     fp = open(outfile, 'rb')
     data = fp.read()
     fp.close()
-    assert len(data) == 30, len(data)
+    assert len(data) == 32, len(data)
 
 
 def test_save_load_tagset_noclear():
@@ -454,7 +454,7 @@ def test_save_load_tagset_noclear():
     fp = open(outfile, 'rb')
     data = fp.read()
     fp.close()
-    assert len(data) == 38, len(data)
+    assert len(data) == 42, len(data)
 
 
 def test_stop_traverse():


### PR DESCRIPTION
This is another extract from #1444. This implements a type that can be used with hash values >64bits.
- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?
