### PR TITLE
rename consume to consume_string

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -1624,7 +1624,7 @@ hashtable_consume_fasta_with_reads_parser(khmer_KHashtable_Object * me,
 
 static
 PyObject *
-hashtable_consume(khmer_KHashtable_Object * me, PyObject * args)
+hashtable_consume_string(khmer_KHashtable_Object * me, PyObject * args)
 {
     Hashtable * hashtable = me->hashtable;
 
@@ -2223,8 +2223,8 @@ static PyMethodDef khmer_hashtable_methods[] = {
         "Increment the count of this k-mer. (Synonym for 'count'.)"
     },
     {
-        "consume",
-        (PyCFunction)hashtable_consume, METH_VARARGS,
+        "consume_string",
+        (PyCFunction)hashtable_consume_string, METH_VARARGS,
         "Increment the counts of all of the k-mers in the string."
     },
     {
@@ -4460,7 +4460,7 @@ junctioncountassembler_assemble(khmer_KJunctionCountAssembler_Object * me,
 
 static
 PyObject *
-junctioncountassembler_consume(khmer_KJunctionCountAssembler_Object * me,
+junctioncountassembler_consume_string(khmer_KJunctionCountAssembler_Object * me,
                                PyObject * args)
 {
     JunctionCountAssembler * assembler = me->assembler;
@@ -4476,7 +4476,7 @@ junctioncountassembler_consume(khmer_KJunctionCountAssembler_Object * me,
         return NULL;
     }
 
-    uint16_t n_junctions = assembler->consume(long_str);
+    uint16_t n_junctions = assembler->consume_string(long_str);
 
     return PyLong_FromLong((HashIntoType) n_junctions);
 }
@@ -4489,8 +4489,8 @@ static PyMethodDef khmer_junctioncountassembler_methods[] = {
         "Assemble paths, using recorded junctions to jump branches."
     },
     {
-        "consume",
-        (PyCFunction)junctioncountassembler_consume, METH_VARARGS,
+        "consume_string",
+        (PyCFunction)junctioncountassembler_consume_string, METH_VARARGS,
         "Consume a string and count its branch junctions."
     },
     {NULL, NULL, 0, NULL}           /* sentinel */


### PR DESCRIPTION
For consistencies sake.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
