### PR TITLE
Travis all the way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ install:
 # command to run tests
 script:
   - make test
+  # copy of `make autopep8`, explicitly placed here as `autopep8` does not
+  # return a non-zero exit status when there are violations
+  - pep8 --ignore E309 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
 
 # generate all the diagnostic reports
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,6 @@ script:
   # copy of `make autopep8`, explicitly placed here as `autopep8` does not
   # return a non-zero exit status when there are violations
   - pep8 --ignore E309 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make astyle; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && $(git status -s) ]] then exit 1; fi 
 
 # generate all the diagnostic reports
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ after_success:
   - make doc
   # XXX Do not upload results from travis yet. Currently jenkins is considered
   # XXX the source of truth about coverage
-  # only upload the linux coverage report to codecov as it merges all reports
-  # from all builds into one
-  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install codecov; fi
-  #- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi
+  # only upload one coverage report to codecov as it merges all reports
+  # from all builds into one.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install codecov; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ script:
   # copy of `make autopep8`, explicitly placed here as `autopep8` does not
   # return a non-zero exit status when there are violations
   - pep8 --ignore E309 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make astyle; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && $(git status -s) ]] then exit 1; fi 
 
 # generate all the diagnostic reports
 after_success:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-10-03  Tim Head  <betatim@gmail.com>
+
+   * .travis.yml: adjust setup for exclusive use of travis (jenkins is retiring)
+
 2016-10-02  Titus Brown  <titus@idyll.org>
 
    * khmer/{utils.py,thread_utils.py,trimming.py}: introduce new function,

--- a/tests/khmer_tst_utils.py
+++ b/tests/khmer_tst_utils.py
@@ -130,8 +130,7 @@ def _runscript(scriptname, sandbox=False):
     scriptfile = os.path.join(path, scriptname)
     if os.path.isfile(scriptfile):
         if os.path.isfile(scriptfile):
-            exec(  # pylint: disable=exec-used
-                 compile(open(scriptfile).read(), scriptfile, 'exec'),
+            exec(compile(open(scriptfile).read(), scriptfile, 'exec'),
                  namespace)
             return 0
     elif sandbox:

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -1127,7 +1127,7 @@ def test_assemble_linear_path_2():
     nodegraph.consume(contig)
     nodegraph.count(contig[101:121] + 'G')  # will add another neighbor
 
-    path = nodegraph.assemble_linear_path(contig[100:100+K])
+    path = nodegraph.assemble_linear_path(contig[100:100 + K])
     len_path = len(path)
 
     assert _equals_rc(path, contig[:len_path])

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -245,6 +245,7 @@ def test_create_countgraph_5():
         khmer_args.create_countgraph(args, ksize=None)
         message = "Warning: Maximum recommended number of tables is 20, " + \
                   "discarded by force nonetheless!"
+
         assert message in capture.getvalue()
     except SystemExit as e:
         print(str(e))

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -245,7 +245,6 @@ def test_create_countgraph_5():
         khmer_args.create_countgraph(args, ksize=None)
         message = "Warning: Maximum recommended number of tables is 20, " + \
                   "discarded by force nonetheless!"
-
         assert message in capture.getvalue()
     except SystemExit as e:
         print(str(e))


### PR DESCRIPTION
Moving to travis only. Following on from #1447 

This PR uploads coverage from travis, so we need to disable (that on) jenkins otherwise the reports from codecov will be useless.

This also makes `pep8` mandatory. We've been running `autopep8` on travis and asking people if they ran it but ever so often formatting errors sneak in.

`astyle` is a bit more tricky as I can not find a way to get it to return a non zero exit code when it does reformat stuff. Ideas/knowledge?

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Is the Copyright year up to date?
