### PR TITLE
Address the silly gcc bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-10-13  Camille Scott  <camille.scott.w@gmail.com>
+
+   * Wrap IO functions in with an extra catch to handle the gcc
+     basic_ios_failure bug.
+
 2016-10-03  Tim Head  <betatim@gmail.com>
 
    * .travis.yml: adjust setup for exclusive use of travis (jenkins is retiring)

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -341,6 +341,11 @@ CountingHashFileReader::CountingHashFileReader(
             err = "Unknown error in opening file: " + infilename;
         }
         throw khmer_file_exception(err + " " + strerror(errno));
+    } catch (const std::exception &e) {
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno) + "; please poke the gcc devs at "
+                  "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145";
+        throw khmer_file_exception(err);
     }
 
     if (ht._counts) {
@@ -444,6 +449,10 @@ CountingHashFileReader::CountingHashFileReader(
             err = "Error reading from k-mer count file: " + infilename + " "
                   + strerror(errno);
         }
+        throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        std::string err = "Error reading from k-mer count file: " + infilename + " "
+                  + strerror(errno);
         throw khmer_file_exception(err);
     }
 }

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -343,7 +343,7 @@ CountingHashFileReader::CountingHashFileReader(
         throw khmer_file_exception(err + " " + strerror(errno));
     } catch (const std::exception &e) {
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -451,7 +451,7 @@ CountingHashFileReader::CountingHashFileReader(
         throw khmer_file_exception(err);
     } catch (const std::exception &e) {
         std::string err = "Error reading from k-mer count file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 }

--- a/lib/counting.cc
+++ b/lib/counting.cc
@@ -343,8 +343,7 @@ CountingHashFileReader::CountingHashFileReader(
         throw khmer_file_exception(err + " " + strerror(errno));
     } catch (const std::exception &e) {
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno) + "; please poke the gcc devs at "
-                  "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145";
+                  + strerror(errno);
         throw khmer_file_exception(err);
     }
 

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -108,6 +108,12 @@ void Hashbits::load(std::string infilename)
             err = "Unknown error in opening file: " + infilename;
         }
         throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
+        throw khmer_file_exception(err);
     }
 
     if (_counts) {
@@ -188,6 +194,12 @@ void Hashbits::load(std::string infilename)
         } else {
             err = "Error reading from k-mer graph file: " + infilename;
         }
+        throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
         throw khmer_file_exception(err);
     }
 }

--- a/lib/hashbits.cc
+++ b/lib/hashbits.cc
@@ -112,7 +112,7 @@ void Hashbits::load(std::string infilename)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -199,7 +199,7 @@ void Hashbits::load(std::string infilename)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 }

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -298,7 +298,7 @@ void Hashtable::load_tagset(std::string infilename, bool clear_tags)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -365,23 +365,23 @@ void Hashtable::load_tagset(std::string infilename, bool clear_tags)
             delete[] buf;
         }
         throw khmer_file_exception(err);
