### PR TITLE
Rename annotations to description

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -325,16 +325,16 @@ int
 khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
 {
     const char * name{};
-    const char * annotations{};
+    const char * description{};
     const char * sequence{};
     const char * quality{};
     char *kwlist[5] = {
         const_cast<char *>("name"), const_cast<char *>("sequence"),
-        const_cast<char *>("quality"), const_cast<char *>("annotations"), NULL
+        const_cast<char *>("quality"), const_cast<char *>("description"), NULL
     };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "ss|zz", kwlist,
-                                     &name, &sequence, &quality, &annotations)) {
+                                     &name, &sequence, &quality, &description)) {
         return -1;
     }
 
@@ -347,8 +347,8 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
     if (quality != NULL) {
         self->read->quality = quality;
     }
-    if (annotations != NULL) {
-        self->read->annotations = annotations;
+    if (description != NULL) {
+        self->read->description = description;
     }
     return 0;
 }
@@ -418,13 +418,13 @@ Read_get_quality(khmer_Read_Object * obj, void * closure)
 
 static
 PyObject *
-Read_get_annotations(khmer_Read_Object * obj, void * closure)
+Read_get_description(khmer_Read_Object * obj, void * closure)
 {
-    if (obj->read->annotations.size() > 0) {
-        return PyUnicode_FromString(obj->read->annotations.c_str());
+    if (obj->read->description.size() > 0) {
+        return PyUnicode_FromString(obj->read->description.c_str());
     } else {
         PyErr_SetString(PyExc_AttributeError,
-                        "'Read' object has no attribute 'annotations'.");
+                        "'Read' object has no attribute 'description'.");
         return NULL;
     }
 }
@@ -498,9 +498,9 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
         (char *)"Quality scores.", NULL
     },
     {
-        (char *)"annotations",
-        (getter)Read_get_annotations, (setter)NULL,
-        (char *)"Annotations.", NULL
+        (char *)"description",
+        (getter)Read_get_description, (setter)NULL,
+        (char *)"Description.", NULL
     },
     {
         (char *)"cleaned_seq",

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -85,7 +85,7 @@ struct InvalidReadPair : public  khmer_value_exception {
 
 struct Read {
     std::string name;
-    std::string annotations;
+    std::string description;
     std::string sequence;
     std::string quality;
     std::string cleaned_seq;
@@ -95,7 +95,7 @@ struct Read {
     inline void reset( )
     {
         name.clear();
-        annotations.clear();
+        description.clear();
         sequence.clear();
         quality.clear();
         cleaned_seq.clear();

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -60,7 +60,7 @@ def test_read_type_basic():
         assert x.name == name
         assert x.sequence == sequence
         assert not hasattr(x, 'quality'), x
-        assert not hasattr(x, 'annotations'), x
+        assert not hasattr(x, 'description'), x
 
 
 def test_read_quality_none():
@@ -69,11 +69,11 @@ def test_read_quality_none():
 
 
 def test_read_type_attributes():
-    r = Read(sequence='ACGT', quality='good', name='1234', annotations='ann')
+    r = Read(sequence='ACGT', quality='good', name='1234', description='desc')
     assert r.sequence == 'ACGT'
     assert r.quality == 'good'
     assert r.name == '1234'
-    assert r.annotations == 'ann'
+    assert r.description == 'desc'
     # test setting and deleting of cleaned_seq
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
Bring `khmer.Read` property names in line with those used by `screed`. Related to #1484 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
