### PR TITLE
Fix reading empty partition maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ under semantic versioning, but will be in future versions of khmer.
   `require_paired` is set.
 - Bug related to handling lowercase [acgtn] characters in input data.
 - Bug in `load-graph.py` that calculated required graph space incorrectly.
+- Fix loading of empty partion map files
 
 ## [2.0] - 2015-10-08
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -188,7 +188,7 @@ static bool ht_convert_PyObject_to_HashIntoType(PyObject * value,
         return convert_PyLong_to_HashIntoType(value, hashval);
     } else if (PyUnicode_Check(value))  {
         PyObject* val_as_str = PyUnicode_AsEncodedString(value,
-           "utf-8", "strict");
+                               "utf-8", "strict");
         std::string s = PyBytes_AsString(val_as_str);
         if (strlen(s.c_str()) != ht->ksize()) {
             Py_DECREF(val_as_str);

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -913,6 +913,15 @@ void SubsetPartition::merge_from_disk(string other_filename)
                           + strerror(errno);
         throw khmer_file_exception(err);
     }
+    infile.seekg(0, infile.end);
+    const int length = infile.tellg();
+    infile.seekg(0, infile.beg);
+    if (length == 18) {
+        std::string err;
+        err = other_filename + " contains only a header and no partition IDs.";
+        throw khmer_file_exception(err);
+    }
+
 
     try {
         unsigned int save_ksize = 0;

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -885,6 +885,21 @@ def test_partition_graph_nojoin_k21():
     assert x == (99, 0), x          # should be 99 partitions at K=21
 
 
+def test_partition_load_empty_pmap():
+    graphbase = _make_graph(utils.get_test_data('random-20-a.fa'), ksize=24)
+
+    script = 'partition-graph.py'
+    args = [graphbase, '-s', '10']
+
+    utils.runscript(script, args)
+
+    script = 'merge-partitions.py'
+    args = [graphbase, '-k', '24']
+    status, out, err = utils.runscript(script, args, fail_ok=True)
+    assert status == -1
+    assert 'only a header and no partition IDs' in err
+
+
 def test_partition_graph_nojoin_stoptags():
     # test with stoptags
     graphbase = _make_graph(utils.get_test_data('random-20-a.fa'))


### PR DESCRIPTION
Fixes #1580 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
