### PR TITLE
Add  cleaned_seq attribute to `Read` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ under semantic versioning, but will be in future versions of khmer.
 - Add --info flag for obtaining citation information.
 - Add a new storage class using half a byte per entry. Exposed as
   SmallCounttable and SmallCountgraph.
+- Added `cleaned_seq` attribute to `khmer.Read` class which provides a cleaned
+  version of the sequence of each read.
 
 ### Changed
 - Switch from nose to py.test as the testing framework.

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -343,6 +343,7 @@ khmer_Read_init(khmer_Read_Object *self, PyObject *args, PyObject *kwds)
     }
     if (sequence != NULL) {
         self->read->sequence = sequence;
+        self->read->set_clean_seq();
     }
     if (quality != NULL) {
         self->read->quality = quality;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -445,40 +445,6 @@ Read_get_cleaned_seq(khmer_Read_Object * obj, void * closure)
 }
 
 
-static int
-Read_set_cleaned_seq(khmer_Read_Object *obj, PyObject *value, void *closure)
-{
-    if (value == NULL) {
-        obj->read->cleaned_seq = "";
-        return 0;
-    }
-
-    if (! (PyUnicode_Check(value) | PyBytes_Check(value))) {
-        PyErr_SetString(PyExc_TypeError,
-                        "The 'cleaned_seq' attribute value must be a string");
-        return -1;
-    }
-
-    if (PyUnicode_Check(value)) {
-        PyObject* temp = PyUnicode_AsASCIIString(value);
-        if (temp == NULL) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Could not encode 'cleaned_seq' as ASCII.");
-            return -1;
-        }
-
-        obj->read->cleaned_seq = std::string(PyBytes_AS_STRING(temp));
-        Py_DECREF(temp);
-    }
-    // in python2 not everything is a unicode object
-    else {
-        obj->read->cleaned_seq = std::string(PyBytes_AS_STRING(value));
-    }
-
-    return 0;
-}
-
-
 // TODO? Implement setters.
 
 
