### PR TITLE
fix documentation build failure on ReadTheDocs from bad autoprogram version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-11-11  Titus Brown  <titus@idyll.org>
+
+  * doc/requirements.txt: set autoprogram version requirements to something
+  that works on python 2.7, in order to fix ReadTheDocs builds.
+
 2016-11-10  Camille Scott  <camille.scott.w@gmail.com>
 
   * lib/assembler.{hh,cc}: add JunctionCountAssembler implementation.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinxcontrib-autoprogram>=0.1.2
+sphinxcontrib-autoprogram==0.1.2
 setuptools>=3.4.1


### PR DESCRIPTION
Doc builds have been failing for a while (see e.g. [this])(https://readthedocs.org/projects/khmer/builds/4650703/) since we allowed newer version of autoprogram in doc/requirements.txt with

```
sphinxcontrib-autoprogram>=0.1.2
```

but the 0.1.3 release of autoprogram [breaks on python 2.7](https://bitbucket.org/birkenfeld/sphinx-contrib/issues/168/autoprogram-013-fails-on-python-27-due-to).  This PR fixes it by nailing autoprogram down to 0.1.2 which works ([see here](https://khmer.readthedocs.io/en/fix-rtd/)).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [x] Is the Copyright year up to date?

