### PR TITLE
Clean up README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,13 @@ them, please visit the following URLs:
 
 -  Announcements: http://lists.idyll.org/listinfo/khmer-announce
 
-We chat at https://gitter.im/dib-lab/khmer and the maintainers can be
-contacted at khmer-project@idyll.org.
+We have a slack chat that [you can join](LINK/EMAIL/JOIN) and the maintainers
+can be contacted at khmer-project@idyll.org.
 
 For getting help please see this guide: http://khmer.readthedocs.io/en/stable/user/getting-help.html
 
-IMPORTANT NOTE: CITE US!
+
+Important note: cite us!
 ------------------------
 
 khmer is *research software*, so you should cite us when you use it
@@ -75,25 +76,33 @@ in scientific publications!  Please see the `CITATION
 <http://khmer.readthedocs.io/en/stable/citations.html>`__ file for
 citation information.
 
-INSTALL INSTRUCTIONS:
----------------------
 
-khmer requires a 64-bit operating system and Python version 2.7.x, 3.3.x, or
-3.4.x. Linux users will need the Python development libraries and gcc. OS X
-users may need XCode installed to build from source.
+Install
+-------
 
-In short:
+khmer works with Python version 2.7 or 3.5. Create a
+`virtual environemnt <http://docs.python-guide.org/en/latest/dev/virtualenvs/>`_
+and install khmer with:
 
-``pip install khmer`` to download, build, and install the latest stable
-version.
+```
+pip install khmer
+```
 
-For more details see `doc/install.rst <https://khmer.readthedocs.io/en/stable/user/install.html>`_
+You are ready to go. For more details see `doc/install.rst
+<https://khmer.readthedocs.io/en/stable/user/install.html>`_
 
-The use of a virtualenv is recommended, see
-https://virtualenv.readthedocs.io/en/latest/installation.html
 
-khmer is under the BSD license; see doc/LICENSE.txt. Distribution,
+Contributing
+------------
+
+If you want to modify khmer or contribute to its development read the
+`developer instructions
+<https://khmer.readthedocs.io/en/stable/dev/getting-started.html>`_
+
+
+License
+-------
+
+khmer is distributed under the BSD license; see doc/LICENSE.txt. Distribution,
 modification and redistribution, incorporation into other software, and
 pretty much everything else is allowed.
-
-MRC 2015-09-07

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ them, please visit the following URLs:
 The maintainers can be contacted at khmer-project@idyll.org.
 
 For getting help please see this guide: http://khmer.readthedocs.io/en/stable/user/getting-help.html
+Your first port of call when looking for help should be: https://github.com/dib-lab/khmer/issues
 
 
 Important note: cite us!

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,7 @@ them, please visit the following URLs:
 
 -  Announcements: http://lists.idyll.org/listinfo/khmer-announce
 
-We have a slack chat that [you can join](LINK/EMAIL/JOIN) and the maintainers
-can be contacted at khmer-project@idyll.org.
+The maintainers can be contacted at khmer-project@idyll.org.
 
 For getting help please see this guide: http://khmer.readthedocs.io/en/stable/user/getting-help.html
 


### PR DESCRIPTION
A proposal for #1296 with opinions.

Basically it is all about reducing the amount of text. Don't know what it is about the dev instructions but I found them confusing (given I was trying to get a quick gist to then translate to my `conda` world).

I would also reduce `doc/dev/getting-started.rst`:
* fork the repo on github, clone locally, setup dib remote. Instead of expanding on this link to the github docs for details. I think today most people either know their way around github or are super new in which case they will need a human to help them,
* virtualenvs only,
* one section per OS instead of by tool,
* remove instructions for more obscure tools (ccache, cppformat) instead explain how to find the output of travis that runs this for you

My ideal would be to get it down to in terms of steps and verbosity of instructions:
```
conda create -n khmer python=2 # or 3
source activate khmer
git clone https://github.com/dib-lab/khmer
cd khmer
make install-dependencies
make
```

Please provide some counter-balance to this viewpoint which is based on spending every day on github etc.

- [x] Is it mergeable?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Is the Copyright year up to date?

