### PR TITLE
Make `Read` accessible from python

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-11-04  Tim Head  <betatim@gmail.com>
+
+   * Make khmer's Read type accesible from the python API.
+
 2016-11-03  Titus Brown  <titus@idyll.org>
 
    * lib/{counting.cc,counting.hh,hashbits.cc,hashbits.hh,hashtable.cc,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2016-11-04  Tim Head  <betatim@gmail.com>
 
-   * Make khmer's Read type accesible from the python API.
+   * Make khmer's Read type accessible from the python API.
 
 2016-11-03  Titus Brown  <titus@idyll.org>
 

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -46,6 +46,7 @@ from khmer._khmer import Nodegraph as _Nodegraph
 from khmer._khmer import HLLCounter as _HLLCounter
 from khmer._khmer import ReadAligner as _ReadAligner
 from khmer._khmer import HashSet
+from khmer._khmer import Read
 from khmer._khmer import forward_hash
 # tests/test_{functions,countgraph,counting_single}.py
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -299,7 +299,8 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
     const char * quality{};
     char *kwlist[5] = {
         const_cast<char *>("name"), const_cast<char *>("sequence"),
-        const_cast<char *>("quality"), const_cast<char *>("annotations"), NULL};
+        const_cast<char *>("quality"), const_cast<char *>("annotations"), NULL
+    };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzz", kwlist,
                                      &name, &sequence, &quality, &annotations)) {
@@ -337,8 +338,7 @@ Read_get_name(khmer_Read_Object * obj, void * closure )
 {
     if (obj->read->name.size() > 0) {
         return PyUnicode_FromString(obj->read->name.c_str());
-    }
-    else {
+    } else {
         PyErr_SetString(PyExc_AttributeError,
                         "'Read' object has no attribute 'name'.");
         return NULL;
@@ -352,8 +352,7 @@ Read_get_sequence(khmer_Read_Object * obj, void * closure)
 {
     if (obj->read->sequence.size() > 0) {
         return PyUnicode_FromString(obj->read->sequence.c_str());
-    }
-    else {
+    } else {
         PyErr_SetString(PyExc_AttributeError,
                         "'Read' object has no attribute 'sequence'.");
         return NULL;
@@ -367,8 +366,7 @@ Read_get_quality(khmer_Read_Object * obj, void * closure)
 {
     if (obj->read->quality.size() > 0) {
         return PyUnicode_FromString(obj->read->quality.c_str());
-    }
-    else {
+    } else {
         PyErr_SetString(PyExc_AttributeError,
                         "'Read' object has no attribute 'quality'.");
         return NULL;
@@ -382,8 +380,7 @@ Read_get_annotations(khmer_Read_Object * obj, void * closure)
 {
     if (obj->read->annotations.size() > 0) {
         return PyUnicode_FromString(obj->read->annotations.c_str());
-    }
-    else {
+    } else {
         PyErr_SetString(PyExc_AttributeError,
                         "'Read' object has no attribute 'annotations'.");
         return NULL;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -302,7 +302,7 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
         const_cast<char *>("quality"), const_cast<char *>("annotations"), NULL
     };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzz", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "ss|zz", kwlist,
                                      &name, &sequence, &quality, &annotations)) {
         return 0;
     }

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -297,10 +297,13 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
     const char * annotations{};
     const char * sequence{};
     const char * quality{};
-    static char *kwlist[] = {"name", "annotations", "sequence", "quality", NULL};
+    char *kwlist[5] = {
+        const_cast<char *>("name"), const_cast<char *>("annotations"),
+        const_cast<char *>("sequence"), const_cast<char *>("quality"), NULL};
+
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzz", kwlist,
                                      &name, &sequence, &quality, &annotations)) {
-        return NULL;
+        return 0;
     }
 
     if (name != NULL) {
@@ -388,6 +391,24 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
     { NULL, NULL, NULL, NULL, NULL } // sentinel
 };
 
+static
+PyObject *
+khmer_Read_getattr(PyObject *self, PyObject *attr_name)
+{
+  PyObject * ascii = PyUnicode_AsASCIIString(attr_name);
+  const char * c = PyBytes_AsString(ascii);
+  std::cout << c << std::endl;
+  if (!strncmp(c, "name", 4)) {
+    std::cout << "special" << std::endl;
+    PyErr_SetString(PyExc_AttributeError,
+                           "'Read' object has no attribute.");
+    return NULL;
+  }
+  Py_DECREF(ascii);
+  Py_INCREF(Py_None);
+  return Py_None;
+}
+
 
 static PyTypeObject khmer_Read_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
@@ -406,7 +427,7 @@ static PyTypeObject khmer_Read_Type = {
     0,                                    /* tp_hash */
     0,                                    /* tp_call */
     0,                                    /* tp_str */
-    0,                                    /* tp_getattro */
+    khmer_Read_getattr,                   /* tp_getattro */
     0,                                    /* tp_setattro */
     0,                                    /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                   /* tp_flags */

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -335,7 +335,14 @@ static
 PyObject *
 Read_get_name(khmer_Read_Object * obj, void * closure )
 {
-    return PyUnicode_FromString(obj->read->name.c_str()) ;
+    if (obj->read->name.size() > 0) {
+        return PyUnicode_FromString(obj->read->name.c_str());
+    }
+    else {
+        PyErr_SetString(PyExc_AttributeError,
+                        "'Read' object has no attribute 'name'.");
+        return NULL;
+    }
 }
 
 
@@ -343,7 +350,14 @@ static
 PyObject *
 Read_get_sequence(khmer_Read_Object * obj, void * closure)
 {
-    return PyUnicode_FromString(obj->read->sequence.c_str()) ;
+    if (obj->read->sequence.size() > 0) {
+        return PyUnicode_FromString(obj->read->sequence.c_str());
+    }
+    else {
+        PyErr_SetString(PyExc_AttributeError,
+                        "'Read' object has no attribute 'sequence'.");
+        return NULL;
+    }
 }
 
 
@@ -351,7 +365,14 @@ static
 PyObject *
 Read_get_quality(khmer_Read_Object * obj, void * closure)
 {
-    return PyUnicode_FromString(obj->read->quality.c_str()) ;
+    if (obj->read->quality.size() > 0) {
+        return PyUnicode_FromString(obj->read->quality.c_str());
+    }
+    else {
+        PyErr_SetString(PyExc_AttributeError,
+                        "'Read' object has no attribute 'quality'.");
+        return NULL;
+    }
 }
 
 
@@ -359,7 +380,14 @@ static
 PyObject *
 Read_get_annotations(khmer_Read_Object * obj, void * closure)
 {
-    return PyUnicode_FromString(obj->read->annotations.c_str()) ;
+    if (obj->read->annotations.size() > 0) {
+        return PyUnicode_FromString(obj->read->annotations.c_str());
+    }
+    else {
+        PyErr_SetString(PyExc_AttributeError,
+                        "'Read' object has no attribute 'annotations'.");
+        return NULL;
+    }
 }
 
 
@@ -392,63 +420,6 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
 };
 
 
-static
-PyObject *
-khmer_Read_getattr(khmer_Read_Object *self, PyObject *attr_name)
-{
-    char *name{};
-    PyObject * rval = NULL;
-
-    if (PyUnicode_Check(attr_name))
-        name = _PyUnicode_AsString(attr_name);
-
-    if (strcmp(name, "name") == 0) {
-        if (self->read->name.size() > 0) {
-            rval = PyUnicode_FromString(self->read->name.c_str());
-        }
-        else {
-            PyErr_SetString(PyExc_AttributeError,
-                            "'Read' object has no attribute 'name'.");
-            rval = NULL;
-        }
-    }
-    else if (strcmp(name, "sequence") == 0) {
-        if (self->read->sequence.size() > 0) {
-            rval = PyUnicode_FromString(self->read->sequence.c_str());
-        }
-        else {
-            PyErr_SetString(PyExc_AttributeError,
-                            "'Read' object has no attribute 'sequence'.");
-            rval = NULL;
-        }
-    }
-    else if (strcmp(name, "quality") == 0) {
-        if (self->read->quality.size() > 0) {
-            rval = PyUnicode_FromString(self->read->quality.c_str());
-        }
-        else {
-            PyErr_SetString(PyExc_AttributeError,
-                            "'Read' object has no attribute 'quality'.");
-            rval = NULL;
-        }
-    }
-    else if (strcmp(name, "annotations") == 0) {
-        if (self->read->annotations.size() > 0) {
-            rval = PyUnicode_FromString(self->read->annotations.c_str());
-        }
-        else {
-            PyErr_SetString(PyExc_AttributeError,
-                            "'Read' object has no attribute 'annotations'.");
-            rval = NULL;
-        }
-    }
-    else {
-        rval = PyObject_GenericGetAttr((PyObject *)self, attr_name);
-    }
-    return rval;
-}
-
-
 static PyTypeObject khmer_Read_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
     "khmer.Read",                         /* tp_name */
@@ -466,7 +437,7 @@ static PyTypeObject khmer_Read_Type = {
     0,                                    /* tp_hash */
     0,                                    /* tp_call */
     0,                                    /* tp_str */
-    (getattrofunc)khmer_Read_getattr,     /* tp_getattro */
+    0,                                    /* tp_getattro */
     0,                                    /* tp_setattro */
     0,                                    /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                   /* tp_flags */

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -278,6 +278,47 @@ typedef struct {
 
 
 static
+PyObject*
+khmer_Read_new(PyTypeObject * type, PyObject * args, PyObject * kwds)
+{
+    khmer_Read_Object * self;
+    self = (khmer_Read_Object *)type->tp_alloc(type, 0);
+    if (self != NULL) {
+        self->read = new Read;
+    }
+    return (PyObject *)self;
+}
+
+static
+int
+khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
+{
+    const char * name{};
+    const char * annotations{};
+    const char * sequence{};
+    const char * quality{};
+    static char *kwlist[] = {"name", "annotations", "sequence", "quality", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzz", kwlist,
+                                     &name, &sequence, &quality, &annotations)) {
+        return NULL;
+    }
+
+    if (name != NULL) {
+        self->read->name = name;
+    }
+    if (sequence != NULL) {
+        self->read->sequence = sequence;
+    }
+    if (quality != NULL) {
+        self->read->quality = quality;
+    }
+    if (annotations != NULL) {
+        self->read->annotations = annotations;
+    }
+    return 0;
+}
+
+static
 void
 khmer_Read_dealloc(khmer_Read_Object * obj)
 {
@@ -350,7 +391,7 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
 
 static PyTypeObject khmer_Read_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)        /* init & ob_size */
-    "_khmer.Read",                        /* tp_name */
+    "khmer.Read",                         /* tp_name */
     sizeof(khmer_Read_Object),            /* tp_basicsize */
     0,                                    /* tp_itemsize */
     (destructor)khmer_Read_dealloc,       /* tp_dealloc */
@@ -379,7 +420,16 @@ static PyTypeObject khmer_Read_Type = {
     0,                                    /* tp_methods */
     0,                                    /* tp_members */
     (PyGetSetDef *)khmer_Read_accessors,  /* tp_getset */
+    0,                                    /* tp_base */
+    0,                                    /* tp_dict */
+    0,                                    /* tp_descr_get */
+    0,                                    /* tp_descr_set */
+    0,                                    /* tp_dictoffset */
+    (initproc)khmer_Read_init,            /* tp_init */
+    0,                                    /* tp_alloc */
+    khmer_Read_new,                       /* tp_new */
 };
+
 
 /***********************************************************************/
 
@@ -5464,6 +5514,12 @@ MOD_INIT(_khmer)
             KhmerMethods);
 
     if (m == NULL) {
+        return MOD_ERROR_VAL;
+    }
+
+    Py_INCREF(&khmer_Read_Type);
+    if (PyModule_AddObject( m, "Read",
+                            (PyObject *)&khmer_Read_Type ) < 0) {
         return MOD_ERROR_VAL;
     }
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -298,8 +298,8 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
     const char * sequence{};
     const char * quality{};
     char *kwlist[5] = {
-        const_cast<char *>("name"), const_cast<char *>("annotations"),
-        const_cast<char *>("sequence"), const_cast<char *>("quality"), NULL};
+        const_cast<char *>("name"), const_cast<char *>("sequence"),
+        const_cast<char *>("quality"), const_cast<char *>("annotations"), NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzz", kwlist,
                                      &name, &sequence, &quality, &annotations)) {
@@ -391,22 +391,61 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
     { NULL, NULL, NULL, NULL, NULL } // sentinel
 };
 
+
 static
 PyObject *
-khmer_Read_getattr(PyObject *self, PyObject *attr_name)
+khmer_Read_getattr(khmer_Read_Object *self, PyObject *attr_name)
 {
-  PyObject * ascii = PyUnicode_AsASCIIString(attr_name);
-  const char * c = PyBytes_AsString(ascii);
-  std::cout << c << std::endl;
-  if (!strncmp(c, "name", 4)) {
-    std::cout << "special" << std::endl;
-    PyErr_SetString(PyExc_AttributeError,
-                           "'Read' object has no attribute.");
-    return NULL;
-  }
-  Py_DECREF(ascii);
-  Py_INCREF(Py_None);
-  return Py_None;
+    char *name{};
+    PyObject * rval = NULL;
+
+    if (PyUnicode_Check(attr_name))
+        name = _PyUnicode_AsString(attr_name);
+
+    if (strcmp(name, "name") == 0) {
+        if (self->read->name.size() > 0) {
+            rval = PyUnicode_FromString(self->read->name.c_str());
+        }
+        else {
+            PyErr_SetString(PyExc_AttributeError,
+                            "'Read' object has no attribute 'name'.");
+            rval = NULL;
+        }
+    }
+    else if (strcmp(name, "sequence") == 0) {
+        if (self->read->sequence.size() > 0) {
+            rval = PyUnicode_FromString(self->read->sequence.c_str());
+        }
+        else {
+            PyErr_SetString(PyExc_AttributeError,
+                            "'Read' object has no attribute 'sequence'.");
+            rval = NULL;
+        }
+    }
+    else if (strcmp(name, "quality") == 0) {
+        if (self->read->quality.size() > 0) {
+            rval = PyUnicode_FromString(self->read->quality.c_str());
+        }
+        else {
+            PyErr_SetString(PyExc_AttributeError,
+                            "'Read' object has no attribute 'quality'.");
+            rval = NULL;
+        }
+    }
+    else if (strcmp(name, "annotations") == 0) {
+        if (self->read->annotations.size() > 0) {
+            rval = PyUnicode_FromString(self->read->annotations.c_str());
+        }
+        else {
+            PyErr_SetString(PyExc_AttributeError,
+                            "'Read' object has no attribute 'annotations'.");
+            rval = NULL;
+        }
+    }
+    else {
+        rval = PyObject_GenericGetAttr((PyObject *)self, attr_name);
+    }
+    return rval;
 }
 
 
@@ -427,7 +466,7 @@ static PyTypeObject khmer_Read_Type = {
     0,                                    /* tp_hash */
     0,                                    /* tp_call */
     0,                                    /* tp_str */
-    khmer_Read_getattr,                   /* tp_getattro */
+    (getattrofunc)khmer_Read_getattr,     /* tp_getattro */
     0,                                    /* tp_setattro */
     0,                                    /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                   /* tp_flags */

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -284,7 +284,12 @@ khmer_Read_new(PyTypeObject * type, PyObject * args, PyObject * kwds)
     khmer_Read_Object * self;
     self = (khmer_Read_Object *)type->tp_alloc(type, 0);
     if (self != NULL) {
-        self->read = new Read;
+        try {
+            self->read = new Read;
+        } catch (std::bad_alloc &exc) {
+            Py_DECREF(self);
+            return PyErr_NoMemory();
+        }
     }
     return (PyObject *)self;
 }
@@ -304,7 +309,7 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "ss|zz", kwlist,
                                      &name, &sequence, &quality, &annotations)) {
-        return 0;
+        return -1;
     }
 
     if (name != NULL) {

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -37,11 +37,18 @@
 # Tests for the ReadParser and Read classes.
 from __future__ import print_function
 from __future__ import absolute_import
+from khmer import Read
 from khmer import ReadParser
 from . import khmer_tst_utils as utils
 import pytest
 from functools import reduce  # pylint: disable=redefined-builtin
 
+
+def test_read_type_basic():
+    # basic properties of khmer.Read
+    r = Read()
+    for attr in ('sequence', 'name', 'quality', 'annotations'):
+        assert hasattr(r, attr) == False, attr
 
 def test_read_properties():
 

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -47,6 +47,10 @@ from functools import reduce  # pylint: disable=redefined-builtin
 
 def test_read_type_basic():
     # test that basic properties of khmer.Read behave like screed.Record
+    # Constructing without mandatory arguments should raise an exception
+    with pytest.raises(TypeError):
+        Read()
+
     name = "895:1:1:1246:14654 1:N:0:NNNNN"
     sequence = "ACGT"
     r = Read(name, sequence)

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -50,8 +50,8 @@ def test_read_type_basic():
     r = Read()
     s = Record()
     for attr in ('sequence', 'name', 'quality', 'annotations'):
-        assert hasattr(r, attr) == False, attr
-        assert hasattr(s, attr) == False, attr
+        assert not hasattr(r, attr), attr
+        assert not hasattr(s, attr), attr
 
 
 def test_read_type_attributes():
@@ -71,7 +71,8 @@ def test_read_properties():
     for read in rparser:
         assert read.name == "895:1:1:1246:14654 1:N:0:NNNNN"
         assert read.sequence == "CAGGCGCCCACCACCGTGCCCTCCAACCTGATGGT"
-        assert read.annotations == ""
+        # if an attribute is empty it shouldn't exist
+        assert not hasattr(read, 'annotations')
         assert read.quality == """][aaX__aa[`ZUZ[NONNFNNNNNO_____^RQ_"""
 
 

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -39,16 +39,28 @@ from __future__ import print_function
 from __future__ import absolute_import
 from khmer import Read
 from khmer import ReadParser
+from screed import Record
 from . import khmer_tst_utils as utils
 import pytest
 from functools import reduce  # pylint: disable=redefined-builtin
 
 
 def test_read_type_basic():
-    # basic properties of khmer.Read
+    # test that basic properties of khmer.Read behave like screed.Record
     r = Read()
+    s = Record()
     for attr in ('sequence', 'name', 'quality', 'annotations'):
         assert hasattr(r, attr) == False, attr
+        assert hasattr(s, attr) == False, attr
+
+
+def test_read_type_attributes():
+    r = Read(sequence='ACGT', quality='good', name='1234', annotations='ann')
+    assert r.sequence == 'ACGT'
+    assert r.quality == 'good'
+    assert r.name == '1234'
+    assert r.annotations == 'ann'
+
 
 def test_read_properties():
 

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -47,11 +47,16 @@ from functools import reduce  # pylint: disable=redefined-builtin
 
 def test_read_type_basic():
     # test that basic properties of khmer.Read behave like screed.Record
-    r = Read()
-    s = Record()
-    for attr in ('sequence', 'name', 'quality', 'annotations'):
-        assert not hasattr(r, attr), attr
-        assert not hasattr(s, attr), attr
+    name = "895:1:1:1246:14654 1:N:0:NNNNN"
+    sequence = "ACGT"
+    r = Read(name, sequence)
+    s = Record(dict(name=name, sequence=sequence))
+
+    for x in (r, s):
+        assert x.name == name
+        assert x.sequence == sequence
+        assert not hasattr(x, 'quality'), x
+        assert not hasattr(x, 'annotations'), x
 
 
 def test_read_type_attributes():


### PR DESCRIPTION
Fixes #769 

This makes `khmer.Read` accessible from python land. If you do not set one of the attributes `hasattr` will return `False`.
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?
