### PR TITLE
Speed up writing records

### DIFF
--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -235,17 +235,28 @@ def write_record(record, fileobj):
             sequence=record.sequence)
 
     try:
-        fileobj.write(bytes(recstr, 'utf-8'))
+        fileobj.write(bytes(recstr, 'ascii'))
     except TypeError:
         fileobj.write(recstr)
 
 
+_rec_pair = '@%s\n%s\n+\n%s\n' * 2
+_rec_pair_no_qual = '>%s\n%s\n' * 2
 def write_record_pair(read1, read2, fileobj):
     """Write a pair of sequence records to 'fileobj' in FASTA/FASTQ format."""
     if hasattr(read1, 'quality'):
         assert hasattr(read2, 'quality')
-    write_record(read1, fileobj)
-    write_record(read2, fileobj)
+        recstr = _rec_pair % (read1.name, read1.sequence, read1.quality,
+                              read2.name, read2.sequence, read2.quality)
+
+    else:
+        recstr = _rec_pair_no_qual % (read1.name, read1.sequence,
+                                      read2.name, read2.sequence)
+
+    try:
+        fileobj.write(bytes(recstr, 'ascii'))
+    except TypeError:
+        fileobj.write(recstr)
 
 
 def clean_input_reads(screed_iter):

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -240,10 +240,11 @@ def write_record(record, fileobj):
         fileobj.write(recstr)
 
 
-_rec_pair = '@%s\n%s\n+\n%s\n' * 2
-_rec_pair_no_qual = '>%s\n%s\n' * 2
 def write_record_pair(read1, read2, fileobj):
     """Write a pair of sequence records to 'fileobj' in FASTA/FASTQ format."""
+    _rec_pair = '@%s\n%s\n+\n%s\n' * 2
+    _rec_pair_no_qual = '>%s\n%s\n' * 2
+
     if hasattr(read1, 'quality'):
         assert hasattr(read2, 'quality')
         recstr = _rec_pair % (read1.name, read1.sequence, read1.quality,


### PR DESCRIPTION
Calling functions is costly in python, so duplicate some short code instead of calling it.

```
$ time scripts/extract-paired-reads.py ecoli_ref-5m.fastq -s a.se -p a.pe
67.88s user 28.85s system 93% cpu 1:43.77 total
$ git checkout master
$ time scripts/extract-paired-reads.py ecoli_ref-5m.fastq -s a.se -p a.pe
78.75s user 30.85s system 93% cpu 1:57.20 total
```

Happy 🦃 day!

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
