### PR TITLE
Abstract hash <-> pyobject conversion

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -111,15 +111,16 @@ extern "C" {
 
 // Convert a hash to a python long object.
 static bool convert_HashIntoType_to_PyObject(const HashIntoType &hashval,
-                                             PyObject **value) {
-      *value = PyLong_FromUnsignedLongLong(hashval);
-      return true;
+        PyObject **value)
+{
+    *value = PyLong_FromUnsignedLongLong(hashval);
+    return true;
 }
 
 
 // Convert a python long to a hash
 static bool convert_PyLong_to_HashIntoType(PyObject * value,
-   HashIntoType &hashval)
+        HashIntoType &hashval)
 {
     if (PyLong_Check(value)) {
         //(PyLongObject *)
@@ -144,7 +145,7 @@ static bool convert_PyObject_to_Kmer(PyObject * value,
     if (PyInt_Check(value) || PyLong_Check(value)) {
         HashIntoType h;
         if (!convert_PyLong_to_HashIntoType(value, h)) {
-          return false;
+            return false;
         }
         kmer.set_from_unique_hash(h, ksize);
         return true;
@@ -5121,7 +5122,7 @@ static PyObject * reverse_hash(PyObject * self, PyObject * args)
     }
     if (PyLong_Check(val) || PyInt_Check(val)) {
         if (!convert_PyLong_to_HashIntoType(val, hash)) {
-          return NULL;
+            return NULL;
         }
     } else {
         PyErr_SetString(PyExc_TypeError,

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -131,8 +131,8 @@ def _runscript(scriptname, sandbox=False):
     if os.path.isfile(scriptfile):
         if os.path.isfile(scriptfile):
             exec(  # pylint: disable=exec-used
-                compile(open(scriptfile).read(), scriptfile, 'exec'),
-                namespace)
+                 compile(open(scriptfile).read(), scriptfile, 'exec'),
+                 namespace)
             return 0
     elif sandbox:
         pytest.skip("sandbox tests are only run in a repository.")


### PR DESCRIPTION
Add a layer of abstraction for converting hash values into python
objects (and back). This is in preparation for supporting our
own hash type that is not a plain integer.

---

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
