### PR TITLE
Whitelist master branch for travis build-on-push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ dist: trusty
 notifications:
   email: false
 
+# with building pushes enabled on travis we would get
+# two builds for every new commit pushed to a branch
+# for a PR. So we disable build-on-push for all branches
+# except the ones whitelisted here.
+branches:
+  only: 
+    - master
 
 matrix:
   fast_finish: true

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-11-14  Tim Head  <betatim@gmail.com>
+
+  * .travis.yml: whitelist `master` branch to allow build-on-push without
+  building every push for a PR twice.
+
 2016-11-11  Titus Brown  <titus@idyll.org>
 
   * doc/requirements.txt: set autoprogram version requirements to something


### PR DESCRIPTION
Fixes #1512 

We need build-on-push to re-run travis when a PR is merged to generate
coverage information. Without this explicit whitelist we would
build every push to a PR related branch twice.

This PR goes together with toggling "build on push" in [the settings](https://travis-ci.org/dib-lab/khmer/settings). Did this for now.

nb. We need to do this bit of gymnastics because we use the origin
repo to also store the branches for PRs. A lot of projects keep those
in the user's repo so you can just flick the "build on push" switch in
the [travis config](https://travis-ci.org/dib-lab/khmer/settings)

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?

