### PR TITLE
More reasonable change log format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,12 @@
   `scripts/` is it tested?
 - [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
   formatted?
-- [ ] Did it change the command-line interface? Only additions are allowed
-  without a major version increment. Changing file formats also requires a
-  major version number increment.
-- [ ] Is it documented in the `ChangeLog`?
-  http://en.wikipedia.org/wiki/Changelog#Format
+- [ ] Did it change the command-line interface? Only backwards-compatible
+  additions are allowed without a major version increment. Changing file
+  formats also requires a major version number increment.
+- [ ] For substantial changes or changes to the command-line interface, is it
+  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
+  for more details.
 - [ ] Was a spellchecker run on the source code and documentation after
   changes were made?
 - [ ] Do the changes respect streaming IO? (Are they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Change Log
+All notable changes to the khmer project will be documented in this file.
+See [keepachangelog](http://keepachangelog.com/) for more info.
+
+The khmer project's command line scripts adhere to
+[Semantic Versioning](http://semver.org/). The Python and C++ APIs are not yet
+under semantic versioning, but will be in future versions of khmer.
+
+## [Unreleased]
+### Added
+- asdf
+
+### Changed
+- asdf
+
+### Fixed
+- asdf
+
+## [2.0] - 2015-10-08
+
+Previous to the khmer 2.1 release, all changes were documented in a file named
+`ChangeLog`. This file is now at `legacy/ChangeLog` for posterity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,41 @@ under semantic versioning, but will be in future versions of khmer.
 
 ## [Unreleased]
 ### Added
-- asdf
+- New `--no-reformat` option for `interleave-reads.py` script disables default
+  read name correction behavior.
+- New `HashSet` data structure for managing collections of k-mer hashes and
+  tags.
+- khmer package version now included in `.info` files.
+- New `-o|--outfile` option for `filter-abund-single.py` script.
+- New sandbox script `extract-compact-dbg.py` for computing a compact de Bruijn
+  graph from sequence data.
+- New `--quiet` flag to several scripts, silencing diagnostic messages in
+  terminal output.
+- Support for human-friendly memory requests (2G instead of 2000000000 or 2e9).
+- Support for variable-coverage trimming in the `filter-abund-single.py` script.
+- A simple example of the C++ API in `examples/c++-api`.
+- New `assemble_linear_path` function for baiting unambiguous contigs with a
+  seed k-mer from a hashtable.
+- Support for assembling directly from k-mer graphs, and a new
+  JunctionCountAssembler class.
 
 ### Changed
-- asdf
+- Switch from nose to py.test as the testing framework.
+- Switch from internally managed Jenkins setup to Travis CI for continuous
+  integration testing.
+- Renamed core data structures: CountingHash --> Countgraph,
+  Hashbits --> Nodegraph.
 
 ### Fixed
-- asdf
+- The hashbits `update_from` function to correctly track occupied bins for
+  calculating FPR.
+- Bug in the `filter-abund.py` script when `--gzip` and `-o` flags are used
+  simultaneously.
+- Bug in the hashtable `get_kmers` function based on incorrect usage of the
+  `substr` function.
+- Bug in `broken_paired_reader` related to dropping short reads when
+  `require_paired` is set.
+- Bug related to handling lowercase [acgtn] characters in input data.
 
 ## [2.0] - 2015-10-08
 

--- a/doc/dev/coding-guidelines-and-review.rst
+++ b/doc/dev/coding-guidelines-and-review.rst
@@ -139,11 +139,12 @@ checklist::
      `scripts/` is it tested?
    - [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
      formatted?
-   - [ ] Did it change the command-line interface? Only additions are allowed
-     without a major version increment. Changing file formats also requires a
-     major version number increment.
-   - [ ] Is it documented in the `ChangeLog`?
-     http://en.wikipedia.org/wiki/Changelog#Format
+   - [ ] Did it change the command-line interface? Only backwards-compatible
+     additions are allowed without a major version increment. Changing file
+     formats also requires a major version number increment.
+   - [ ] For substantial changes or changes to the command-line interface, is it
+     documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
+     for more details.
    - [ ] Was a spellchecker run on the source code and documentation after
      changes were made?
    - [ ] Do the changes respect streaming IO? (Are they

--- a/legacy/ChangeLog
+++ b/legacy/ChangeLog
@@ -1,4 +1,4 @@
-2016-11-15  Titus Brown  <titus@idyll.org
+2016-11-15  Titus Brown  <titus@idyll.org>
 
    * khmer/{_cpy_counttable,_cpy_hashgraph.hh,cpy_nodetable.hh,_khmer.cc,
    khmer/__init__.py}: new Counttable and Nodetable CPython types, plus


### PR DESCRIPTION
This PR moves the existing ChangeLog into a legacy directory and replaces it with a new CHANGELOG.md file that is much more reasonable for what we need. It will be much less verbose, and include only substantial changes to khmer. Anything relevant to semantic versioning MUST be included, but under-the-hood changes can also be mentioned if they are suitably large and interesting.

We should still include this in the PR checklist, but maybe replace the message with something like "Are substantial changes documented in CHANGELOG.md?"

My prediction: merge conflicts will drop by > 75%.

Fixes #1457.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
<strike>- [ ] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.</strike>
- [ ] Is it documented in the `ChangeLog`?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
<strike>- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)</strike>
- [x] Is the Copyright year up to date?

