### PR TITLE
expose khmer.Read to python and use ReadParser in scripts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2016-11-14  Tim Head  <betatim@gmail.com>
+
+   * khmer/_khmer.cc,lib/read_parsers.hh: Expose khmer's Read type fully to
+   the python side.
+   * scripts/{extract-paired-reads.py,filter-abund-single.py,filter-abund.py,
+   sample-reads-randomly.py,split-paired-reads.py,trim-low-abund.py}: Switch to
+   using ReadParser to speed up scripts.
+   * tests/test_read_handling.py,tests/test_scripts.py: Remove streaming tests
+   that use a FIFO.
+
 2016-11-14  Shannon EK Joslin	<sejoslin@ucdavis.edu>
    *khmer/tests/test_countgraph.py: Refactor test code to use load_countgraph #1474
    *khmer/tests/test_nodegraph.py: Refactor test code to use load_nodegraph and load_countgraph #1474

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -426,7 +426,7 @@ Read_set_cleaned_seq(khmer_Read_Object *obj, PyObject *value, void *closure)
         return 0;
     }
 
-    if (! PyUnicode_Check(value)) {
+    if (! (PyUnicode_Check(value) | PyBytes_Check(value))) {
         PyErr_SetString(PyExc_TypeError,
                         "The 'cleaned_seq' attribute value must be a string");
         return -1;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -339,6 +339,17 @@ khmer_Read_dealloc(khmer_Read_Object * obj)
 }
 
 
+static Py_ssize_t
+khmer_Read_len(khmer_Read_Object* obj)
+{
+    return obj->read->sequence.size();
+}
+
+static PySequenceMethods khmer_Read_sequence_methods = {
+    (lenfunc)khmer_Read_len,                  /* sq_length */
+};
+
+
 static
 PyObject *
 Read_get_name(khmer_Read_Object * obj, void * closure )
@@ -483,7 +494,7 @@ static PyTypeObject khmer_Read_Type = {
     0,                                    /* tp_compare */
     0,                                    /* tp_repr */
     0,                                    /* tp_as_number */
-    0,                                    /* tp_as_sequence */
+    &khmer_Read_sequence_methods,         /* tp_as_sequence */
     0,                                    /* tp_as_mapping */
     0,                                    /* tp_hash */
     0,                                    /* tp_call */

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -526,78 +526,6 @@ static PyTypeObject khmer_Read_Type = {
 
 /***********************************************************************/
 
-typedef struct {
-    PyObject_HEAD
-    std::vector<read_parsers::Read> reads;
-} khmer_ReadBundle_Object;
-
-static
-int
-khmer_ReadBundle_init(khmer_ReadBundle_Object *self, PyObject *args,
-                      PyObject *kwds)
-{
-    PyObject* pyread;
-    Py_ssize_t length = PyTuple_Size(args);
-    for (Py_ssize_t i(0); i < length; i++) {
-        pyread = PyTuple_GetItem(args, i);
-        if (pyread == NULL || !PyMapping_Check(pyread)) {
-            return NULL;
-        }
-        read_parsers::Read read;
-        const char* key{"sequence"};
-        PyObject* pystr = PyMapping_GetItemString(pyread, key);
-        PyObject* temp = PyUnicode_AsASCIIString(pystr);
-        read.sequence = std::string(PyByteArray_AsString(temp));
-        Py_DECREF(temp);
-        self->reads.push_back(read);
-    }
-
-    return 0;
-}
-
-static PyTypeObject khmer_ReadBundle_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
-    "_khmer.ReadBundle",                        /* tp_name */
-    sizeof(khmer_ReadBundle_Object),            /* tp_basicsize */
-    0,                                    /* tp_itemsize */
-    0,       /* tp_dealloc */
-    0,                                    /* tp_print */
-    0,                                    /* tp_getattr */
-    0,                                    /* tp_setattr */
-    0,                                    /* tp_compare */
-    0,                                    /* tp_repr */
-    0,                                    /* tp_as_number */
-    0,                                    /* tp_as_sequence */
-    0,                                    /* tp_as_mapping */
-    0,                                    /* tp_hash */
-    0,                                    /* tp_call */
-    0,                                    /* tp_str */
-    0,                                    /* tp_getattro */
-    0,                                    /* tp_setattro */
-    0,                                    /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                   /* tp_flags */
-    "A FASTQ record plus some metadata.", /* tp_doc */
-    0,                                    /* tp_traverse */
-    0,                                    /* tp_clear */
-    0,                                    /* tp_richcompare */
-    0,                                    /* tp_weaklistoffset */
-    0,                                    /* tp_iter */
-    0,                                    /* tp_iternext */
-    0,                                    /* tp_methods */
-    0,                                    /* tp_members */
-    0,                                    /* tp_getset */
-    0,                                    /* tp_base */
-    0,                                    /* tp_dict */
-    0,                                    /* tp_descr_get */
-    0,                                    /* tp_descr_set */
-    0,                                    /* tp_dictoffset */
-    (initproc)khmer_ReadBundle_init,      /* tp_init */
-    //0,                                    /* tp_alloc */
-    //khmer_Read_new,                       /* tp_new */
-};
-
-/***********************************************************************/
-
 //
 // ReadParser object -- parse reads directly from streams
 // ReadPairIterator -- return pairs of Read objects
@@ -6100,11 +6028,6 @@ MOD_INIT(_khmer)
 {
     using namespace python;
 
-    khmer_ReadBundle_Type.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&khmer_ReadBundle_Type) < 0) {
-        return MOD_ERROR_VAL;
-    }
-
     if (PyType_Ready(&khmer_KHashtable_Type) < 0) {
         return MOD_ERROR_VAL;
     }
@@ -6178,12 +6101,6 @@ MOD_INIT(_khmer)
     Py_INCREF(&khmer_Read_Type);
     if (PyModule_AddObject( m, "Read",
                             (PyObject *)&khmer_Read_Type ) < 0) {
-        return MOD_ERROR_VAL;
-    }
-
-    Py_INCREF(&khmer_ReadBundle_Type);
-    if (PyModule_AddObject( m, "ReadBundle",
-                            (PyObject *)&khmer_ReadBundle_Type ) < 0) {
         return MOD_ERROR_VAL;
     }
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -42,10 +42,8 @@ Contact: khmer-project@idyll.org
 
 // Must be first.
 #include <Python.h>
-#include "structmember.h"
 
 #include <iostream>
-#include <vector>
 
 #include "khmer.hh"
 #include "kmer_hash.hh"

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -185,8 +185,8 @@ static bool convert_PyObject_to_HashIntoType(PyObject * value,
 // that checks this.
 
 static bool ht_convert_PyObject_to_HashIntoType(PyObject * value,
-                                                HashIntoType& hashval,
-                                                const Hashtable * ht)
+        HashIntoType& hashval,
+        const Hashtable * ht)
 {
     if (PyInt_Check(value) || PyLong_Check(value)) {
         return convert_PyLong_to_HashIntoType(value, hashval);
@@ -2227,11 +2227,11 @@ hashtable_do_subset_partition(khmer_KHashtable_Object * me, PyObject * args)
         return NULL;
     }
     if (!ht_convert_PyObject_to_HashIntoType(start_kmer_obj, start_kmer,
-                                             hashtable)) {
+            hashtable)) {
         return NULL;
     }
     if (!ht_convert_PyObject_to_HashIntoType(end_kmer_obj, end_kmer,
-                                             hashtable)) {
+            hashtable)) {
         return NULL;
     }
 
