### PR TITLE
Stop it with the copyright updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,3 @@
   changes were made?
 - [ ] Do the changes respect streaming IO? (Are they
   tested for streaming IO?)
-- [ ] Is the Copyright year up to date?

--- a/doc/dev/coding-guidelines-and-review.rst
+++ b/doc/dev/coding-guidelines-and-review.rst
@@ -149,7 +149,6 @@ checklist::
      changes were made?
    - [ ] Do the changes respect streaming IO? (Are they
      tested for streaming IO?)
-   - [ ] Is the Copyright year up to date?
 
 **Note** that after you submit the pull request you can check and uncheck
 the individual boxes on the formatted comment; no need to put x or y


### PR DESCRIPTION
See #1461. The notice needs only be added when new files are created, establishing copyright. Subsequent updates do not require changes to the initial notice establishing the initial claim of copyright. This will simplify the PR checklist.

- [x] Is it mergeable?
<strike> - [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
- [ ] Is the Copyright year up to date?</strike>

