### PR TITLE
Fix linear path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-10-28  Daniel Standage  <daniel.standage@gmail.com>
+
+   * lib/hashtable.cc,tests/test_nodegraph.py: fix bug in assemble_linear_path
+     that returns seed k-mer even if it is not present in the DBG.
+
 2016-10-13  Camille Scott  <camille.scott.w@gmail.com>
 
    * Wrap IO functions in with an extra catch to handle the gcc

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -1132,6 +1132,12 @@ std::string Hashtable::assemble_linear_path(const Kmer seed_kmer,
         const Hashtable * stop_bf)
 const
 {
+    if (get_count(seed_kmer) == 0) {
+        // If the seed k-mer is not in the de Bruijn graph, stop trying to make
+        // something happen. It's not going to happen!
+        return "";
+    }
+
     std::string start_kmer = seed_kmer.get_string_rep(_ksize);
     std::string right = _assemble_right(start_kmer.c_str(), stop_bf);
 

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -1353,3 +1353,15 @@ def test_assemble_linear_path_single_node_interrupted():
     print('len path:', len_path)
 
     assert _equals_rc(path, contig)       # this is bad behavior...
+
+
+def test_assemble_linear_path_bad_seed():
+    # assemble single node.
+    contigfile = utils.get_test_data('simple-genome.fa')
+    contig = list(screed.open(contigfile))[0].sequence
+
+    nodegraph = khmer.Nodegraph(21, 1e5, 4)
+    nodegraph.consume(contig)
+
+    path = nodegraph.assemble_linear_path('GATTACA' * 3)
+    assert path == ''


### PR DESCRIPTION
Currently calling `assemble_linear_path` with a seed _k_-mer that is not in the DBG will return the seed _k_-mer (or its reverse complement). I'm not sure if this is a feature or a bug, but I'd argue it's misleading. This PR treats it as a bug and returns an empty string if the seed _k_-mer is not in the DBG.
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- <strike>[ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.</strike>
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- <strike>[ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)</strike>
- [x] Is the Copyright year up to date?