-    /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
-     * regarding the basic_ios::failure that makes it impossible to catch
-     * with more specificty. So, we catch *all* exceptions after trying to
-     * get the ifstream::failure, and assume it must have been the buggy one.
-     * Unfortunately, this would also cause us to catch the
-     * khmer_file_exceptions thrown above, so we catch them again first and 
-     * rethrow them :) If this is understandably irritating to you, please
-     * bother the gcc devs at: 
-     *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
-     *
-     * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
-     */
+        /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
+         * regarding the basic_ios::failure that makes it impossible to catch
+         * with more specificty. So, we catch *all* exceptions after trying to
+         * get the ifstream::failure, and assume it must have been the buggy one.
+         * Unfortunately, this would also cause us to catch the
+         * khmer_file_exceptions thrown above, so we catch them again first and
+         * rethrow them :) If this is understandably irritating to you, please
+         * bother the gcc devs at:
+         *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+         *
+         * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
+         */
     } catch (khmer_file_exception &e) {
         throw e;
     } catch (const std::exception &e) {
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 }
@@ -772,7 +772,7 @@ void Hashtable::load_stop_tags(std::string infilename, bool clear_tags)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -838,7 +838,7 @@ void Hashtable::load_stop_tags(std::string infilename, bool clear_tags)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + infilename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 }
@@ -1129,8 +1129,8 @@ const
 // results.
 
 std::string Hashtable::assemble_linear_path(const Kmer seed_kmer,
-                                            const Hashtable * stop_bf)
-    const
+        const Hashtable * stop_bf)
+const
 {
     std::string start_kmer = seed_kmer.get_string_rep(_ksize);
     std::string right = _assemble_right(start_kmer.c_str(), stop_bf);
@@ -1144,7 +1144,7 @@ std::string Hashtable::assemble_linear_path(const Kmer seed_kmer,
 
 std::string Hashtable::_assemble_right(const char * start_kmer,
                                        const Hashtable * stop_bf)
-    const
+const
 {
     const char bases[] = "ACGT";
     std::string kmer = start_kmer;
@@ -1168,7 +1168,7 @@ std::string Hashtable::_assemble_right(const char * start_kmer,
 
             // a hit!
             if (this->get_count(try_kmer.c_str()) &&
-                (!stop_bf || !stop_bf->get_count(try_kmer.c_str()))) {
+                    (!stop_bf || !stop_bf->get_count(try_kmer.c_str()))) {
                 if (found) {
                     found2 = true;
                     break;

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -832,6 +832,8 @@ void Hashtable::load_stop_tags(std::string infilename, bool clear_tags)
     } catch (std::ifstream::failure &e) {
         std::string err = "Error reading stoptags from: " + infilename;
         throw khmer_file_exception(err);
+    } catch (khmer_file_exception &e) {
+        throw e;
     } catch (const std::exception &e) {
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -294,6 +294,12 @@ void Hashtable::load_tagset(std::string infilename, bool clear_tags)
             err = "Unknown error in opening file: " + infilename;
         }
         throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
+        throw khmer_file_exception(err);
     }
 
     if (clear_tags) {
@@ -358,6 +364,24 @@ void Hashtable::load_tagset(std::string infilename, bool clear_tags)
         if (buf != NULL) {
             delete[] buf;
         }
+        throw khmer_file_exception(err);
+    /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
+     * regarding the basic_ios::failure that makes it impossible to catch
+     * with more specificty. So, we catch *all* exceptions after trying to
+     * get the ifstream::failure, and assume it must have been the buggy one.
+     * Unfortunately, this would also cause us to catch the
+     * khmer_file_exceptions thrown above, so we catch them again first and 
+     * rethrow them :) If this is understandably irritating to you, please
+     * bother the gcc devs at: 
+     *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+     *
+     * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
+     */
+    } catch (khmer_file_exception &e) {
+        throw e;
+    } catch (const std::exception &e) {
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
         throw khmer_file_exception(err);
     }
 }
@@ -744,6 +768,12 @@ void Hashtable::load_stop_tags(std::string infilename, bool clear_tags)
             err = "Unknown error in opening file: " + infilename;
         }
         throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
+        throw khmer_file_exception(err);
     }
 
     if (clear_tags) {
@@ -801,6 +831,12 @@ void Hashtable::load_stop_tags(std::string infilename, bool clear_tags)
         delete[] buf;
     } catch (std::ifstream::failure &e) {
         std::string err = "Error reading stoptags from: " + infilename;
+        throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + infilename + " "
+                  + strerror(errno);
         throw khmer_file_exception(err);
     }
 }

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -438,6 +438,12 @@ void LabelHash::load_labels_and_tags(std::string filename)
             err = "Unknown error in opening file: " + filename;
         }
         throw khmer_file_exception(err);
+    } catch (const std::exception &e) {
+        // Catching std::exception is a stopgap for
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+        std::string err = "Unknown error opening file: " + filename + " "
+                  + strerror(errno);
+        throw khmer_file_exception(err);
     }
 
     unsigned long n_labeltags = 1;
@@ -483,6 +489,24 @@ void LabelHash::load_labels_and_tags(std::string filename)
         std::string err;
         err = "Unknown error reading header info from: " + filename;
         throw khmer_file_exception(err);
+    /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
+     * regarding the basic_ios::failure that makes it impossible to catch
+     * with more specificty. So, we catch *all* exceptions after trying to
+     * get the ifstream::failure, and assume it must have been the buggy one.
+     * Unfortunately, this would also cause us to catch the
+     * khmer_file_exceptions thrown above, so we catch them again first and 
+     * rethrow them :) If this is understandably irritating to you, please
+     * bother the gcc devs at: 
+     *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
+     *
+     * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
+     */
+    } catch (khmer_file_exception &e) {
+        throw e;
+    } catch (const std::exception &e) {
+        std::string err = "Unknown error opening file: " + filename + " "
+                  + strerror(errno);
+        throw khmer_file_exception(err);
     }
 
     char * buf = new char[IO_BUF_SIZE];