@@ -4483,7 +4483,7 @@ labelhash_get_tag_labels(khmer_KGraphLabels_Object * me, PyObject * args)
         return NULL;
     }
     if (!ht_convert_PyObject_to_HashIntoType(tag_o, tag,
-                                             labelhash->graph)) {
+            labelhash->graph)) {
         return NULL;
     }
 
@@ -5371,7 +5371,7 @@ static void khmer_linearassembler_dealloc(khmer_KLinearAssembler_Object * obj)
 }
 
 static PyObject * khmer_linearassembler_new(PyTypeObject *type, PyObject *args,
-                                            PyObject *kwds)
+        PyObject *kwds)
 {
     khmer_KLinearAssembler_Object *self;
     self = (khmer_KLinearAssembler_Object*)type->tp_alloc(type, 0);
@@ -5414,7 +5414,7 @@ static PyObject * khmer_linearassembler_new(PyTypeObject *type, PyObject *args,
 static
 PyObject *
 linearassembler_assemble(khmer_KLinearAssembler_Object * me,
-                                PyObject * args, PyObject *kwargs)
+                         PyObject * args, PyObject *kwargs)
 {
     LinearAssembler * assembler= me->assembler;
 
@@ -5427,8 +5427,8 @@ linearassembler_assemble(khmer_KLinearAssembler_Object * me,
     const char *kwnames[] = {"seed_kmer", "stop_filter", "direction", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O!s",
-                                     const_cast<char **>(kwnames), 
-                                     &val_o, &khmer_KNodegraph_Type, 
+                                     const_cast<char **>(kwnames),
+                                     &val_o, &khmer_KNodegraph_Type,
                                      &nodegraph_o, &dir_str)) {
         return NULL;
     }
@@ -5448,7 +5448,7 @@ linearassembler_assemble(khmer_KLinearAssembler_Object * me,
     }
 
     std::string contig;
-    if (dir == 'B') { 
+    if (dir == 'B') {
         contig = assembler->assemble(start_kmer, stop_bf);
     } else if (dir == 'L') {
         contig = assembler->assemble_left(start_kmer, stop_bf);
@@ -5456,7 +5456,7 @@ linearassembler_assemble(khmer_KLinearAssembler_Object * me,
         contig = assembler->assemble_right(start_kmer, stop_bf);
     } else {
         PyErr_SetString(PyExc_ValueError, "Direction must be B (both), L (left),"
-                " or R (right).");
+                        " or R (right).");
         return NULL;
     }
 
@@ -5523,7 +5523,8 @@ typedef struct {
 } khmer_KSimpleLabeledAssembler_Object;
 
 
-static void khmer_simplelabeledassembler_dealloc(khmer_KLinearAssembler_Object * obj)
+static void khmer_simplelabeledassembler_dealloc(khmer_KLinearAssembler_Object *
+        obj)
 {
     delete obj->assembler;
     obj->assembler = NULL;
@@ -5531,8 +5532,9 @@ static void khmer_simplelabeledassembler_dealloc(khmer_KLinearAssembler_Object *
     Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
-static PyObject * khmer_simplelabeledassembler_new(PyTypeObject *type, PyObject *args,
-                                            PyObject *kwds)
+static PyObject * khmer_simplelabeledassembler_new(PyTypeObject *type,
+        PyObject *args,
+        PyObject *kwds)
 {
     khmer_KSimpleLabeledAssembler_Object *self;
     self = (khmer_KSimpleLabeledAssembler_Object*)type->tp_alloc(type, 0);
@@ -5583,8 +5585,8 @@ simplelabeledassembler_assemble(khmer_KSimpleLabeledAssembler_Object * me,
     const char *kwnames[] = {"seed_kmer", "stop_filter", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O!",
-                                     const_cast<char **>(kwnames), 
-                                     &val_o, &khmer_KNodegraph_Type, 
+                                     const_cast<char **>(kwnames),
+                                     &val_o, &khmer_KNodegraph_Type,
                                      &nodegraph_o)) {
         return NULL;
     }
@@ -5600,7 +5602,7 @@ simplelabeledassembler_assemble(khmer_KSimpleLabeledAssembler_Object * me,
     }
 
     std::vector<std::string> contigs = assembler->assemble(start_kmer, stop_bf);
-  
+
     PyObject * ret = PyList_New(contigs.size());
     for (unsigned int i = 0; i < contigs.size(); i++) {
         PyList_SET_ITEM(ret, i, PyUnicode_FromString(contigs[i].c_str()));
@@ -5672,7 +5674,8 @@ typedef struct {
     JunctionCountAssembler * assembler;
 } khmer_KJunctionCountAssembler_Object;
 
-static void khmer_junctioncountassembler_dealloc(khmer_KJunctionCountAssembler_Object * obj)
+static void khmer_junctioncountassembler_dealloc(
+    khmer_KJunctionCountAssembler_Object * obj)
 {
     delete obj->assembler;
     obj->assembler = NULL;
@@ -5680,8 +5683,9 @@ static void khmer_junctioncountassembler_dealloc(khmer_KJunctionCountAssembler_O
     Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
-static PyObject * khmer_junctioncountassembler_new(PyTypeObject *type, PyObject *args,
-                                            PyObject *kwds)
+static PyObject * khmer_junctioncountassembler_new(PyTypeObject *type,
+        PyObject *args,
+        PyObject *kwds)
 {
     khmer_KJunctionCountAssembler_Object *self;
     self = (khmer_KJunctionCountAssembler_Object*)type->tp_alloc(type, 0);
@@ -5736,10 +5740,10 @@ junctioncountassembler_assemble(khmer_KJunctionCountAssembler_Object * me,
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|O!",
                                      const_cast<char **>(kwnames),
-                                     &val_o, &khmer_KNodegraph_Type, 
+                                     &val_o, &khmer_KNodegraph_Type,
                                      &nodegraph_o)) {
         return NULL;
-    } 
+    }
 
     Kmer start_kmer;
     if (!ht_convert_PyObject_to_Kmer(val_o, start_kmer, assembler->graph)) {
@@ -5751,7 +5755,7 @@ junctioncountassembler_assemble(khmer_KJunctionCountAssembler_Object * me,
     }
 
     std::vector<std::string> contigs = assembler->assemble(start_kmer, stop_bf);
-  
+
     PyObject * ret = PyList_New(contigs.size());
     for (unsigned int i = 0; i < contigs.size(); i++) {
         PyList_SET_ITEM(ret, i, PyUnicode_FromString(contigs[i].c_str()));
@@ -5763,7 +5767,8 @@ junctioncountassembler_assemble(khmer_KJunctionCountAssembler_Object * me,
 
 static
 PyObject *
-junctioncountassembler_consume(khmer_KJunctionCountAssembler_Object * me, PyObject * args)
+junctioncountassembler_consume(khmer_KJunctionCountAssembler_Object * me,
+                               PyObject * args)
 {
     JunctionCountAssembler * assembler = me->assembler;
     const char * long_str;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -432,15 +432,21 @@ Read_set_cleaned_seq(khmer_Read_Object *obj, PyObject *value, void *closure)
         return -1;
     }
 
-    PyObject* temp = PyUnicode_AsASCIIString(value);
-    if (temp == NULL) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Could not encode 'cleaned_seq' as ASCII.");
-        return -1;
-    }
+    if (PyUnicode_Check(value)) {
+        PyObject* temp = PyUnicode_AsASCIIString(value);
+        if (temp == NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Could not encode 'cleaned_seq' as ASCII.");
+            return -1;
+        }
 
-    obj->read->cleaned_seq = std::string(PyBytes_AS_STRING(temp));
-    Py_DECREF(temp);
+        obj->read->cleaned_seq = std::string(PyBytes_AS_STRING(temp));
+        Py_DECREF(temp);
+    }
+    // in python2 not everything is a unicode object
+    else {
+        obj->read->cleaned_seq = std::string(PyBytes_AS_STRING(value));
+    }
 
     return 0;
 }

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -42,8 +42,10 @@ Contact: khmer-project@idyll.org
 
 // Must be first.
 #include <Python.h>
+#include "structmember.h"
 
 #include <iostream>
+#include <vector>
 
 #include "khmer.hh"
 #include "kmer_hash.hh"
@@ -463,6 +465,77 @@ static PyTypeObject khmer_Read_Type = {
     khmer_Read_new,                       /* tp_new */
 };
 
+
+/***********************************************************************/
+
+typedef struct {
+    PyObject_HEAD
+    std::vector<read_parsers::Read> reads;
+} khmer_ReadBundle_Object;
+
+static
+int
+khmer_ReadBundle_init(khmer_ReadBundle_Object *self, PyObject *args,
+                      PyObject *kwds)
+{
+    PyObject* pyread;
+    Py_ssize_t length = PyTuple_Size(args);
+    for (Py_ssize_t i(0); i < length; i++) {
+        pyread = PyTuple_GetItem(args, i);
+        if (pyread == NULL || !PyMapping_Check(pyread)) {
+            return NULL;
+        }
+        read_parsers::Read read;
+        const char* key{"sequence"};
+        PyObject* pystr = PyMapping_GetItemString(pyread, key);
+        PyObject* temp = PyUnicode_AsASCIIString(pystr);
+        read.sequence = std::string(PyByteArray_AsString(temp));
+        self->reads.push_back(read);
+    }
+
+    return 0;
+}
+
+static PyTypeObject khmer_ReadBundle_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
+    "_khmer.ReadBundle",                        /* tp_name */
+    sizeof(khmer_ReadBundle_Object),            /* tp_basicsize */
+    0,                                    /* tp_itemsize */
+    0,       /* tp_dealloc */
+    0,                                    /* tp_print */
+    0,                                    /* tp_getattr */
+    0,                                    /* tp_setattr */
+    0,                                    /* tp_compare */
+    0,                                    /* tp_repr */
+    0,                                    /* tp_as_number */
+    0,                                    /* tp_as_sequence */
+    0,                                    /* tp_as_mapping */
+    0,                                    /* tp_hash */
+    0,                                    /* tp_call */
+    0,                                    /* tp_str */
+    0,                                    /* tp_getattro */
+    0,                                    /* tp_setattro */
+    0,                                    /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                   /* tp_flags */
+    "A FASTQ record plus some metadata.", /* tp_doc */
+    0,                                    /* tp_traverse */
+    0,                                    /* tp_clear */
+    0,                                    /* tp_richcompare */
+    0,                                    /* tp_weaklistoffset */
+    0,                                    /* tp_iter */
+    0,                                    /* tp_iternext */
+    0,                                    /* tp_methods */
+    0,                                    /* tp_members */
+    0,                                    /* tp_getset */
+    0,                                    /* tp_base */
+    0,                                    /* tp_dict */
+    0,                                    /* tp_descr_get */
+    0,                                    /* tp_descr_set */
+    0,                                    /* tp_dictoffset */
+    (initproc)khmer_ReadBundle_init,      /* tp_init */
+    //0,                                    /* tp_alloc */
+    //khmer_Read_new,                       /* tp_new */
+};
 
 /***********************************************************************/
 
@@ -5968,6 +6041,11 @@ MOD_INIT(_khmer)
 {
     using namespace python;
 
+    khmer_ReadBundle_Type.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&khmer_ReadBundle_Type) < 0) {
+        return MOD_ERROR_VAL;
+    }
+
     if (PyType_Ready(&khmer_KHashtable_Type) < 0) {
         return MOD_ERROR_VAL;
     }
@@ -6041,6 +6119,12 @@ MOD_INIT(_khmer)
     Py_INCREF(&khmer_Read_Type);
     if (PyModule_AddObject( m, "Read",
                             (PyObject *)&khmer_Read_Type ) < 0) {
+        return MOD_ERROR_VAL;
+    }
+
+    Py_INCREF(&khmer_ReadBundle_Type);
+    if (PyModule_AddObject( m, "ReadBundle",
+                            (PyObject *)&khmer_ReadBundle_Type ) < 0) {
         return MOD_ERROR_VAL;
     }
 

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -250,7 +250,7 @@ def write_record_pair(read1, read2, fileobj):
 
 def clean_input_reads(screed_iter):
     for record in screed_iter:
-        record.cleaned_seq = record.sequence.upper().replace('N', 'A')
+        #record.cleaned_seq = record.sequence.upper().replace('N', 'A')
         yield record
 
 

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -250,7 +250,7 @@ def write_record_pair(read1, read2, fileobj):
 
 def clean_input_reads(screed_iter):
     for record in screed_iter:
-        #record.cleaned_seq = record.sequence.upper().replace('N', 'A')
+        record.cleaned_seq = record.sequence.upper().replace('N', 'A')
         yield record
 
 

--- a/lib/assembler.cc
+++ b/lib/assembler.cc
@@ -370,8 +370,10 @@ uint16_t JunctionCountAssembler::consume(std::string sequence)
             count_junction(kmer, next_kmer);
             n_junctions++;
 #if DEBUG_ASSEMBLY
-            std::cout << "Junction: " << kmer.repr(_ksize) << ", " << next_kmer.repr(_ksize) << std::endl;
-            std::cout << "Junction Count: " << get_junction_count(kmer, next_kmer) << std::endl;
+            std::cout << "Junction: " << kmer.repr(_ksize) << ", " << next_kmer.repr(
+                          _ksize) << std::endl;
+            std::cout << "Junction Count: " << get_junction_count(kmer,
+                      next_kmer) << std::endl;
 #endif
         }
         kmer = next_kmer;
@@ -380,7 +382,7 @@ uint16_t JunctionCountAssembler::consume(std::string sequence)
         next_d = this->traverser.degree(next_kmer);
     }
 
-    return n_junctions / 2; 
+    return n_junctions / 2;
 }
 
 void JunctionCountAssembler::count_junction(Kmer kmer_a, Kmer kmer_b)
@@ -388,7 +390,8 @@ void JunctionCountAssembler::count_junction(Kmer kmer_a, Kmer kmer_b)
     junctions->count(kmer_a.kmer_u ^ kmer_b.kmer_u);
 }
 
-BoundedCounterType JunctionCountAssembler::get_junction_count(Kmer kmer_a, Kmer kmer_b)
+BoundedCounterType JunctionCountAssembler::get_junction_count(Kmer kmer_a,
+        Kmer kmer_b)
 const
 {
     return junctions->get_count(kmer_a.kmer_u ^ kmer_b.kmer_u);
@@ -412,7 +415,8 @@ const
     SeenSet visited;
 
 #if DEBUG_ASSEMBLY
-    std::cout << "Assemble Junctions RIGHT: " << seed_kmer.repr(_ksize) << std::endl;
+    std::cout << "Assemble Junctions RIGHT: " << seed_kmer.repr(
+                  _ksize) << std::endl;
 #endif
     StringVector right_paths;
     NonLoopingAT<RIGHT> rcursor(graph, seed_kmer, node_filters, &visited);
@@ -446,16 +450,17 @@ void JunctionCountAssembler::_assemble_directed(NonLoopingAT<direction>&
 const
 {
 #if DEBUG_ASSEMBLY
-    std::cout << "## assemble_junctions_directed_" << direction << " [start] at " << 
-        start_cursor.cursor.repr(_ksize) << std::endl;
+    std::cout << "## assemble_junctions_directed_" << direction << " [start] at " <<
+              start_cursor.cursor.repr(_ksize) << std::endl;
 #endif
 
     // prime the traversal with the first linear segment
-    std::string root_contig = linear_asm._assemble_directed<direction>(start_cursor);
+    std::string root_contig = linear_asm._assemble_directed<direction>
+                              (start_cursor);
 #if DEBUG_ASSEMBLY
     std::cout << "Primed: " << root_contig << std::endl;
     std::cout << "Cursor: " << start_cursor.cursor.repr(_ksize) << std::endl;
-#endif 
+#endif
     StringVector segments;
     std::vector< NonLoopingAT<direction> > cursors;
 
@@ -463,7 +468,7 @@ const
     cursors.push_back(start_cursor);
 
     while(segments.size() != 0) {
-        
+
         std::string segment = segments.back();
         NonLoopingAT<direction> cursor = cursors.back();
 #if DEBUG_ASSEMBLY
@@ -471,12 +476,12 @@ const
         std::cout << "Segment: " << segment << std::endl;
         std::cout << "Cursor: " << cursor.cursor.repr(_ksize) << std::endl;
         std::cout << "n_filters: " << cursor.n_filters() << std::endl;
-#endif 
+#endif
         segments.pop_back();
         cursors.pop_back();
 
         // check if the cursor has hit a HDN or reached a dead end
-        if (cursor.cursor_degree() > 1) { 
+        if (cursor.cursor_degree() > 1) {
 
             cursor.push_filter(get_junction_count_filter(cursor.cursor, this->junctions));
             KmerQueue branch_starts;
@@ -490,7 +495,7 @@ const
                 paths.push_back(segment);
                 continue;
             }
-            
+
             // found some neighbors; extend them
             while(!branch_starts.empty()) {
                 // spin off a cursor for the new branch

--- a/lib/hashbits.hh
+++ b/lib/hashbits.hh
@@ -53,7 +53,8 @@ namespace khmer
 class CountingHash;
 class LabelHash;
 
-class Hashbits : public Hashgraph {
+class Hashbits : public Hashgraph
+{
 public:
     explicit Hashbits(WordLength ksize, std::vector<uint64_t> sizes)
         : Hashgraph(ksize, new BitStorage(sizes)) { } ;

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -131,14 +131,16 @@ public:
     inline
     virtual
     HashIntoType
-    hash_dna(const char * kmer) const {
+    hash_dna(const char * kmer) const
+    {
         return _hash(kmer, _ksize);
     }
 
     inline
     virtual
     HashIntoType
-    hash_dna_top_strand(const char * kmer) const {
+    hash_dna_top_strand(const char * kmer) const
+    {
         HashIntoType f = 0, r = 0;
         _hash(kmer, _ksize, f, r);
         return f;
@@ -147,7 +149,8 @@ public:
     inline
     virtual
     HashIntoType
-    hash_dna_bottom_strand(const char * kmer) const {
+    hash_dna_bottom_strand(const char * kmer) const
+    {
         HashIntoType f = 0, r = 0;
         _hash(kmer, _ksize, f, r);
         return r;
@@ -156,27 +159,44 @@ public:
     inline
     virtual
     std::string
-    unhash_dna(HashIntoType hashval) const {
+    unhash_dna(HashIntoType hashval) const
+    {
         return _revhash(hashval, _ksize);
     }
 
-    void count(const char * kmer) { store->add(hash_dna(kmer)); }
-    void count(HashIntoType khash) { store->add(khash); }
-    void add(const char * kmer) { store->add(hash_dna(kmer)); }
-    void add(HashIntoType khash) { store->add(khash); }
+    void count(const char * kmer)
+    {
+        store->add(hash_dna(kmer));
+    }
+    void count(HashIntoType khash)
+    {
+        store->add(khash);
+    }
+    void add(const char * kmer)
+    {
+        store->add(hash_dna(kmer));
+    }
+    void add(HashIntoType khash)
+    {
+        store->add(khash);
+    }
 
     // get the count for the given k-mer.
-    const BoundedCounterType get_count(const char * kmer) const {
+    const BoundedCounterType get_count(const char * kmer) const
+    {
         return store->get_count(hash_dna(kmer));
     }
-    const BoundedCounterType get_count(HashIntoType khash) const {
+    const BoundedCounterType get_count(HashIntoType khash) const
+    {
         return store->get_count(khash);
     }
 
-    void save(std::string filename) {
+    void save(std::string filename)
+    {
         store->save(filename, _ksize);
     }
-    void load(std::string filename) {
+    void load(std::string filename)
+    {
         store->load(filename, _ksize);
         _init_bitstuff();
     }
@@ -209,8 +229,14 @@ public:
         unsigned long long  &n_consumed
     );
 
-    void set_use_bigcount(bool b) { store->set_use_bigcount(b); }
-    bool get_use_bigcount() { return store->get_use_bigcount(); }
+    void set_use_bigcount(bool b)
+    {
+        store->set_use_bigcount(b);
+    }
+    bool get_use_bigcount()
+    {
+        return store->get_use_bigcount();
+    }
 
     bool median_at_least(const std::string &s,
                          unsigned int cutoff);
@@ -221,16 +247,26 @@ public:
                           float &stddev);
 
     // number of unique k-mers
-    const uint64_t n_unique_kmers() const { return store->n_unique_kmers(); }
-    
+    const uint64_t n_unique_kmers() const
+    {
+        return store->n_unique_kmers();
+    }
+
     // count number of occupied bins
-    const uint64_t n_occupied() const { return store->n_occupied(); }
+    const uint64_t n_occupied() const
+    {
+        return store->n_occupied();
+    }
 
     // table information
-    std::vector<uint64_t> get_tablesizes() const {
+    std::vector<uint64_t> get_tablesizes() const
+    {
         return store->get_tablesizes();
     }
-    const size_t n_tables() const { return store->n_tables(); }
+    const size_t n_tables() const
+    {
+        return store->n_tables();
+    }
 
     // return all k-mer substrings, on the forward strand.
     void get_kmers(const std::string &s, std::vector<std::string> &kmers)
@@ -249,14 +285,18 @@ public:
                          std::vector<BoundedCounterType> &counts) const;
 
     // get access to raw tables.
-    Byte ** get_raw_tables() { return store->get_raw_tables(); }
+    Byte ** get_raw_tables()
+    {
+        return store->get_raw_tables();
+    }
 };
 
 //
 // Hashgraph: Extension of Hashtable to support graph operations.
 //
 
-class Hashgraph: public Hashtable {
+class Hashgraph: public Hashtable
+{
 
     friend class SubsetPartition;
     friend class LabelHash;
@@ -280,7 +320,7 @@ protected:
     {
         delete partition;
     }
-    
+
     void _clear_all_partitions()
     {
         if (partition != NULL) {
@@ -294,7 +334,7 @@ public:
     SeenSet all_tags;
     SeenSet stop_tags;
     SeenSet repart_small_tags;
-    
+
     virtual void save_tagset(std::string);
     virtual void load_tagset(std::string, bool clear_tags=true);
 
@@ -402,11 +442,11 @@ public:
                                       SeenSet &adjacencies,
                                       SeenSet &nodes, Hashtable& bf,
                                       SeenSet &high_degree_nodes) const;
-    
+
     //
     // for debugging/testing purposes only!
     //
-    
+
     // check partition map validity.
     void _validate_pmap()
     {

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -90,6 +90,7 @@ struct Read {
     std:: string    annotations;
     std:: string    sequence;
     std:: string    quality;
+    std:: string    cleaned_seq;
     // TODO? Add description field.
 
     inline void reset ( )

--- a/lib/storage.hh
+++ b/lib/storage.hh
@@ -48,7 +48,8 @@ class CountingHash;
 // base Storage class for hashtable-related storage of information in memory.
 //
 
-class Storage {
+class Storage
+{
 public:
     bool _use_bigcount;
 
@@ -86,7 +87,7 @@ public:
 
 class BitStorage : public Storage
 {
-friend class Hashbits;
+    friend class Hashbits;
 protected:
     std::vector<uint64_t> _tablesizes;
     size_t _n_tables;
@@ -95,14 +96,15 @@ protected:
     Byte ** _counts;
 
     BitStorage(std::vector<uint64_t>& tablesizes) :
-        _tablesizes(tablesizes) 
+        _tablesizes(tablesizes)
     {
         _occupied_bins = 0;
         _n_unique_kmers = 0;
 
         _allocate_counters();
     }
-    ~BitStorage() {
+    ~BitStorage()
+    {
         if (_counts) {
             for (size_t i = 0; i < _n_tables; i++) {
                 delete[] _counts[i];
@@ -114,7 +116,7 @@ protected:
             _n_tables = 0;
         }
     }
-    
+
     void _allocate_counters()
     {
         _n_tables = _tablesizes.size();
@@ -240,7 +242,8 @@ class CountingHashFileWriter;
 class CountingHashGzFileReader;
 class CountingHashGzFileWriter;
 
-class ByteStorage : public Storage {
+class ByteStorage : public Storage
+{
     friend class CountingHashFile;
     friend class CountingHashFileReader;
     friend class CountingHashFileWriter;
@@ -301,11 +304,23 @@ public:
         }
     }
 
-    std::vector<uint64_t> get_tablesizes() const { return _tablesizes; }
+    std::vector<uint64_t> get_tablesizes() const
+    {
+        return _tablesizes;
+    }
 
-    const uint64_t n_unique_kmers() const { return _n_unique_kmers; }
-    const size_t n_tables() const { return _n_tables; }
-    const uint64_t n_occupied() const { return _occupied_bins; }
+    const uint64_t n_unique_kmers() const
+    {
+        return _n_unique_kmers;
+    }
+    const size_t n_tables() const
+    {
+        return _n_tables;
+    }
+    const uint64_t n_occupied() const
+    {
+        return _occupied_bins;
+    }
 
     void save(std::string, WordLength);
     void load(std::string, WordLength&);
@@ -343,7 +358,7 @@ public:
             //	 However, do we actually care if there is a little
             //	 bit of slop here? It can always be trimmed off later, if
             //	 that would help with stats.
-            
+
             if ( _max_count > current_count ) {
                 __sync_add_and_fetch( *(_counts + i) + bin, 1 );
             } else {

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -123,6 +123,8 @@ def main():
 
     # decide where to put output files - specific directory? or just default?
     if infile in ('/dev/stdin', '-'):
+        # seqan only treats '-' as "read from stdin"
+        infile = '-'
         if not (args.output_paired and args.output_single):
             print("Accepting input from stdin; output filenames must be "
                   "provided.", file=sys.stderr)
@@ -157,7 +159,6 @@ def main():
     n_pe = 0
     n_se = 0
 
-    #screed_iter = screed.open(infile)
     screed_iter = ReadParser(infile)
     for index, is_pair, read1, read2 in broken_paired_reader(screed_iter):
         if index % 100000 == 0 and index > 0:

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -52,6 +52,7 @@ import textwrap
 import argparse
 
 from khmer import __version__
+from khmer import ReadParser
 from khmer.kfile import check_input_files, check_space
 from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
                               _VersionStdErrAction)
@@ -156,7 +157,8 @@ def main():
     n_pe = 0
     n_se = 0
 
-    screed_iter = screed.open(infile)
+    #screed_iter = screed.open(infile)
+    screed_iter = ReadParser(infile)
     for index, is_pair, read1, read2 in broken_paired_reader(screed_iter):
         if index % 100000 == 0 and index > 0:
             print('...', index, file=sys.stderr)

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -51,7 +51,8 @@ import sys
 import threading
 import textwrap
 import khmer
-import screed
+
+from khmer import ReadParser
 from khmer.utils import broken_paired_reader, write_record
 from khmer import khmer_args
 from khmer.khmer_args import (build_counting_args, report_on_config,
@@ -164,8 +165,8 @@ def main():
     outfp = open(outfile, 'wb')
     outfp = get_file_writer(outfp, args.gzip, args.bzip)
 
-    screed_iter = screed.open(args.datafile)
-    paired_iter = broken_paired_reader(screed_iter, min_length=graph.ksize(),
+    paired_iter = broken_paired_reader(ReadParser(args.datafile),
+                                       min_length=graph.ksize(),
                                        force_single=True)
 
     for n, is_pair, read1, read2 in paired_iter:

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -50,8 +50,9 @@ import os
 import textwrap
 import argparse
 import khmer
-import screed
+
 from khmer import __version__
+from khmer import ReadParser
 from khmer.utils import (broken_paired_reader, write_record)
 from khmer.khmer_args import (ComboFormatter, add_threading_args, info,
                               sanitize_help, _VersionStdErrAction,
@@ -152,8 +153,8 @@ def main():
             outfp = open(outfile, 'wb')
             outfp = get_file_writer(outfp, args.gzip, args.bzip)
 
-        screed_iter = screed.open(infile)
-        paired_iter = broken_paired_reader(screed_iter, min_length=ksize,
+        paired_iter = broken_paired_reader(ReadParser(infile),
+                                           min_length=ksize,
                                            force_single=True)
 
         for n, is_pair, read1, read2 in paired_iter:

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -48,13 +48,13 @@ Reads FASTQ and FASTA input, retains format for output.
 from __future__ import print_function
 
 import argparse
-import screed
 import os.path
 import random
 import textwrap
 import sys
 
 from khmer import __version__
+from khmer import ReadParser
 from khmer.kfile import (check_input_files, add_output_compression_type,
                          get_file_writer)
 from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
@@ -148,6 +148,11 @@ def main():
             sys.exit(1)
         output_filename = os.path.basename(filename) + '.subset'
 
+    filename = args.filenames[0]
+    if filename in ('/dev/stdin', '-'):
+        # seqan only treats '-' as "read from stdin"
+        filename = '-'
+
     if num_samples == 1:
         print('Subsampling %d reads using reservoir sampling.' %
               args.num_reads, file=sys.stderr)
@@ -169,10 +174,9 @@ def main():
     # read through all the sequences and load/resample the reservoir
     for filename in args.filenames:
         print('opening', filename, 'for reading', file=sys.stderr)
-        screed_iter = screed.open(filename)
 
         for count, (_, _, rcrd1, rcrd2) in enumerate(broken_paired_reader(
-                screed_iter, force_single=args.force_single)):
+                ReadParser(filename), force_single=args.force_single)):
             if count % 10000 == 0:
                 print('...', count, 'reads scanned', file=sys.stderr)
                 if count >= args.max_reads:

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2013-2015, Michigan State University.
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -45,12 +45,13 @@ files (.1 and .2).
 Reads FASTQ and FASTA input, retains format for output.
 """
 from __future__ import print_function
-import screed
 import sys
 import os
 import textwrap
 import argparse
+
 from khmer import __version__
+from khmer import ReadParser
 from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
                               _VersionStdErrAction)
 from khmer.utils import (write_record, broken_paired_reader,
@@ -133,6 +134,8 @@ def main():
 
     # decide where to put output files - specific directory? or just default?
     if infile in ('/dev/stdin', '-'):
+        # seqan only treats '-' as "read from stdin"
+        infile = '-'
         if not (args.output_first and args.output_second):
             print("Accepting input from stdin; "
                   "output filenames must be provided.", file=sys.stderr)
@@ -170,10 +173,8 @@ def main():
     counter3 = 0
     index = None
 
-    screed_iter = screed.open(infile)
-
     # walk through all the reads in broken-paired mode.
-    paired_iter = broken_paired_reader(screed_iter,
+    paired_iter = broken_paired_reader(ReadParser(infile),
                                        require_paired=not args.output_orphaned)
 
     try:

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -53,8 +53,8 @@ import shutil
 import textwrap
 import argparse
 
-from screed import Record
 from khmer import khmer_args
+from khmer import ReadParser
 
 from khmer.khmer_args import (build_counting_args, info, add_loadgraph_args,
                               report_on_config, calculate_graphsize,
@@ -365,8 +365,7 @@ def main():
         pass2list.append((filename, pass2filename, trimfp))
 
         # input file stuff: get a broken_paired reader.
-        screed_iter = screed.open(filename)
-        paired_iter = broken_paired_reader(screed_iter, min_length=K,
+        paired_iter = broken_paired_reader(ReadParser(filename), min_length=K,
                                            force_single=args.ignore_pairs)
 
         # main loop through the file.
@@ -420,8 +419,8 @@ def main():
         # so pairs will stay together if not orphaned.  This is in contrast
         # to the first loop.  Hence, force_single=True below.
 
-        screed_iter = screed.open(pass2filename, parse_description=False)
-        paired_iter = broken_paired_reader(screed_iter, min_length=K,
+        paired_iter = broken_paired_reader(ReadParser(pass2filename),
+                                           min_length=K,
                                            force_single=True)
 
         watermark = REPORT_EVERY_N_READS

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -539,7 +539,7 @@ class TestNonBranching:
         for start in range(0, len(contig), 150):
             path = asm.assemble(contig[start:start + K], direction='L')
             print(path, ', ', contig[:start])
-            assert utils._equals_rc(path, contig[:start+K]), start
+            assert utils._equals_rc(path, contig[:start + K]), start
 
     def test_all_right_to_end(self, linear_structure):
         # assemble directed right

--- a/tests/test_read_handling.py
+++ b/tests/test_read_handling.py
@@ -259,36 +259,6 @@ def test_interleave_reads_2_fa():
     assert n > 0
 
 
-def execute_split_paired_streaming(ifilename):
-    fifo = utils.get_temp_filename('fifo')
-    in_dir = os.path.dirname(fifo)
-    outfile1 = utils.get_temp_filename('paired-1.fa')
-    outfile2 = utils.get_temp_filename('paired-2.fa')
-    script = 'split-paired-reads.py'
-    args = [fifo, '-1', outfile1, '-2', outfile2]
-
-    # make a fifo to simulate streaming
-    os.mkfifo(fifo)
-
-    thread = threading.Thread(target=utils.runscript,
-                              args=(script, args, in_dir))
-    thread.start()
-    ifile = open(ifilename, 'r')
-    fifofile = open(fifo, 'w')
-    chunk = ifile.read(4)
-    while len(chunk) > 0:
-        fifofile.write(chunk)
-        chunk = ifile.read(4)
-    fifofile.close()
-    thread.join()
-    assert os.path.exists(outfile1), outfile1
-    assert os.path.exists(outfile2), outfile2
-
-
-def test_split_paired_streaming():
-    o = execute_split_paired_streaming(utils.get_test_data('paired.fa'))
-
-
 def test_split_paired_reads_1_fa():
     # test input file
     infile = utils.get_test_data('paired.fa')

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -72,6 +72,8 @@ def test_read_type_attributes():
     # test setting and deleting of cleaned_seq
     assert not hasattr(r, 'cleaned_seq')
     r.cleaned_seq = "ACGT"
+    r.cleaned_seq = u"ACGT"
+
     assert hasattr(r, 'cleaned_seq')
     del r.cleaned_seq
     assert not hasattr(r, 'cleaned_seq')
@@ -80,7 +82,7 @@ def test_read_type_attributes():
         r.cleaned_seq = 12
 
     with pytest.raises(TypeError):
-        r.cleaned_seq = "some weird unicode \u2588"
+        r.cleaned_seq = u"some weird unicode \u2588"
 
 
 def test_read_properties():

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -70,6 +70,10 @@ def test_read_type_attributes():
     assert r.name == '1234'
     assert r.annotations == 'ann'
     # test setting and deleting of cleaned_seq
+
+    with pytest.raises(TypeError):
+        r.cleaned_seq = 12
+
     assert not hasattr(r, 'cleaned_seq')
     r.cleaned_seq = "ACGT"
     r.cleaned_seq = u"ACGT"
@@ -77,9 +81,6 @@ def test_read_type_attributes():
     assert hasattr(r, 'cleaned_seq')
     del r.cleaned_seq
     assert not hasattr(r, 'cleaned_seq')
-
-    with pytest.raises(TypeError):
-        r.cleaned_seq = 12
 
     with pytest.raises(TypeError):
         r.cleaned_seq = u"some weird unicode \u2588"

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -69,6 +69,18 @@ def test_read_type_attributes():
     assert r.quality == 'good'
     assert r.name == '1234'
     assert r.annotations == 'ann'
+    # test setting and deleting of cleaned_seq
+    assert not hasattr(r, 'cleaned_seq')
+    r.cleaned_seq = "ACGT"
+    assert hasattr(r, 'cleaned_seq')
+    del r.cleaned_seq
+    assert not hasattr(r, 'cleaned_seq')
+
+    with pytest.raises(TypeError):
+        r.cleaned_seq = 12
+
+    with pytest.raises(TypeError):
+        r.cleaned_seq = "some weird unicode \u2588"
 
 
 def test_read_properties():

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1603,12 +1603,15 @@ def execute_extract_paired_streaming(ifilename):
 
     # make a fifo to simulate streaming
     os.mkfifo(fifo)
+    dummy_fd = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
 
+    #import pdb; pdb.set_trace()
     thread = threading.Thread(target=utils.runscript,
                               args=(script, args, in_dir))
-    thread.start()
+
     ifile = open(ifilename, 'r')
     fifofile = open(fifo, 'w')
+    thread.start()
     chunk = ifile.read(4)
     while len(chunk) > 0:
         fifofile.write(chunk)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1593,40 +1593,6 @@ def test_make_initial_stoptags_load_stoptags():
     assert os.path.exists(outfile1), outfile1
 
 
-def execute_extract_paired_streaming(ifilename):
-    fifo = utils.get_temp_filename('fifo')
-    in_dir = os.path.dirname(fifo)
-    outfile1 = utils.get_temp_filename('paired.pe')
-    outfile2 = utils.get_temp_filename('paired.se')
-    script = 'extract-paired-reads.py'
-    args = [fifo, '-p', outfile1, '-s', outfile2]
-
-    # make a fifo to simulate streaming
-    os.mkfifo(fifo)
-    dummy_fd = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
-
-    #import pdb; pdb.set_trace()
-    thread = threading.Thread(target=utils.runscript,
-                              args=(script, args, in_dir))
-
-    ifile = open(ifilename, 'r')
-    fifofile = open(fifo, 'w')
-    thread.start()
-    chunk = ifile.read(4)
-    while len(chunk) > 0:
-        fifofile.write(chunk)
-        chunk = ifile.read(4)
-    fifofile.close()
-    thread.join()
-    assert os.path.exists(outfile1), outfile1
-    assert os.path.exists(outfile2), outfile2
-
-
-def test_extract_paired_streaming():
-    testinput = utils.get_test_data('paired-mixed.fa')
-    o = execute_extract_paired_streaming(testinput)
-
-
 def test_sample_reads_randomly():
     infile = utils.copy_test_data('test-reads.fa')
     in_dir = os.path.dirname(infile)

--- a/tests/test_streaming_io.py
+++ b/tests/test_streaming_io.py
@@ -1,5 +1,5 @@
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
-# Copyright (C) 2015, The Regents of the University of California.
+# Copyright (C) 2015-2016, The Regents of the University of California.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are

--- a/tests/test_streaming_io.py
+++ b/tests/test_streaming_io.py
@@ -210,6 +210,24 @@ def test_extract_paired_se():
     assert files_are_equal(out1, out_test), diff_files(out1, out_test)
 
 
+def test_extract_paired_stdin_equivalence():
+    # Use '/dev/stdin' instead of '-' to check it is treated the same way
+    in1 = utils.get_test_data('paired-mixed.fq')
+    out_test = utils.get_test_data('paired-mixed.fq.se')
+    out1 = utils.get_temp_filename('a.fq')
+
+    cmd = """
+       cat {in1} |
+       {scripts}/extract-paired-reads.py /dev/stdin -p /dev/null -s - > {out1}
+    """
+
+    cmd = cmd.format(scripts=scriptpath(), in1=in1, out1=out1)
+
+    run_shell_cmd(cmd)
+
+    assert files_are_equal(out1, out_test), diff_files(out1, out_test)
+
+
 def test_extract_paired_se_fail():
     in1 = utils.get_test_data('paired-mixed.fq')
     out1 = utils.get_temp_filename('a.fq')


### PR DESCRIPTION
Fix #1098
and related to #1483 

After getting started on this I realised I wasn't sure how we wanted to use this. So far I am assuming the use case is to replace `utils.ReadBundle` as used in for example `trim-low-abund.py`.

Is it really worth it? We will end up turning all the screed `Records` into `read_parser::Read`s via various unicode -> bytes stuff, to then do some computation on them. In the current setup we pass the cleaned sequence to `get_median_count` and friends. Maybe there is something I am missing.
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

ReadBundles group several Reads together.
