### PR TITLE
Fix memory leak when converting to HashIntoType

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -187,14 +187,17 @@ static bool ht_convert_PyObject_to_HashIntoType(PyObject * value,
     if (PyInt_Check(value) || PyLong_Check(value)) {
         return convert_PyLong_to_HashIntoType(value, hashval);
     } else if (PyUnicode_Check(value))  {
-        std::string s = PyBytes_AsString(PyUnicode_AsEncodedString(
-                                             value, "utf-8", "strict"));
+        PyObject* val_as_str = PyUnicode_AsEncodedString(value,
+           "utf-8", "strict");
+        std::string s = PyBytes_AsString(val_as_str);
         if (strlen(s.c_str()) != ht->ksize()) {
+            Py_DECREF(val_as_str);
             PyErr_SetString(PyExc_ValueError,
                             "k-mer length must equal the k-mer size");
             return false;
         }
         hashval = ht->hash_dna(s.c_str());
+        Py_DECREF(val_as_str);
         return true;
 
     } else if (PyBytes_Check(value)) {


### PR DESCRIPTION
Fixes #1555 Missed a DECREF when converting to `HashIntoType`

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
