### PR TITLE
Add info flag to command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ under semantic versioning, but will be in future versions of khmer.
   seed k-mer from a hashtable.
 - Support for assembling directly from k-mer graphs, and a new
   JunctionCountAssembler class.
+- Add --info flag for obtaining citation information, which is not printed
+  by default anymore.
 
 ### Changed
 - Switch from nose to py.test as the testing framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ under semantic versioning, but will be in future versions of khmer.
   seed k-mer from a hashtable.
 - Support for assembling directly from k-mer graphs, and a new
   JunctionCountAssembler class.
-- Add --info flag for obtaining citation information, which is not printed
-  by default anymore.
+- Add --info flag for obtaining citation information.
 
 ### Changed
 - Switch from nose to py.test as the testing framework.

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -77,6 +77,16 @@ ALGORITHMS = {
 }
 
 
+class CitationAction(argparse.Action):
+    def __init__(self, *args, **kwargs):
+        self.citations = kwargs.pop('citations')
+        super(CitationAction, self).__init__(*args, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        info(parser.prog, self.citations)
+        parser.exit()
+
+
 class _VersionStdErrAction(_VersionAction):
     # pylint: disable=too-few-public-methods, protected-access
     """Force output to StdErr."""
@@ -372,7 +382,7 @@ def _check_fp_rate(args, desired_max_fp):
     return args
 
 
-def build_graph_args(descr=None, epilog=None, parser=None):
+def build_graph_args(descr=None, epilog=None, parser=None, citations=None):
     """Build an ArgumentParser with args for bloom filter based scripts."""
     if parser is None:
         parser = argparse.ArgumentParser(description=descr, epilog=epilog,
@@ -380,6 +390,9 @@ def build_graph_args(descr=None, epilog=None, parser=None):
 
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+
+    parser.add_argument('--info', action=CitationAction,
+                        citations=citations)
 
     parser.add_argument('--ksize', '-k', type=int, default=DEFAULT_K,
                         help='k-mer size to use')
@@ -406,9 +419,9 @@ def build_graph_args(descr=None, epilog=None, parser=None):
     return parser
 
 
-def build_counting_args(descr=None, epilog=None):
+def build_counting_args(descr=None, epilog=None, citations=None):
     """Build an ArgumentParser with args for countgraph based scripts."""
-    parser = build_graph_args(descr=descr, epilog=epilog)
+    parser = build_graph_args(descr=descr, epilog=epilog, citations=citations)
 
     return parser
 

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -87,6 +87,13 @@ class CitationAction(argparse.Action):
         parser.exit()
 
 
+class _HelpAction(argparse._HelpAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        info(parser.prog, parser._citations)
+        super(_HelpAction, self).__call__(parser, namespace, values,
+                                          option_string=option_string)
+
+
 class _VersionStdErrAction(_VersionAction):
     # pylint: disable=too-few-public-methods, protected-access
     """Force output to StdErr."""
@@ -115,13 +122,16 @@ class KhmerArgumentParser(argparse.ArgumentParser):
     def __init__(self, citations=None, formatter_class=ComboFormatter,
                  **kwargs):
         super(KhmerArgumentParser, self).__init__(
-            formatter_class=formatter_class, **kwargs)
+            formatter_class=formatter_class, add_help=False, **kwargs)
         self._citations = citations
 
         self.add_argument('--version', action=_VersionStdErrAction,
                           version='khmer {v}'.format(v=__version__))
         self.add_argument('--info', action=CitationAction,
                           citations=self._citations)
+        self.add_argument('-h', '--help', action=_HelpAction,
+                          default=argparse.SUPPRESS,
+                          help='show this help message and exit')
 
     def parse_args(self, args=None, namespace=None):
         args = super(KhmerArgumentParser, self).parse_args(args=args,

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -78,6 +78,8 @@ ALGORITHMS = {
 
 
 class CitationAction(argparse.Action):
+    # pylint: disable=too-few-public-methods
+    """Output citation information and exit."""
     def __init__(self, *args, **kwargs):
         self.citations = kwargs.pop('citations')
         super(CitationAction, self).__init__(*args, nargs=0, **kwargs)
@@ -88,6 +90,7 @@ class CitationAction(argparse.Action):
 
 
 class _HelpAction(argparse._HelpAction):
+    # pylint: disable=too-few-public-methods, protected-access
     def __call__(self, parser, namespace, values, option_string=None):
         info(parser.prog, parser._citations)
         super(_HelpAction, self).__call__(parser, namespace, values,
@@ -119,6 +122,10 @@ class ComboFormatter(argparse.ArgumentDefaultsHelpFormatter,
 
 
 class KhmerArgumentParser(argparse.ArgumentParser):
+    """Specialize ArgumentParser with khmer defaults.
+
+    Take care of common arguments and setup printing of citation information.
+    """
     def __init__(self, citations=None, formatter_class=ComboFormatter,
                  **kwargs):
         super(KhmerArgumentParser, self).__init__(

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -52,7 +52,7 @@ import threading
 import textwrap
 from khmer import khmer_args
 from khmer.khmer_args import (build_counting_args, add_threading_args,
-                              report_on_config, info, calculate_graphsize,
+                              report_on_config, calculate_graphsize,
                               sanitize_help)
 from khmer.kfile import (check_input_files, check_space_for_graph)
 from khmer.khmer_logger import (configure_logging, log_info, log_error,
@@ -76,7 +76,8 @@ def get_parser():
     '''
     parser = build_counting_args(
         descr="Calculate the abundance distribution of k-mers from a "
-        "single sequence file.", epilog=textwrap.dedent(epilog))
+        "single sequence file.", epilog=textwrap.dedent(epilog),
+        citations=['counting', 'SeqAn'])
     add_threading_args(parser)
 
     parser.add_argument('input_sequence_filename', help='The name of the input'
@@ -106,8 +107,6 @@ def get_parser():
 
 def main():  # pylint: disable=too-many-locals,too-many-branches
     args = sanitize_help(get_parser()).parse_args()
-    if not args.quiet:
-        info('abundance-dist-single.py', ['counting', 'SeqAn'])
 
     configure_logging(args.quiet)
     report_on_config(args)

--- a/scripts/abundance-dist.py
+++ b/scripts/abundance-dist.py
@@ -51,8 +51,8 @@ import textwrap
 import os
 from khmer import __version__
 from khmer.kfile import check_input_files
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 from khmer.khmer_logger import (configure_logging, log_info, log_error,
                                 log_warn)
 
@@ -88,6 +88,8 @@ def get_parser():
                         help='Do not count k-mers past 255')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['counting'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Continue even if specified input files '
                         'do not exist or are empty.')
@@ -98,8 +100,6 @@ def get_parser():
 
 def main():
     args = sanitize_help(get_parser()).parse_args()
-    if not args.quiet:
-        info('abundance-dist.py', ['counting'])
 
     configure_logging(args.quiet)
 

--- a/scripts/abundance-dist.py
+++ b/scripts/abundance-dist.py
@@ -46,13 +46,10 @@ from __future__ import print_function
 import sys
 import csv
 import khmer
-import argparse
 import textwrap
 import os
-from khmer import __version__
 from khmer.kfile import check_input_files
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import (sanitize_help, KhmerArgumentParser)
 from khmer.khmer_logger import (configure_logging, log_info, log_error,
                                 log_warn)
 
@@ -65,10 +62,10 @@ def get_parser():
                 tests/test-data/test-abund-read-2.fa
         abundance-dist.py counts tests/test-data/test-abund-read-2.fa test-dist
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Calculate abundance distribution of the k-mers in "
         "the sequence file using a pre-made k-mer countgraph.",
-        formatter_class=ComboFormatter, epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog), citations=['counting'])
 
     parser.add_argument('input_count_graph_filename', help='The name of the'
                         ' input k-mer countgraph file.')
@@ -86,10 +83,6 @@ def get_parser():
     parser.add_argument('-b', '--no-bigcount', dest='bigcount', default=True,
                         action='store_false',
                         help='Do not count k-mers past 255')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['counting'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Continue even if specified input files '
                         'do not exist or are empty.')

--- a/scripts/annotate-partitions.py
+++ b/scripts/annotate-partitions.py
@@ -46,13 +46,11 @@ Use '-h' for parameter help.
 from __future__ import print_function
 
 import os
-import argparse
 import textwrap
 import sys
 from khmer import __version__, Nodegraph
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import (sanitize_help, KhmerArgumentParser)
 
 DEFAULT_K = 32
 
@@ -71,9 +69,9 @@ def get_parser():
         merge-partitions.py -k 20 example
         annotate-partitions.py -k 20 example tests/test-data/random-20-a.fa
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Annotate sequences with partition IDs.",
-        epilog=textwrap.dedent(epilog), formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('--ksize', '-k', type=int, default=DEFAULT_K,
                         help="k-mer size (default: %d)" % DEFAULT_K)
@@ -82,10 +80,6 @@ def get_parser():
     parser.add_argument('input_filenames', metavar='input_sequence_filename',
                         nargs='+', help='input FAST[AQ] sequences to '
                         'annotate.')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser

--- a/scripts/annotate-partitions.py
+++ b/scripts/annotate-partitions.py
@@ -51,8 +51,8 @@ import textwrap
 import sys
 from khmer import __version__, Nodegraph
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 
 DEFAULT_K = 32
 
@@ -84,13 +84,14 @@ def get_parser():
                         'annotate.')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser
 
 
 def main():
-    info('annotate-partitions.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
 
     ksize = args.ksize

--- a/scripts/count-median.py
+++ b/scripts/count-median.py
@@ -50,16 +50,15 @@ The output file contains sequence id, median, average, stddev, and seq length.
 NOTE: All 'N's in the input sequences are converted to 'A's.
 """
 from __future__ import print_function
-import screed
 import argparse
+import screed
 import sys
 import csv
 import textwrap
 
 from khmer import __version__, load_countgraph
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import (sanitize_help, KhmerArgumentParser)
 
 
 def get_parser():
@@ -78,9 +77,9 @@ def get_parser():
 
     NOTE: All 'N's in the input sequences are converted to 'A's.
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Count k-mers summary stats for sequences',
-        epilog=textwrap.dedent(epilog), formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('countgraph', metavar='input_count_graph_filename',
                         help='input k-mer countgraph filename')
@@ -89,10 +88,6 @@ def get_parser():
     parser.add_argument('output', metavar='output_summary_filename',
                         help='output summary filename',
                         type=argparse.FileType('w'))
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['diginorm'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser

--- a/scripts/count-median.py
+++ b/scripts/count-median.py
@@ -58,8 +58,8 @@ import textwrap
 
 from khmer import __version__, load_countgraph
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 
 
 def get_parser():
@@ -91,13 +91,14 @@ def get_parser():
                         type=argparse.FileType('w'))
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['diginorm'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser
 
 
 def main():
-    info('count-median.py', ['diginorm'])
     args = sanitize_help(get_parser()).parse_args()
 
     htfile = args.countgraph

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -51,7 +51,7 @@ import os
 import gc
 import textwrap
 from khmer import khmer_args
-from khmer.khmer_args import (build_nodegraph_args, report_on_config, info,
+from khmer.khmer_args import (build_nodegraph_args, report_on_config,
                               add_threading_args, sanitize_help)
 import glob
 from khmer.kfile import check_input_files, check_space
@@ -86,7 +86,7 @@ def get_parser():
     """
     parser = build_nodegraph_args(
         descr='Load, partition, and annotate FAST[AQ] sequences',
-        epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog), citations=['graph'])
     add_threading_args(parser)
     parser.add_argument('--subset-size', '-s', default=DEFAULT_SUBSET_SIZE,
                         dest='subset_size', type=float,
@@ -107,7 +107,6 @@ def get_parser():
 
 # pylint: disable=too-many-branches
 def main():  # pylint: disable=too-many-locals,too-many-statements
-    info('do-partition.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
 
     report_on_config(args, graphtype='nodegraph')

--- a/scripts/extract-long-sequences.py
+++ b/scripts/extract-long-sequences.py
@@ -54,8 +54,8 @@ import sys
 from khmer import __version__
 from khmer.utils import write_record
 from khmer.kfile import add_output_compression_type, get_file_writer
-from khmer.khmer_args import (ComboFormatter, sanitize_help, info,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (ComboFormatter, sanitize_help,
+                              _VersionStdErrAction, CitationAction)
 
 
 def get_parser():
@@ -79,12 +79,13 @@ def get_parser():
                         type=int, default=200)
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     add_output_compression_type(parser)
     return parser
 
 
 def main():
-    info('extract-long-sequences.py')
     args = sanitize_help(get_parser()).parse_args()
     outfp = get_file_writer(args.output, args.gzip, args.bzip)
     for filename in args.input_filenames:

--- a/scripts/extract-long-sequences.py
+++ b/scripts/extract-long-sequences.py
@@ -54,8 +54,7 @@ import sys
 from khmer import __version__
 from khmer.utils import write_record
 from khmer.kfile import add_output_compression_type, get_file_writer
-from khmer.khmer_args import (ComboFormatter, sanitize_help,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 
 
 def get_parser():
@@ -64,10 +63,10 @@ def get_parser():
 
         extract-long-sequences.py --length 10 tests/test-data/paired-mixed.fa
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Extract FASTQ or FASTA sequences longer than'
         ' specified length (default: 200 bp).',
-        formatter_class=ComboFormatter, epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('input_filenames', help='Input FAST[AQ]'
                         ' sequence filename.', nargs='+')
@@ -77,10 +76,6 @@ def get_parser():
     parser.add_argument('-l', '--length', help='The minimum length of'
                         ' the sequence file.',
                         type=int, default=200)
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     add_output_compression_type(parser)
     return parser
 
@@ -93,6 +88,7 @@ def main():
             if len(record['sequence']) >= args.length:
                 write_record(record, outfp)
     print('wrote to: ' + args.output.name, file=sys.stderr)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -49,13 +49,11 @@ import screed
 import sys
 import os.path
 import textwrap
-import argparse
 
 from khmer import __version__
 from khmer import ReadParser
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import add_output_compression_type
 from khmer.kfile import get_file_writer
@@ -91,15 +89,10 @@ def get_parser():
 
         extract-paired-reads.py tests/test-data/paired.fq
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Take a mixture of reads and split into pairs and '
-        'orphans.', epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        'orphans.', epilog=textwrap.dedent(epilog))
     parser.add_argument('infile', nargs='?', default='/dev/stdin')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     parser.add_argument('-d', '--output-dir', default='', help='Output '
                         'split reads to specified directory. Creates '
                         'directory if necessary')

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -54,8 +54,8 @@ import argparse
 from khmer import __version__
 from khmer import ReadParser
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import add_output_compression_type
 from khmer.kfile import get_file_writer
@@ -98,6 +98,8 @@ def get_parser():
     parser.add_argument('infile', nargs='?', default='/dev/stdin')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     parser.add_argument('-d', '--output-dir', default='', help='Output '
                         'split reads to specified directory. Creates '
                         'directory if necessary')
@@ -115,7 +117,6 @@ def get_parser():
 
 
 def main():
-    info('extract-paired-reads.py')
     args = sanitize_help(get_parser()).parse_args()
 
     infile = args.infile

--- a/scripts/extract-partitions.py
+++ b/scripts/extract-partitions.py
@@ -58,8 +58,8 @@ import khmer
 from khmer.kfile import (check_input_files, check_space,
                          add_output_compression_type,
                          get_file_writer)
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, __version__)
+from khmer.khmer_args import (sanitize_help, ComboFormatter, __version__,
+                              _VersionStdErrAction, CitationAction)
 from khmer.utils import write_record
 
 DEFAULT_MAX_SIZE = int(1e6)
@@ -110,6 +110,8 @@ def get_parser():
                         help='Output unassigned sequences, too')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_output_compression_type(parser)
@@ -254,7 +256,6 @@ class PartitionExtractor(object):
 
 
 def main():
-    info('extract-partitions.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
 
     distfilename = args.prefix + '.dist'

--- a/scripts/extract-partitions.py
+++ b/scripts/extract-partitions.py
@@ -50,7 +50,6 @@ from __future__ import print_function
 
 import sys
 import screed
-import argparse
 import textwrap
 from contextlib import contextmanager
 import khmer
@@ -58,8 +57,7 @@ import khmer
 from khmer.kfile import (check_input_files, check_space,
                          add_output_compression_type,
                          get_file_writer)
-from khmer.khmer_args import (sanitize_help, ComboFormatter, __version__,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.utils import write_record
 
 DEFAULT_MAX_SIZE = int(1e6)
@@ -89,10 +87,10 @@ def get_parser():
     (2) count of partitions with n reads, (3) cumulative sum of partitions,
     (4) cumulative sum of reads.)
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Separate sequences that are annotated with partitions "
         "into grouped files.", epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        citations=['graph'])
     parser.add_argument('prefix', metavar='output_filename_prefix')
     parser.add_argument('part_filenames', metavar='input_partition_filename',
                         nargs='+')
@@ -108,10 +106,6 @@ def get_parser():
     parser.add_argument('--output-unassigned', '-U', default=False,
                         action='store_true',
                         help='Output unassigned sequences, too')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_output_compression_type(parser)

--- a/scripts/fastq-to-fasta.py
+++ b/scripts/fastq-to-fasta.py
@@ -50,8 +50,8 @@ from khmer import __version__
 from khmer.kfile import (add_output_compression_type, get_file_writer,
                          describe_file_handle)
 from khmer.utils import write_record
-from khmer.khmer_args import (sanitize_help, ComboFormatter, info,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 from khmer.khmer_args import FileType as khFileType
 
 
@@ -72,12 +72,13 @@ def get_parser():
                              'input_sequence file. Default is to drop reads')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     add_output_compression_type(parser)
     return parser
 
 
 def main():
-    info('fastq-to-fasta.py')
     args = sanitize_help(get_parser()).parse_args()
 
     print('fastq from ', args.input_sequence, file=sys.stderr)

--- a/scripts/fastq-to-fasta.py
+++ b/scripts/fastq-to-fasta.py
@@ -44,21 +44,18 @@ Use '-h' for parameter help.
 """
 from __future__ import print_function, unicode_literals
 import sys
-import argparse
 import screed
 from khmer import __version__
 from khmer.kfile import (add_output_compression_type, get_file_writer,
                          describe_file_handle)
 from khmer.utils import write_record
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.khmer_args import FileType as khFileType
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(
-        description='Converts FASTQ format (.fq) files to FASTA format (.fa).',
-        formatter_class=ComboFormatter)
+    parser = KhmerArgumentParser(
+        description='Converts FASTQ format (.fq) files to FASTA format (.fa).')
 
     parser.add_argument('input_sequence', help='The name of the input'
                         ' FASTQ sequence file.')
@@ -70,10 +67,6 @@ def get_parser():
     parser.add_argument('-n', '--n_keep', default=False, action='store_true',
                         help='Option to keep reads containing \'N\'s in '
                              'input_sequence file. Default is to drop reads')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     add_output_compression_type(parser)
     return parser
 

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -86,7 +86,8 @@ def get_parser():
     """
     parser = build_counting_args(
         descr="Trims sequences at a minimum k-mer abundance "
-        "(in memory version).", epilog=textwrap.dedent(epilog))
+        "(in memory version).", epilog=textwrap.dedent(epilog),
+        citations=['counting', 'SeqAn'])
     add_threading_args(parser)
 
     parser.add_argument('--cutoff', '-C', default=DEFAULT_CUTOFF,

--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -56,7 +56,7 @@ from khmer import ReadParser
 from khmer.utils import broken_paired_reader, write_record
 from khmer import khmer_args
 from khmer.khmer_args import (build_counting_args, report_on_config,
-                              add_threading_args, info, calculate_graphsize,
+                              add_threading_args, calculate_graphsize,
                               sanitize_help, check_argument_range)
 from khmer.kfile import (check_input_files, check_space,
                          check_space_for_graph,
@@ -120,8 +120,6 @@ def get_parser():
 
 def main():
     args = sanitize_help(get_parser()).parse_args()
-    if not args.quiet:
-        info('filter-abund-single.py', ['counting', 'SeqAn'])
 
     configure_logging(args.quiet)
     check_input_files(args.datafile, args.force)

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -54,9 +54,9 @@ import khmer
 from khmer import __version__
 from khmer import ReadParser
 from khmer.utils import (broken_paired_reader, write_record)
-from khmer.khmer_args import (ComboFormatter, add_threading_args, info,
+from khmer.khmer_args import (ComboFormatter, add_threading_args,
                               sanitize_help, _VersionStdErrAction,
-                              check_argument_range)
+                              check_argument_range, CitationAction)
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import (check_input_files, check_space,
                          add_output_compression_type, get_file_writer)
@@ -109,6 +109,8 @@ def get_parser():
                         'file for each input file.')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['counting'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
@@ -119,8 +121,6 @@ def get_parser():
 
 def main():
     args = sanitize_help(get_parser()).parse_args()
-    if not args.quiet:
-        info('filter-abund.py', ['counting'])
 
     configure_logging(args.quiet)
 

--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -48,15 +48,13 @@ from __future__ import print_function
 import sys
 import os
 import textwrap
-import argparse
 import khmer
 
 from khmer import __version__
 from khmer import ReadParser
 from khmer.utils import (broken_paired_reader, write_record)
-from khmer.khmer_args import (ComboFormatter, add_threading_args,
-                              sanitize_help, _VersionStdErrAction,
-                              check_argument_range, CitationAction)
+from khmer.khmer_args import (add_threading_args, KhmerArgumentParser,
+                              sanitize_help, check_argument_range)
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import (check_input_files, check_space,
                          add_output_compression_type, get_file_writer)
@@ -80,10 +78,10 @@ def get_parser():
         load-into-counting.py -k 20 -x 5e7 countgraph data/100k-filtered.fa
         filter-abund.py -C 2 countgraph data/100k-filtered.fa
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Trim sequences at a minimum k-mer abundance.',
         epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        citations=['counting'])
     parser.add_argument('input_graph', metavar='input_count_graph_filename',
                         help='The input k-mer countgraph filename')
     parser.add_argument('input_filename', metavar='input_sequence_filename',
@@ -107,10 +105,6 @@ def get_parser():
                         help='Output the trimmed sequences into a single file '
                         'with the given filename instead of creating a new '
                         'file for each input file.')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['counting'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,

--- a/scripts/filter-stoptags.py
+++ b/scripts/filter-stoptags.py
@@ -47,14 +47,12 @@ Use '-h' for parameter help.
 from __future__ import print_function
 
 import os
-import argparse
 import textwrap
 import sys
 from khmer import __version__, Nodegraph
 from khmer.thread_utils import ThreadedSequenceProcessor, verbose_loader
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 
 # @CTB K should be loaded from file...
 DEFAULT_K = 32
@@ -66,18 +64,14 @@ def get_parser():
     or remove the sequences in `<file1-N>`.  Trimmed sequences will be placed
     in `<fileN>.stopfilt`.
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Trim sequences at stoptags.",
-        epilog=textwrap.dedent(epilog), formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog), citations=['graph'])
     parser.add_argument('--ksize', '-k', default=DEFAULT_K, type=int,
                         help='k-mer size')
     parser.add_argument('stoptags_file', metavar='input_stoptags_filename')
     parser.add_argument('input_filenames', metavar='input_sequence_filename',
                         nargs='+')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser

--- a/scripts/filter-stoptags.py
+++ b/scripts/filter-stoptags.py
@@ -53,8 +53,8 @@ import sys
 from khmer import __version__, Nodegraph
 from khmer.thread_utils import ThreadedSequenceProcessor, verbose_loader
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 
 # @CTB K should be loaded from file...
 DEFAULT_K = 32
@@ -76,13 +76,14 @@ def get_parser():
                         nargs='+')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser
 
 
 def main():
-    info('filter-stoptags.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
     stoptags = args.stoptags_file
     infiles = args.input_filenames

--- a/scripts/find-knots.py
+++ b/scripts/find-knots.py
@@ -50,7 +50,7 @@ import khmer
 import sys
 from khmer.kfile import check_input_files, check_space
 from khmer import khmer_args
-from khmer.khmer_args import (build_counting_args, info, sanitize_help)
+from khmer.khmer_args import (build_counting_args, sanitize_help)
 
 # counting hash parameters.
 DEFAULT_COUNTING_HT_SIZE = 3e6                # number of bytes
@@ -94,7 +94,8 @@ def get_parser():
     """
     parser = build_counting_args(
         descr="Find all highly connected k-mers.",
-        epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog),
+        citations=['graph'])
 
     parser.add_argument('graphbase', help='Basename for the input and output '
                         'files.')
@@ -104,7 +105,6 @@ def get_parser():
 
 
 def main():
-    info('find-knots.py', ['graph'])
     parser = get_parser()
     parser.epilog = parser.epilog.replace(
         ":doc:`partitioning-big-data`",

--- a/scripts/interleave-reads.py
+++ b/scripts/interleave-reads.py
@@ -49,11 +49,9 @@ from __future__ import print_function
 import screed
 import sys
 import textwrap
-import argparse
 from khmer import __version__
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import (add_output_compression_type, get_file_writer,
                          describe_file_handle)
@@ -82,19 +80,15 @@ def get_parser():
 
         interleave-reads.py tests/test-data/paired.fq.1 \\
                 tests/test-data/paired.fq.2 -o paired.fq"""
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Produce interleaved files from R1/R2 paired files',
-        epilog=textwrap.dedent(epilog), formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('left')
     parser.add_argument('right')
     parser.add_argument('-o', '--output', metavar="filename",
                         type=khFileType('wb'),
                         default=sys.stdout)
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     parser.add_argument('--no-reformat', default=False, action='store_true',
                         help='Do not reformat read names or enforce\
                               consistency')

--- a/scripts/interleave-reads.py
+++ b/scripts/interleave-reads.py
@@ -52,8 +52,8 @@ import textwrap
 import argparse
 from khmer import __version__
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 from khmer.khmer_args import FileType as khFileType
 from khmer.kfile import (add_output_compression_type, get_file_writer,
                          describe_file_handle)
@@ -93,6 +93,8 @@ def get_parser():
                         default=sys.stdout)
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     parser.add_argument('--no-reformat', default=False, action='store_true',
                         help='Do not reformat read names or enforce\
                               consistency')
@@ -103,7 +105,6 @@ def get_parser():
 
 
 def main():
-    info('interleave-reads.py')
     args = sanitize_help(get_parser()).parse_args()
 
     check_input_files(args.left, args.force)

--- a/scripts/load-graph.py
+++ b/scripts/load-graph.py
@@ -44,20 +44,20 @@ Use '-h' for parameter help.
 
 import sys
 
-from khmer.khmer_args import build_nodegraph_args, info
+from khmer.khmer_args import build_nodegraph_args
 from oxli import build_graph
 
 
 def get_parser():
     parser = build_nodegraph_args(descr="Load sequences into the compressible "
-                                  "graph format plus optional tagset.")
+                                  "graph format plus optional tagset.",
+                                  citations=['graph', 'SeqAn'])
 
     parser = build_graph.build_parser(parser)
     return parser
 
 
 if __name__ == '__main__':
-    info('load-graph.py', ['graph', 'SeqAn'])
     build_graph.main(get_parser().parse_args())
 
 # vim: set ft=python ts=4 sts=4 sw=4 et tw=79:

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -81,7 +81,8 @@ def get_parser():
     """
 
     parser = build_counting_args("Build a k-mer countgraph from the given"
-                                 " sequences.", epilog=textwrap.dedent(epilog))
+                                 " sequences.", epilog=textwrap.dedent(epilog),
+                                 citations=['counting', 'SeqAn'])
     add_threading_args(parser)
     parser.add_argument('output_countgraph_filename', help="The name of the"
                         " file to write the k-mer countgraph to.")
@@ -107,8 +108,6 @@ def get_parser():
 def main():
 
     args = sanitize_help(get_parser()).parse_args()
-    if not args.quiet:
-        info('load-into-counting.py', ['counting', 'SeqAn'])
 
     configure_logging(args.quiet)
     report_on_config(args)

--- a/scripts/make-initial-stoptags.py
+++ b/scripts/make-initial-stoptags.py
@@ -45,7 +45,7 @@ import sys
 import textwrap
 import khmer
 from khmer import khmer_args
-from khmer.khmer_args import (build_counting_args, info, sanitize_help)
+from khmer.khmer_args import (build_counting_args, sanitize_help)
 from khmer.kfile import check_input_files
 
 DEFAULT_SUBSET_SIZE = int(1e4)
@@ -85,7 +85,8 @@ def get_parser():
     """
     parser = build_counting_args(
         descr="Find an initial set of highly connected k-mers.",
-        epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog),
+        citations=['graph'])
     parser.add_argument('--subset-size', '-s', default=DEFAULT_SUBSET_SIZE,
                         dest='subset_size', type=float,
                         help='Set subset size (default 1e4 is prob ok)')
@@ -99,8 +100,6 @@ def get_parser():
 
 
 def main():
-
-    info('make-initial-stoptags.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
 
     graphbase = args.graphbase

--- a/scripts/merge-partitions.py
+++ b/scripts/merge-partitions.py
@@ -44,16 +44,13 @@ merged pmap file will be in <base>.pmap.merged.
 """
 from __future__ import print_function
 
-import argparse
 import glob
 import os
 import textwrap
 import khmer
 import sys
-from khmer import __version__
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 
 DEFAULT_K = 32
 
@@ -64,9 +61,10 @@ def get_parser():
     single ``${graphbase}.pmap.merged`` file for
     :program:`annotate-partitions.py` to use.
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Merge partition map '.pmap' files.",
-        epilog=textwrap.dedent(epilog), formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog),
+        citations=['graph'])
     parser.add_argument('--ksize', '-k', type=int, default=DEFAULT_K,
                         help="k-mer size (default: %d)" % DEFAULT_K)
     parser.add_argument('--keep-subsets', dest='remove_subsets',
@@ -74,10 +72,6 @@ def get_parser():
                         help='Keep individual subsets (default: False)')
     parser.add_argument('graphbase', help='basename for input and output '
                         'files')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser

--- a/scripts/merge-partitions.py
+++ b/scripts/merge-partitions.py
@@ -52,8 +52,8 @@ import khmer
 import sys
 from khmer import __version__
 from khmer.kfile import check_input_files, check_space
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 
 DEFAULT_K = 32
 
@@ -76,13 +76,14 @@ def get_parser():
                         'files')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     return parser
 
 
 def main():
-    info('merge-partitions.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
 
     output_file = args.graphbase + '.pmap.merged'

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -254,7 +254,8 @@ def get_parser():
         tests/test-data/test-fastq-reads.fq"""
     parser = build_counting_args(
         descr="Do digital normalization (remove mostly redundant sequences)",
-        epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog),
+        citations=['diginorm'])
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
                         action='store_true')
     parser.add_argument('-C', '--cutoff', help="when the median "
@@ -299,9 +300,6 @@ def get_parser():
 def main():  # pylint: disable=too-many-branches,too-many-statements
     parser = sanitize_help(get_parser())
     args = parser.parse_args()
-
-    if not args.quiet:
-        info('normalize-by-median.py', ['diginorm'])
 
     configure_logging(args.quiet)
     report_on_config(args)

--- a/scripts/partition-graph.py
+++ b/scripts/partition-graph.py
@@ -46,7 +46,6 @@ Use '-h' for parameter help.
 from __future__ import print_function
 
 import threading
-import argparse
 import textwrap
 import sys
 import gc
@@ -54,8 +53,7 @@ import os.path
 
 from khmer import __version__, load_nodegraph
 from khmer.khmer_args import (add_threading_args, sanitize_help,
-                              ComboFormatter, _VersionStdErrAction,
-                              CitationAction)
+                              KhmerArgumentParser)
 from khmer.kfile import check_input_files
 from oxli.partition import worker
 
@@ -74,10 +72,10 @@ def get_parser():
     The resulting partition maps are saved as ``${basename}.subset.#.pmap``
     files.
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Partition a sequence graph based upon waypoint "
         "connectivity", epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        citations=['graph'])
 
     parser.add_argument('basename', help="basename of the input k-mer "
                         "nodegraph  + tagset files")
@@ -89,10 +87,6 @@ def get_parser():
     parser.add_argument('--no-big-traverse', action='store_true',
                         default=False, help='Truncate graph joins at big '
                         'traversals')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_threading_args(parser)

--- a/scripts/partition-graph.py
+++ b/scripts/partition-graph.py
@@ -53,8 +53,9 @@ import gc
 import os.path
 
 from khmer import __version__, load_nodegraph
-from khmer.khmer_args import (add_threading_args, info, sanitize_help,
-                              ComboFormatter, _VersionStdErrAction)
+from khmer.khmer_args import (add_threading_args, sanitize_help,
+                              ComboFormatter, _VersionStdErrAction,
+                              CitationAction)
 from khmer.kfile import check_input_files
 from oxli.partition import worker
 
@@ -90,6 +91,8 @@ def get_parser():
                         'traversals')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['graph'])
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_threading_args(parser)
@@ -97,7 +100,6 @@ def get_parser():
 
 
 def main():
-    info('partition-graph.py', ['graph'])
     args = sanitize_help(get_parser()).parse_args()
     basename = args.basename
 

--- a/scripts/readstats.py
+++ b/scripts/readstats.py
@@ -50,8 +50,8 @@ import argparse
 import textwrap
 
 from khmer import __version__
-from khmer.khmer_args import (sanitize_help, ComboFormatter, info,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 
 
 def get_parser():
@@ -80,6 +80,8 @@ def get_parser():
                         'including column headers.')
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     return parser
 
 
@@ -176,7 +178,6 @@ def analyze_file(filename):
 
 def main():
     """Main function - run when executed as a script."""
-    info('readstats.py')
     args = sanitize_help(get_parser()).parse_args()
 
     statistics = []

--- a/scripts/readstats.py
+++ b/scripts/readstats.py
@@ -43,15 +43,14 @@ Use '-h' for parameter help.
 """
 from __future__ import print_function
 
+import argparse
 import sys
 import csv
 import screed
-import argparse
 import textwrap
 
 from khmer import __version__
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 
 
 def get_parser():
@@ -68,9 +67,9 @@ def get_parser():
         readstats.py tests/test-data/test-abund-read-2.fa
     """
 
-    parser = argparse.ArgumentParser(
-        description=descr, formatter_class=ComboFormatter,
-        epilog=textwrap.dedent(epilog),)
+    parser = KhmerArgumentParser(
+        description=descr,
+        epilog=textwrap.dedent(epilog))
     parser.add_argument('filenames', nargs='+')
     parser.add_argument('-o', '--output', dest='outfp', metavar="filename",
                         help="output file for statistics; defaults to stdout.",
@@ -78,10 +77,6 @@ def get_parser():
     parser.add_argument('--csv', default=False, action='store_true',
                         help='Use the CSV format for the statistics, '
                         'including column headers.')
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     return parser
 
 

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -57,8 +57,8 @@ from khmer import __version__
 from khmer import ReadParser
 from khmer.kfile import (check_input_files, add_output_compression_type,
                          get_file_writer)
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+from khmer.khmer_args import (sanitize_help, ComboFormatter,
+                              _VersionStdErrAction, CitationAction)
 from khmer.utils import write_record, broken_paired_reader
 
 DEFAULT_NUM_READS = int(1e5)
@@ -102,6 +102,8 @@ def get_parser():
                         metavar="filename", default=None)
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exits')
     add_output_compression_type(parser)
@@ -109,7 +111,6 @@ def get_parser():
 
 
 def main():
-    info('sample-reads-randomly.py')
     parser = get_parser()
     parser.epilog = parser.epilog.replace(
         "`reservoir sampling\n"

--- a/scripts/sample-reads-randomly.py
+++ b/scripts/sample-reads-randomly.py
@@ -57,8 +57,7 @@ from khmer import __version__
 from khmer import ReadParser
 from khmer.kfile import (check_input_files, add_output_compression_type,
                          get_file_writer)
-from khmer.khmer_args import (sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.utils import write_record, broken_paired_reader
 
 DEFAULT_NUM_READS = int(1e5)
@@ -82,9 +81,9 @@ def get_parser():
     <http://en.wikipedia.org/wiki/Reservoir_sampling>`__ algorithm.
     """
 
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description="Uniformly subsample sequences from a collection of files",
-        formatter_class=ComboFormatter, epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('filenames', nargs='+')
     parser.add_argument('-N', '--num_reads', type=int, dest='num_reads',
@@ -100,10 +99,6 @@ def get_parser():
     parser.add_argument('-o', '--output', dest='output_file',
                         type=argparse.FileType('wb'),
                         metavar="filename", default=None)
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exits')
     add_output_compression_type(parser)

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -53,7 +53,7 @@ import argparse
 from khmer import __version__
 from khmer import ReadParser
 from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction)
+                              _VersionStdErrAction, CitationAction)
 from khmer.khmer_args import FileType as khFileType
 from khmer.utils import (write_record, broken_paired_reader,
                          UnpairedReadsError)
@@ -115,6 +115,8 @@ def get_parser():
                         'file', type=khFileType('wb'))
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
+    parser.add_argument('--info', action=CitationAction,
+                        citations=None)
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_output_compression_type(parser)
@@ -122,7 +124,6 @@ def get_parser():
 
 
 def main():
-    info('split-paired-reads.py')
     args = sanitize_help(get_parser()).parse_args()
 
     infile = args.infile

--- a/scripts/split-paired-reads.py
+++ b/scripts/split-paired-reads.py
@@ -48,12 +48,10 @@ from __future__ import print_function
 import sys
 import os
 import textwrap
-import argparse
 
 from khmer import __version__
 from khmer import ReadParser
-from khmer.khmer_args import (info, sanitize_help, ComboFormatter,
-                              _VersionStdErrAction, CitationAction)
+from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 from khmer.khmer_args import FileType as khFileType
 from khmer.utils import (write_record, broken_paired_reader,
                          UnpairedReadsError)
@@ -92,10 +90,9 @@ def get_parser():
 
         split-paired-reads.py -1 reads.1 -2 reads.2 tests/test-data/paired.fq
     """
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description='Split interleaved reads into two files, left and right.',
-        epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        epilog=textwrap.dedent(epilog))
 
     parser.add_argument('infile', nargs='?', default='/dev/stdin')
 
@@ -113,10 +110,6 @@ def get_parser():
     parser.add_argument('-2', '--output-second', metavar='output_second',
                         default=None, help='Output "right" reads to this '
                         'file', type=khFileType('wb'))
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-    parser.add_argument('--info', action=CitationAction,
-                        citations=None)
     parser.add_argument('-f', '--force', default=False, action='store_true',
                         help='Overwrite output file if it exists')
     add_output_compression_type(parser)

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -51,12 +51,11 @@ import khmer
 import tempfile
 import shutil
 import textwrap
-import argparse
 
 from khmer import khmer_args
 from khmer import ReadParser
 
-from khmer.khmer_args import (build_counting_args, info, add_loadgraph_args,
+from khmer.khmer_args import (build_counting_args, add_loadgraph_args,
                               report_on_config, calculate_graphsize,
                               sanitize_help)
 from khmer.khmer_args import FileType as khFileType
@@ -101,7 +100,8 @@ def get_parser():
 
     parser = build_counting_args(
         descr='Trim low-abundance k-mers using a streaming algorithm.',
-        epilog=textwrap.dedent(epilog))
+        epilog=textwrap.dedent(epilog),
+        citations=['streaming'])
 
     parser.add_argument('input_filenames', nargs='+')
 
@@ -275,8 +275,6 @@ class Trimmer(object):
 def main():
     parser = sanitize_help(get_parser())
     args = parser.parse_args()
-    if not args.quiet:
-        info('trim-low-abund.py', ['streaming'])
 
     configure_logging(args.quiet)
 

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -51,8 +51,9 @@ import sys
 import textwrap
 
 import khmer
-from khmer.khmer_args import (DEFAULT_K, info, ComboFormatter,
-                              _VersionStdErrAction, sanitize_help)
+from khmer.khmer_args import (DEFAULT_K, ComboFormatter,
+                              _VersionStdErrAction, CitationAction,
+                              sanitize_help)
 from khmer.khmer_args import graphsize_args_report
 from khmer import __version__
 
@@ -105,6 +106,9 @@ def get_parser():
     parser.add_argument('--version', action=_VersionStdErrAction,
                         version='khmer {v}'.format(v=__version__))
 
+    parser.add_argument('--info', action=CitationAction,
+                        citations=['SeqAn', 'hll'])
+
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
                         action='store_true')
 
@@ -134,7 +138,6 @@ def get_parser():
 
 
 def main():
-    info('unique-kmers.py', ['SeqAn', 'hll'])
     args = sanitize_help(get_parser()).parse_args()
 
     total_hll = khmer.HLLCounter(args.error_rate, args.ksize)

--- a/scripts/unique-kmers.py
+++ b/scripts/unique-kmers.py
@@ -44,18 +44,14 @@ Use '-h' for parameter help.
 """
 from __future__ import print_function
 
-
 import argparse
 import os
 import sys
 import textwrap
 
 import khmer
-from khmer.khmer_args import (DEFAULT_K, ComboFormatter,
-                              _VersionStdErrAction, CitationAction,
-                              sanitize_help)
+from khmer.khmer_args import DEFAULT_K, sanitize_help, KhmerArgumentParser
 from khmer.khmer_args import graphsize_args_report
-from khmer import __version__
 
 
 def get_parser():
@@ -97,17 +93,11 @@ def get_parser():
 
         unique-kmers.py -R unique_count -k 30 \\
         tests/test-data/test-abund-read-paired.fa"""  # noqa
-    parser = argparse.ArgumentParser(
+    parser = KhmerArgumentParser(
         description=descr, epilog=textwrap.dedent(epilog),
-        formatter_class=ComboFormatter)
+        citations=['SeqAn', 'hll'])
 
     env_ksize = os.environ.get('KHMER_KSIZE', DEFAULT_K)
-
-    parser.add_argument('--version', action=_VersionStdErrAction,
-                        version='khmer {v}'.format(v=__version__))
-
-    parser.add_argument('--info', action=CitationAction,
-                        citations=['SeqAn', 'hll'])
 
     parser.add_argument('-q', '--quiet', dest='quiet', default=False,
                         action='store_true')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2762,10 +2762,16 @@ def test_version_and_basic_citation(scriptname):
         line = script.readline()
         line = script.readline()
         if 'khmer' in line:
-            version = re.compile("^khmer .*$", re.MULTILINE)
-            status, out, err = utils.runscript(scriptname, ["--version"])
+            # check citation information appears when using --info
+            status, out, err = utils.runscript(scriptname, ["--info"])
             assert status == 0, status
             print(out)
             print(err)
-            # assert "publication" in err, err
-            assert version.search(err) is not None, err
+            assert "publication" in err, err
+            assert "usage:" not in err, err
+
+            # check no citation information appears otherwise
+            status, out, err = utils.runscript(scriptname, ["--help"])
+            assert status == 0, status
+            assert "publication" not in out, out
+            assert "usage:" in out, out

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2770,8 +2770,8 @@ def test_version_and_basic_citation(scriptname):
             assert "publication" in err, err
             assert "usage:" not in err, err
 
-            # check no citation information appears otherwise
-            status, out, err = utils.runscript(scriptname, ["--help"])
+            # check citation information appears in --version
+            status, out, err = utils.runscript(scriptname, ["--version"])
             assert status == 0, status
-            assert "publication" not in out, out
-            assert "usage:" in out, out
+            assert "publication" in err, err
+            assert "usage:" not in err, err

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2775,3 +2775,9 @@ def test_version_and_basic_citation(scriptname):
             assert status == 0, status
             assert "publication" in err, err
             assert "usage:" not in err, err
+
+            # check citation information appears in --help
+            status, out, err = utils.runscript(scriptname, ["--help"])
+            assert status == 0, status
+            assert "publication" in err, err
+            assert "usage:" in out, out


### PR DESCRIPTION
Fixes #1395

This introduces the `--info` command line flag. `scripts/filter-abund-single.py --info` now prints the citation information and then exits. This still prints the citation information when you run the script. This is a bit ugly because you have to specify what to cite twice (DRY). We can fix that by either getting rid of printing the citation info on every run or by moving things around. WDYT?

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)

New flag that prints citation information