@@ -501,7 +525,7 @@ void LabelHash::load_labels_and_tags(std::string filename)
 
         try {
             infile.read(buf + remainder, IO_BUF_SIZE - remainder);
-        } catch (std::ifstream::failure &e) {
+        } catch (std::exception &e) {
 
             // We may get an exception here if we fail to read all the
             // expected bytes due to EOF -- only pass it up if we read
@@ -514,7 +538,7 @@ void LabelHash::load_labels_and_tags(std::string filename)
                 err = "Unknown error reading data from: " + filename;
                 throw khmer_file_exception(err);
             }
-        }
+        } 
 
         long n_bytes = infile.gcount() + remainder;
         remainder = n_bytes % (sizeof(Label) + sizeof(HashIntoType));

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -489,18 +489,6 @@ void LabelHash::load_labels_and_tags(std::string filename)
         std::string err;
         err = "Unknown error reading header info from: " + filename;
         throw khmer_file_exception(err);
-    /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
-     * regarding the basic_ios::failure that makes it impossible to catch
-     * with more specificty. So, we catch *all* exceptions after trying to
-     * get the ifstream::failure, and assume it must have been the buggy one.
-     * Unfortunately, this would also cause us to catch the
-     * khmer_file_exceptions thrown above, so we catch them again first and 
-     * rethrow them :) If this is understandably irritating to you, please
-     * bother the gcc devs at: 
-     *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
-     *
-     * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
-     */
     } catch (khmer_file_exception &e) {
         throw e;
     } catch (const std::exception &e) {

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -442,7 +442,7 @@ void LabelHash::load_labels_and_tags(std::string filename)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + filename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -493,7 +493,7 @@ void LabelHash::load_labels_and_tags(std::string filename)
         throw e;
     } catch (const std::exception &e) {
         std::string err = "Unknown error opening file: " + filename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -526,7 +526,7 @@ void LabelHash::load_labels_and_tags(std::string filename)
                 err = "Unknown error reading data from: " + filename;
                 throw khmer_file_exception(err);
             }
-        } 
+        }
 
         long n_bytes = infile.gcount() + remainder;
         remainder = n_bytes % (sizeof(Label) + sizeof(HashIntoType));

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -912,7 +912,7 @@ void SubsetPartition::merge_from_disk(string other_filename)
         // Catching std::exception is a stopgap for
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
         std::string err = "Unknown error opening file: " + other_filename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
 
@@ -962,7 +962,7 @@ void SubsetPartition::merge_from_disk(string other_filename)
         throw e;
     } catch (const std::exception &e) {
         std::string err = "Unknown error opening file: " + other_filename + " "
-                  + strerror(errno);
+                          + strerror(errno);
         throw khmer_file_exception(err);
     }
     char * buf = new char[IO_BUF_SIZE];

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -958,18 +958,6 @@ void SubsetPartition::merge_from_disk(string other_filename)
         std::string err;
         err = "Unknown error reading header info from: " + other_filename;
         throw khmer_file_exception(err);
-    /* Yes, this is boneheaded. Unfortunately, there is a bug in gcc > 5
-     * regarding the basic_ios::failure that makes it impossible to catch
-     * with more specificty. So, we catch *all* exceptions after trying to
-     * get the ifstream::failure, and assume it must have been the buggy one.
-     * Unfortunately, this would also cause us to catch the
-     * khmer_file_exceptions thrown above, so we catch them again first and 
-     * rethrow them :) If this is understandably irritating to you, please
-     * bother the gcc devs at: 
-     *     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145
-     *
-     * See also: http://media4.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif
-     */
     } catch (khmer_file_exception &e) {
         throw e;
     } catch (const std::exception &e) {


### PR DESCRIPTION
Address #1368. There is a mismatch between gcc and system libs which makes it impossible to specifically catch an exception from ifstream::read; the problem is described on the gcc bugtacker:
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69877
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66145

This was previously only affecting a few users, but now affects the core devs :) the temporary measure is to just catch all exceptions in those places and hope for the best; a few times, we have to rethrow khmer exceptions to propagate them up.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?