### PR TITLE
Prevents -N from being set higher than 20. Override allowed by -f (fixes issue #1344)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-09-26 Ali Aliyari <aaliyari@ucdavis.edu>
+
+   * khmer/khmer_args.py: prevent -N from being set to more than 20 (override by -f)
+   * tests/test_script_arguments.py added test functions for the above change
+
 2016-09-26  Luiz Irber  <khmer@luizirber.org>
 
    * khmer/khmer_args.py: Update HLL citation to point to preprint.

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -427,12 +427,11 @@ def create_nodegraph(args, ksize=None, multiplier=1.0, fp_rate=0.01):
     args = _check_fp_rate(args, fp_rate)
     
     if hasattr(args, 'force'):
-        if not args.force:
-            if args.n_tables > 20:
+        if args.n_tables > 20:
+            if not args.force:
                 print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
                 sys.exit(1)
-        else:
-            if args.n_tables > 20:
+            else:
                 log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
 
     if ksize is None:
@@ -450,13 +449,13 @@ def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
     args = _check_fp_rate(args, fp_rate)
     
     if hasattr(args, 'force'):
-        if not args.force:
-            if args.n_tables > 20:
+        if args.n_tables > 20:
+            if not args.force:
                 print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
                 sys.exit(1)
-        else:
-            if args.n_tables > 20:
-                log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
+            else:
+                if args.n_tables > 20:
+                    log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
 
     if ksize is None:
         ksize = args.ksize

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -425,6 +425,16 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
 def create_nodegraph(args, ksize=None, multiplier=1.0, fp_rate=0.01):
     """Create and return a nodegraph."""
     args = _check_fp_rate(args, fp_rate)
+    
+    if hasattr(args, 'force'):
+        if not args.force:
+            if args.n_tables > 20:
+                print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
+                sys.exit(1)
+        else:
+            if args.n_tables > 20:
+                log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
+
     if ksize is None:
         ksize = args.ksize
     if ksize > 32:
@@ -438,6 +448,16 @@ def create_nodegraph(args, ksize=None, multiplier=1.0, fp_rate=0.01):
 def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
     """Create and return a countgraph."""
     args = _check_fp_rate(args, fp_rate)
+    
+    if hasattr(args, 'force'):
+        if not args.force:
+            if args.n_tables > 20:
+                print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
+                sys.exit(1)
+        else:
+            if args.n_tables > 20:
+                log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
+
     if ksize is None:
         ksize = args.ksize
     if ksize > 32:

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -150,7 +150,8 @@ FakeArgparseObject = collections.namedtuple('FakeArgs',
                                             ['ksize', 'n_tables',
                                              'max_tablesize',
                                              'max_memory_usage',
-                                             'unique_kmers', 'force'])
+                                             'unique_kmers',
+                                             'force'])
 
 
 def test_create_countgraph_1():


### PR DESCRIPTION
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] <strike>Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.</strike>
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] <strike>Do the changes respect streaming IO? (Are they
  tested for streaming IO?)</strike>
- [x] Is the Copyright year up to date?

