### PR TITLE
correct test of screed.Record to use name/sequence and not 'dict' in constructor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ SETUP_METADATA = \
         "url": 'https://khmer.readthedocs.io/',
         "packages": ['khmer', 'khmer.tests', 'oxli'],
         "package_dir": {'khmer.tests': 'tests'},
-        "install_requires": ['screed >= 0.9', 'bz2file'],
+        "install_requires": ['screed >= 1.0', 'bz2file'],
         "setup_requires": ["pytest-runner>=2.0,<3dev"],
         "extras_require": {':python_version=="2.6"': ['argparse>=1.2.1'],
                            'docs': ['sphinx', 'sphinxcontrib-autoprogram'],

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -54,7 +54,7 @@ def test_read_type_basic():
     name = "895:1:1:1246:14654 1:N:0:NNNNN"
     sequence = "ACGT"
     r = Read(name, sequence)
-    s = Record(dict(name=name, sequence=sequence))
+    s = Record(name, sequence)
 
     for x in (r, s):
         assert x.name == name


### PR DESCRIPTION
This updates khmer master to work with screed master (as well as https://github.com/dib-lab/screed/pull/64).

It will have to wait to be merged until we release a new version of screed though :). We should then update khmer master to require the new version of screed.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
