### PR TITLE
Fix two installation quirks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2016-11-07  Luiz Irber  <khmer@luizirber.org>
+
+   * Makefile: add --ignore-installed flag to pip install (fix installation
+   on conda environments.
+   * doc/requirements.txt: change hard requirement to 'newer than', avoid
+   installing a quite old setuptools version.
+
 2016-11-04  Tim Head  <betatim@gmail.com>
 
    * Make khmer's Read type accessible from the python API.

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ install-dep: install-dependencies
 
 install-dependencies:
 	pip install git+https://github.com/dib-lab/screed.git
-	pip install --upgrade $(DEVPKGS)
+	pip install --upgrade --ignore-installed $(DEVPKGS)
 	pip install --upgrade --requirement doc/requirements.txt
 
 ## sharedobj   : build khmer shared object file

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
 sphinxcontrib-autoprogram>=0.1.2
-setuptools==3.4.1
+setuptools>=3.4.1


### PR DESCRIPTION
- Quirk 1: `doc/requirements.txt` forced `setuptools==3.4.1`, which is super old and breaks installations inside Anaconda (sometimes)
- Quirk 2: `pip` sometimes fails because it can't find a `easy_install.pth` inside the Anaconda `site-packages` (makes sense, no conda package should be installing it), and apparently the fix is to use the `--ignore-installed` flag. [Source](https://github.com/pypa/pip/issues/2751#issuecomment-165390180)

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

