### PR TITLE
Fix up formatting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-09-29  Tim Head  <betatim@gmail.com>
+
+   * khmer/khmer_args.py, tests/test_functions.py,
+   tests/test_script_arguments.py: fix up formatting
+
 2016-09-26 Ali Aliyari <aaliyari@ucdavis.edu>
 
    * khmer/khmer_args.py: prevent -N from being set to more than 20 (override by -f)

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -425,14 +425,16 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
 def create_nodegraph(args, ksize=None, multiplier=1.0, fp_rate=0.01):
     """Create and return a nodegraph."""
     args = _check_fp_rate(args, fp_rate)
-    
+
     if hasattr(args, 'force'):
         if args.n_tables > 20:
             if not args.force:
-                print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
+                print_error(
+                    "\n** ERROR: khmer only supports number of tables <= 20.\n")
                 sys.exit(1)
             else:
-                log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
+                log_warn("\n*** Warning: Maximum recommended number of "
+                         "tables is 20, discarded by force nonetheless!\n")
 
     if ksize is None:
         ksize = args.ksize
@@ -447,15 +449,17 @@ def create_nodegraph(args, ksize=None, multiplier=1.0, fp_rate=0.01):
 def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
     """Create and return a countgraph."""
     args = _check_fp_rate(args, fp_rate)
-    
+
     if hasattr(args, 'force'):
         if args.n_tables > 20:
             if not args.force:
-                print_error("\n** ERROR: khmer only supports number of tables <= 20.\n")
+                print_error(
+                    "\n** ERROR: khmer only supports number of tables <= 20.\n")
                 sys.exit(1)
             else:
                 if args.n_tables > 20:
-                    log_warn("\n*** Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!\n")
+                    log_warn("\n*** Warning: Maximum recommended number of "
+                             "tables is 20, discarded by force nonetheless!\n")
 
     if ksize is None:
         ksize = args.ksize

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -105,7 +105,7 @@ def test_reverse_hash():
 def test_reverse_hash_longs():
     # test explicitly with long integers, only needed for python2
     # the builtin `long` exists in the global scope only
-    global long # pylint: disable=global-variable-undefined
+    global long  # pylint: disable=global-variable-undefined
     if sys.version_info > (3,):
         long = int
 

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -207,17 +207,17 @@ def test_create_countgraph_3():
 
 def test_create_countgraph_4():
     # tests too-big n_tables WITHOUT force
-    
+
     ksize = khmer_args.DEFAULT_K
-    n_tables = 21 # some number larger than 20
+    n_tables = 21  # some number larger than 20
     max_tablesize = khmer_args.DEFAULT_MAX_TABLESIZE
     max_mem = 1e7
-    
+
     args = FakeArgparseObject(ksize, n_tables, max_tablesize, max_mem, 0, 0)
-    
+
     old_stderr = sys.stderr
     sys.stderr = capture = StringIO()
-    
+
     try:
         khmer_args.create_countgraph(args, ksize=None)
         assert 0, "should not reach this"
@@ -230,17 +230,17 @@ def test_create_countgraph_4():
 
 def test_create_countgraph_5():
     # tests too-big n_tables WITH force
-    
+
     ksize = khmer_args.DEFAULT_K
-    n_tables = 21 # some number larger than 20
+    n_tables = 21  # some number larger than 20
     max_tablesize = khmer_args.DEFAULT_MAX_TABLESIZE
     max_mem = 1e7
-    
+
     args = FakeArgparseObject(ksize, n_tables, max_tablesize, max_mem, 0, 1)
-    
+
     old_stderr = sys.stderr
     sys.stderr = capture = StringIO()
-    
+
     try:
         khmer_args.create_countgraph(args, ksize=None)
         message = "Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!"
@@ -316,16 +316,16 @@ def test_create_nodegraph_3():
 
 def test_create_nodegraph_4():
     # tests too-big number of tables WITHOUT force
-    
+
     ksize = khmer_args.DEFAULT_K
-    n_tables = 21 # some number larger than 20
+    n_tables = 21  # some number larger than 20
     max_tablesize = khmer_args.DEFAULT_MAX_TABLESIZE
     max_mem = 1e7
-    
+
     args = FakeArgparseObject(ksize, n_tables, max_tablesize, max_mem, 0, 0)
-    
+
     sys.stderr = capture = StringIO()
-    
+
     try:
         khmer_args.create_nodegraph(args, ksize=None)
         assert 0, "should not reach this"
@@ -336,16 +336,16 @@ def test_create_nodegraph_4():
 
 def test_create_nodegraph_5():
     # tests too-big number of tables WITH force
-    
+
     ksize = khmer_args.DEFAULT_K
-    n_tables = 21 # some number larger than 20
+    n_tables = 21  # some number larger than 20
     max_tablesize = khmer_args.DEFAULT_MAX_TABLESIZE
     max_mem = 1e7
-    
+
     args = FakeArgparseObject(ksize, n_tables, max_tablesize, max_mem, 0, 1)
-    
+
     sys.stderr = capture = StringIO()
-    
+
     try:
         khmer_args.create_nodegraph(args, ksize=None)
         message = "Warning: Maximum recommended number of tables is 20, discarded by force nonetheless!"


### PR DESCRIPTION
These are changes from running `make format`, fixes some formatting stuff accumulated over previous PRs. Backs up @standage's point in #1447 that we should make these failures on travis.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