@@ -505,7 +471,7 @@ static PyGetSetDef khmer_Read_accessors [ ] = {
     },
     {
         (char *)"cleaned_seq",
-        (getter)Read_get_cleaned_seq, (setter)Read_set_cleaned_seq,
+        (getter)Read_get_cleaned_seq, (setter)NULL,
         (char *)"Cleaned sequence.", NULL
     },
 

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -437,6 +437,9 @@ Read_get_cleaned_seq(khmer_Read_Object * obj, void * closure)
 {
     if (obj->read->cleaned_seq.size() > 0) {
         return PyUnicode_FromString(obj->read->cleaned_seq.c_str());
+    } else if (obj->read->sequence.size() > 0) {
+        obj->read->set_clean_seq();
+        return PyUnicode_FromString(obj->read->cleaned_seq.c_str());
     } else {
         PyErr_SetString(PyExc_AttributeError,
                         "'Read' object has no attribute 'cleaned_seq'.");

--- a/khmer/thread_utils.py
+++ b/khmer/thread_utils.py
@@ -40,7 +40,8 @@ from __future__ import print_function, unicode_literals
 import threading
 import sys
 import screed
-from khmer.utils import (write_record, check_is_pair, clean_input_reads)
+import khmer
+from khmer.utils import write_record, check_is_pair
 from khmer.khmer_logger import log_info
 # stdlib queue module was renamed on Python 3
 try:
@@ -53,9 +54,8 @@ DEFAULT_GROUPSIZE = 100
 
 
 def verbose_loader(filename):
-    """Screed iterator that additionally prints progress info to stderr."""
-    screed_iter = clean_input_reads(screed.open(filename))
-    for num, record in enumerate(screed_iter):
+    """Read iterator that additionally prints progress info to stderr."""
+    for num, record in enumerate(khmer.ReadParser(filename)):
         if num % 100000 == 0:
             log_info('... filtering {num}', num=num)
         yield record
@@ -169,11 +169,11 @@ class ThreadedSequenceProcessor(object):
             keep = []
             for record in grouping.seqlist:
                 name, sequence = self.process_fn(record)
-                bp_processed += len(record['sequence'])
+                bp_processed += len(record.sequence)
                 if name:
-                    quality = record.get('quality')
-                    if quality:
-                        quality = quality[:len(sequence)]
+                    quality = None
+                    if hasattr(record, 'quality'):
+                        quality = record.quality[:len(sequence)]
                     bp_written += len(sequence)
                     keep.append((name, sequence, quality))
 

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -183,7 +183,7 @@ def broken_paired_reader(screed_iter, min_length=None,
         raise ValueError("force_single and require_paired cannot both be set!")
 
     # handle the majority of the stream.
-    for record in screed_iter:
+    for record in clean_input_reads(screed_iter):
         if prev_record:
             if check_is_pair(prev_record, record) and not force_single:
                 if min_length and (len(prev_record.sequence) < min_length or
@@ -258,6 +258,19 @@ def write_record_pair(read1, read2, fileobj):
         fileobj.write(bytes(recstr, 'ascii'))
     except TypeError:
         fileobj.write(recstr)
+
+
+def clean_input_reads(records):
+    """Add a cleaned_seq attribute to records that do not have one
+
+    Use this to convert a stream of records that might not have a
+    `cleaned_seq` attribute to one that does. Use this to extend
+    Records loaded by `screed.open()`.
+    """
+    for record in records:
+        if not hasattr(record, 'cleaned_seq'):
+            record.cleaned_seq = record.sequence.upper().replace('N', 'A')
+        yield record
 
 
 class ReadBundle(object):

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -183,7 +183,7 @@ def broken_paired_reader(screed_iter, min_length=None,
         raise ValueError("force_single and require_paired cannot both be set!")
 
     # handle the majority of the stream.
-    for record in clean_input_reads(screed_iter):
+    for record in screed_iter:
         if prev_record:
             if check_is_pair(prev_record, record) and not force_single:
                 if min_length and (len(prev_record.sequence) < min_length or

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -265,11 +265,11 @@ def clean_input_reads(records):
 
     Use this to convert a stream of records that might not have a
     `cleaned_seq` attribute to one that does. Use this to extend
-    Records loaded by `screed.open()`.
+    Records loaded by `screed.open()`. It is a mistake to apply
+    this to a `ReadParser` stream.
     """
     for record in records:
-        if not hasattr(record, 'cleaned_seq'):
-            record.cleaned_seq = record.sequence.upper().replace('N', 'A')
+        record.cleaned_seq = record.sequence.upper().replace('N', 'A')
         yield record
 
 

--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -183,7 +183,7 @@ def broken_paired_reader(screed_iter, min_length=None,
         raise ValueError("force_single and require_paired cannot both be set!")
 
     # handle the majority of the stream.
-    for record in clean_input_reads(screed_iter):
+    for record in screed_iter:
         if prev_record:
             if check_is_pair(prev_record, record) and not force_single:
                 if min_length and (len(prev_record.sequence) < min_length or
@@ -258,12 +258,6 @@ def write_record_pair(read1, read2, fileobj):
         fileobj.write(bytes(recstr, 'ascii'))
     except TypeError:
         fileobj.write(recstr)
-
-
-def clean_input_reads(screed_iter):
-    for record in screed_iter:
-        record.cleaned_seq = record.sequence.upper().replace('N', 'A')
-        yield record
 
 
 class ReadBundle(object):

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -49,20 +49,21 @@ namespace khmer
 namespace read_parsers
 {
 
-unsigned char _to_valid_dna(const unsigned char c) {
+unsigned char _to_valid_dna(const unsigned char c)
+{
     switch(c) {
-        case 'A':
-        case 'C':
-        case 'G':
-        case 'T':
-            return c;
-        case 'a':
-        case 'c':
-        case 'g':
-        case 't':
-            return toupper(c);
-        default:
-            return 'A';
+    case 'A':
+    case 'C':
+    case 'G':
+    case 'T':
+        return c;
+    case 'a':
+    case 'c':
+    case 'g':
+    case 't':
+        return toupper(c);
+    default:
+        return 'A';
     }
 }
 

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -49,6 +49,23 @@ namespace khmer
 namespace read_parsers
 {
 
+unsigned char _to_valid_dna(const unsigned char c) {
+    switch(c) {
+        case 'A':
+        case 'C':
+        case 'G':
+        case 'T':
+            return c;
+        case 'a':
+        case 'c':
+        case 'g':
+        case 't':
+            return toupper(c);
+        default:
+            return 'A';
+    }
+}
+
 void
 Read::write_to(std::ostream& output)
 {
@@ -101,6 +118,7 @@ Read FastxParser::get_next_read()
     if (!atEnd) {
         ret = seqan::readRecord(the_read.name, the_read.sequence,
                                 the_read.quality, _private->stream);
+        the_read.set_clean_seq();
         if (ret == 0) {
             // Detect if we're parsing something w/ qualities on the first read
             // only

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -41,6 +41,7 @@ Contact: khmer-project@idyll.org
 #include <regex.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -83,6 +84,8 @@ struct InvalidReadPair : public  khmer_value_exception {
         khmer_value_exception("Invalid read pair detected.") {}
 };
 
+unsigned char _to_valid_dna(const unsigned char c);
+
 struct Read {
     std::string name;
     std::string description;
@@ -99,6 +102,13 @@ struct Read {
         sequence.clear();
         quality.clear();
         cleaned_seq.clear();
+    }
+
+    // Compute cleaned_seq from sequence. Call this after changing sequence.
+    void set_clean_seq() {
+        cleaned_seq = std::string(sequence.size(), 0);
+        std::transform(sequence.begin(), sequence.end(), cleaned_seq.begin(),
+                       _to_valid_dna);
     }
 
     void write_to(std::ostream&);

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -105,7 +105,8 @@ struct Read {
     }
 
     // Compute cleaned_seq from sequence. Call this after changing sequence.
-    void set_clean_seq() {
+    void set_clean_seq()
+    {
         cleaned_seq = std::string(sequence.size(), 0);
         std::transform(sequence.begin(), sequence.end(), cleaned_seq.begin(),
                        _to_valid_dna);

--- a/scripts/extract-paired-reads.py
+++ b/scripts/extract-paired-reads.py
@@ -45,12 +45,10 @@ extract them into separate files (.pe and .se).
 Reads FASTQ and FASTA input, retains format for output.
 """
 from __future__ import print_function
-import screed
 import sys
 import os.path
 import textwrap
 
-from khmer import __version__
 from khmer import ReadParser
 from khmer.kfile import check_input_files, check_space
 from khmer.khmer_args import sanitize_help, KhmerArgumentParser
@@ -154,8 +152,8 @@ def main():
     n_pe = 0
     n_se = 0
 
-    screed_iter = ReadParser(infile)
-    for index, is_pair, read1, read2 in broken_paired_reader(screed_iter):
+    reads = ReadParser(infile)
+    for index, is_pair, read1, read2 in broken_paired_reader(reads):
         if index % 100000 == 0 and index > 0:
             print('...', index, file=sys.stderr)
 

--- a/scripts/filter-stoptags.py
+++ b/scripts/filter-stoptags.py
@@ -92,8 +92,8 @@ def main():
     nodegraph.load_stop_tags(stoptags)
 
     def process_fn(record):
-        name = record['name']
-        seq = record['sequence']
+        name = record.name
+        seq = record.sequence
         if 'N' in seq:
             return None, None
 

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -62,7 +62,8 @@ import argparse
 from khmer.kfile import (check_space, check_space_for_graph,
                          check_valid_file_exists, add_output_compression_type,
                          get_file_writer, is_block, describe_file_handle)
-from khmer.utils import (write_record, broken_paired_reader, ReadBundle)
+from khmer.utils import (write_record, broken_paired_reader, ReadBundle,
+                         clean_input_reads)
 from khmer.khmer_logger import (configure_logging, log_info, log_error)
 
 
@@ -380,7 +381,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         with catch_io_errors(filename, outfp, args.single_output_file,
                              args.force, corrupt_files):
 
-            screed_iter = screed.open(filename)
+            screed_iter = clean_input_reads(screed.open(filename))
             reader = broken_paired_reader(screed_iter, min_length=args.ksize,
                                           force_single=force_single,
                                           require_paired=require_paired)

--- a/scripts/normalize-by-median.py
+++ b/scripts/normalize-by-median.py
@@ -380,7 +380,6 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         # failsafe context manager in case an input file breaks
         with catch_io_errors(filename, outfp, args.single_output_file,
                              args.force, corrupt_files):
-
             screed_iter = clean_input_reads(screed.open(filename))
             reader = broken_paired_reader(screed_iter, min_length=args.ksize,
                                           force_single=force_single,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -540,3 +540,26 @@ def test_BrokenPairedReader_lowercase():
     assert c.sequence == 'aCgTn'
     assert c.cleaned_seq == 'ACGTA'
     assert d is None
+
+
+def test_BrokenPairedReader_lowercase_khmer_Read():
+    # use khmer.Read objects which should automatically have a `cleaned_seq`
+    # attribute
+    stream = [khmer.Read(name='seq1/1', sequence='acgtn'),
+              khmer.Read(name='seq1/2', sequence='AcGtN'),
+              khmer.Read(name='seq1/2', sequence='aCgTn')]
+
+    results = []
+    for num, is_pair, read1, read2 in broken_paired_reader(stream):
+        results.append((read1, read2))
+
+    a, b = results[0]
+    assert a.sequence == 'acgtn'
+    assert a.cleaned_seq == 'ACGTA'
+    assert b.sequence == 'AcGtN'
+    assert b.cleaned_seq == 'ACGTA'
+
+    c, d = results[1]
+    assert c.sequence == 'aCgTn'
+    assert c.cleaned_seq == 'ACGTA'
+    assert d is None

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -43,7 +43,7 @@ import sys
 import pytest
 from . import khmer_tst_utils as utils
 from khmer.utils import (check_is_pair, broken_paired_reader, check_is_left,
-                         check_is_right)
+                         check_is_right, clean_input_reads)
 from khmer.kfile import check_input_files, get_file_writer
 try:
     from StringIO import StringIO
@@ -524,6 +524,7 @@ def test_BrokenPairedReader_lowercase():
     stream = [screed.Record(name='seq1/1', sequence='acgtn'),
               screed.Record(name='seq1/2', sequence='AcGtN'),
               screed.Record(name='seq1/2', sequence='aCgTn')]
+    stream = clean_input_reads(stream)
 
     results = []
     for num, is_pair, read1, read2 in broken_paired_reader(stream):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -563,3 +563,10 @@ def test_BrokenPairedReader_lowercase_khmer_Read():
     assert c.sequence == 'aCgTn'
     assert c.cleaned_seq == 'ACGTA'
     assert d is None
+
+
+def test_clean_input_reads():
+    # all Read attributes are read only
+    stream = [khmer.Read(name='seq1/1', sequence='ACGT')]
+    with pytest.raises(AttributeError):
+        next(clean_input_reads(stream))

--- a/tests/test_read_handling.py
+++ b/tests/test_read_handling.py
@@ -37,23 +37,16 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import json
-import sys
-import os
-import stat
-from io import StringIO
-import traceback
-import threading
-import bz2
+
 import gzip
-import io
-import re
+import os
+import pytest
 
 from . import khmer_tst_utils as utils
 import khmer
 import khmer.kfile
+import khmer.utils
 import screed
-from khmer.utils import clean_input_reads
 
 
 def test_interleave_read_stdout():
@@ -752,7 +745,7 @@ def test_extract_paired_reads_5_stdin_error():
 
 def test_read_bundler():
     infile = utils.get_test_data('unclean-reads.fastq')
-    records = [r for r in clean_input_reads(screed.open(infile))]
+    records = [r for r in khmer.ReadParser(infile)]
     bundle = khmer.utils.ReadBundle(*records)
 
     raw_seqs = (
@@ -779,7 +772,7 @@ def test_read_bundler():
 
 def test_read_bundler_single_read():
     infile = utils.get_test_data('single-read.fq')
-    records = [r for r in clean_input_reads(screed.open(infile))]
+    records = [r for r in khmer.ReadParser(infile)]
     bundle = khmer.utils.ReadBundle(*records)
     assert bundle.num_reads == 1
     assert bundle.reads[0].sequence == bundle.reads[0].cleaned_seq
@@ -787,9 +780,8 @@ def test_read_bundler_single_read():
 
 def test_read_bundler_empty_file():
     infile = utils.get_test_data('empty-file')
-    records = [r for r in clean_input_reads(screed.open(infile))]
-    bundle = khmer.utils.ReadBundle(*records)
-    assert bundle.num_reads == 0
+    with pytest.raises(OSError):
+        records = [r for r in khmer.ReadParser(infile)]
 
 
 def test_read_bundler_empty_list():

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -71,24 +71,16 @@ def test_read_quality_none():
 def test_read_type_attributes():
     r = Read(sequence='ACGT', quality='good', name='1234', description='desc')
     assert r.sequence == 'ACGT'
+    assert r.cleaned_seq == 'ACGT'
     assert r.quality == 'good'
     assert r.name == '1234'
     assert r.description == 'desc'
-    # test setting and deleting of cleaned_seq
 
-    with pytest.raises(TypeError):
-        r.cleaned_seq = 12
 
-    assert not hasattr(r, 'cleaned_seq')
-    r.cleaned_seq = "ACGT"
-    r.cleaned_seq = u"ACGT"
-
-    assert hasattr(r, 'cleaned_seq')
-    del r.cleaned_seq
-    assert not hasattr(r, 'cleaned_seq')
-
-    with pytest.raises(TypeError):
-        r.cleaned_seq = u"some weird unicode \u2588"
+def test_read_type_cleaned_seq():
+    r = Read(sequence='acgtnN', name='1234')
+    assert r.sequence == 'acgtnN'
+    assert r.cleaned_seq == 'ACGTAA'
 
 
 def test_read_properties():

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -484,5 +484,12 @@ def test_iternext():
         print(str(err))
     except ValueError as err:
         print(str(err))
+
+
+def test_clean_seq():
+    for read in ReadParser(utils.get_test_data("test-abund-read-3.fa")):
+        clean = read.sequence.upper().replace("N", "A")
+        assert clean == read.cleaned_seq
+
 # vim: set filetype=python tabstop=4 softtabstop=4 shiftwidth=4 expandtab:
 # vim: set textwidth=79:


### PR DESCRIPTION
Compute the cleaned version of a read's sequence within the `Read` object.

This isn't ideal yet because the user of `Read` has to remember to call `set_cleaned_seq`. This is only a problem for c++ users, in python we can automate this. In c++ it is difficult because of the way `seqan` works which gets access directly to the sequence member of `Read` (we can't make it private).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
