### PR TITLE
enable static building using pkg-config

### DIFF
--- a/lib/oxli.pc.in
+++ b/lib/oxli.pc.in
@@ -10,5 +10,7 @@ URL: http://khmer.readthedocs.io/
 Version: @VERSION@
 
 Requires:
+Requires.private: zlib
 Libs: -L${libdir} -L${sharedlibdir} -loxli
+Libs.private: -lbz2
 Cflags: -I${includedir}


### PR DESCRIPTION
- [X] Is it mergeable?
- [X] `make test` Did it pass the tests?

This PR does not touch the C++ or Python code. It only adds to line to the pkg-config template that allow pkg-config to output the correct flags for static linking. That makes it possible to develop against liboxli by, for example:

```bash
g++ -o test-prog-static -static -std=c++11 `pkg-config oxli --static --cflags` \
  test-compile.cc `pkg-config oxli --static --libs`
```