### PR TITLE
use `make pep8` target in travis and rebel against fascist whitespace tyranny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ install:
 # command to run tests
 script:
   - make test
-  # copy of `make autopep8`, explicitly placed here as `autopep8` does not
-  # return a non-zero exit status when there are violations
   - make pep8
 
 # generate all the diagnostic reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - make test
   # copy of `make autopep8`, explicitly placed here as `autopep8` does not
   # return a non-zero exit status when there are violations
-  - pep8 --ignore E309 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
+  - make pep8
 
 # generate all the diagnostic reports
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,10 @@ cppcheck-long: FORCE
 
 ## pep8        : check Python code style
 pep8: $(PYSOURCES) $(wildcard tests/*.py)
-	pep8 --ignore E309,E226 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
+	pep8 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
 
 pep8_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
-	pep8 --exclude=_version.py setup.py khmer/ scripts/ tests/ oxli/ \
+	pep8 setup.py khmer/ scripts/ tests/ oxli/ \
 		> pep8_report.txt || true
 
 diff_pep8_report: pep8_report.txt

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,7 @@ cppcheck-long: FORCE
 
 ## pep8        : check Python code style
 pep8: $(PYSOURCES) $(wildcard tests/*.py)
-	pep8 --exclude=_version.py  --show-source setup.py khmer/ \
-		scripts/ tests/ oxli/ || true
+	pep8 --ignore E309,E226 setup.py khmer/*.py scripts/*.py tests/*.py oxli/*.py
 
 pep8_report.txt: $(PYSOURCES) $(wildcard tests/*.py)
 	pep8 --exclude=_version.py setup.py khmer/ scripts/ tests/ oxli/ \

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,7 @@ versionfile_source = khmer/_version.py
 versionfile_build = khmer/_version.py
 tag_prefix = v
 parentdir_prefix = .
+
+[pep8]
+exclude = _version.py
+ignore = E309,E226


### PR DESCRIPTION
Whitespace in arithmetic expressions is hard to read in slices. Fight the power.
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

…whitespace
