### PR TITLE
Support for different input formats using templates: take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ under semantic versioning, but will be in future versions of khmer.
   integration testing.
 - Renamed core data structures: CountingHash --> Countgraph,
   Hashbits --> Nodegraph.
+- Replaced the IParser and FastxParser classes with a single ReadParser class.
+  Different input formats are supported by templating ReadParser with a reader
+  class.
 
 ### Fixed
 - Bug in compressed(gzip) streaming output from scripts

--- a/khmer/_cpy_hashgraph.hh
+++ b/khmer/_cpy_hashgraph.hh
@@ -495,7 +495,7 @@ hashgraph_consume_fasta_and_tag_with_reads_parser(khmer_KHashgraph_Object * me,
         return NULL;
     }
 
-    read_parsers:: IParser * rparser = rparser_obj-> parser;
+    read_parsers::ReadParser<FastxReader> * rparser = rparser_obj-> parser;
 
     // call the C++ function, and trap signals => Python
     const char         *value_exception = NULL;
@@ -506,7 +506,7 @@ hashgraph_consume_fasta_and_tag_with_reads_parser(khmer_KHashgraph_Object * me,
 
     Py_BEGIN_ALLOW_THREADS
     try {
-        hashgraph->consume_fasta_and_tag(rparser, total_reads, n_consumed);
+        hashgraph->consume_fasta_and_tag<FastxReader>(rparser, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         exc_string = exc.what();
         file_exception = exc_string.c_str();
@@ -546,7 +546,7 @@ hashgraph_consume_partitioned_fasta(khmer_KHashgraph_Object * me,
     unsigned int total_reads;
 
     try {
-        hashgraph->consume_partitioned_fasta(filename, total_reads, n_consumed);
+        hashgraph->consume_partitioned_fasta<FastxReader>(filename, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;
@@ -1306,7 +1306,7 @@ hashgraph_consume_fasta_and_tag(khmer_KHashgraph_Object * me, PyObject * args)
     unsigned int total_reads;
 
     try {
-        hashgraph->consume_fasta_and_tag(filename, total_reads, n_consumed);
+        hashgraph->consume_fasta_and_tag<FastxReader>(filename, total_reads, n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/khmer/_cpy_hashgraph.hh
+++ b/khmer/_cpy_hashgraph.hh
@@ -495,7 +495,7 @@ hashgraph_consume_fasta_and_tag_with_reads_parser(khmer_KHashgraph_Object * me,
         return NULL;
     }
 
-    read_parsers::ReadParser<FastxReader> * rparser = rparser_obj-> parser;
+    FastxParserPtr& rparser = rparser_obj->parser;
 
     // call the C++ function, and trap signals => Python
     const char         *value_exception = NULL;

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -564,7 +564,7 @@ static PyTypeObject khmer_Read_Type = {
 
 typedef struct {
     PyObject_HEAD
-    FastxParserPtr& parser;
+    FastxParserPtr parser;
 } khmer_ReadParser_Object;
 
 

--- a/lib/assembler.cc
+++ b/lib/assembler.cc
@@ -88,8 +88,8 @@ const
         node_filters.push_back(get_stop_bf_filter(stop_bf));
     }
 
-    AssemblerTraverser<RIGHT> cursor(graph, seed_kmer, node_filters);
-    return _assemble_directed<RIGHT>(cursor);
+    AssemblerTraverser<TRAVERSAL_RIGHT> cursor(graph, seed_kmer, node_filters);
+    return _assemble_directed<TRAVERSAL_RIGHT>(cursor);
 }
 
 
@@ -102,12 +102,12 @@ const
         node_filters.push_back(get_stop_bf_filter(stop_bf));
     }
 
-    AssemblerTraverser<LEFT> cursor(graph, seed_kmer, node_filters);
-    return _assemble_directed<LEFT>(cursor);
+    AssemblerTraverser<TRAVERSAL_LEFT> cursor(graph, seed_kmer, node_filters);
+    return _assemble_directed<TRAVERSAL_LEFT>(cursor);
 }
 
 template <>
-std::string LinearAssembler::_assemble_directed<LEFT>(AssemblerTraverser<LEFT>&
+std::string LinearAssembler::_assemble_directed<TRAVERSAL_LEFT>(AssemblerTraverser<TRAVERSAL_LEFT>&
         cursor)
 const
 {
@@ -138,8 +138,8 @@ const
 }
 
 template<>
-std::string LinearAssembler::_assemble_directed<RIGHT>
-(AssemblerTraverser<RIGHT>& cursor)
+std::string LinearAssembler::_assemble_directed<TRAVERSAL_RIGHT>
+(AssemblerTraverser<TRAVERSAL_RIGHT>& cursor)
 const
 {
     std::string contig = cursor.cursor.get_string_rep(_ksize);
@@ -201,15 +201,15 @@ const
     std::cout << "Assemble Labeled RIGHT: " << seed_kmer.repr(_ksize) << std::endl;
 #endif
     StringVector right_paths;
-    NonLoopingAT<RIGHT> rcursor(graph, seed_kmer, node_filters, &visited);
-    _assemble_directed<RIGHT>(rcursor, right_paths);
+    NonLoopingAT<TRAVERSAL_RIGHT> rcursor(graph, seed_kmer, node_filters, &visited);
+    _assemble_directed<TRAVERSAL_RIGHT>(rcursor, right_paths);
 
 #if DEBUG_ASSEMBLY
     std::cout << "Assemble Labeled LEFT: " << seed_kmer.repr(_ksize) << std::endl;
 #endif
     StringVector left_paths;
-    NonLoopingAT<LEFT> lcursor(graph, seed_kmer, node_filters, &visited);
-    _assemble_directed<LEFT>(lcursor, left_paths);
+    NonLoopingAT<TRAVERSAL_LEFT> lcursor(graph, seed_kmer, node_filters, &visited);
+    _assemble_directed<TRAVERSAL_LEFT>(lcursor, left_paths);
 
     StringVector paths;
     for (unsigned int i = 0; i < left_paths.size(); i++) {
@@ -419,15 +419,15 @@ const
                   _ksize) << std::endl;
 #endif
     StringVector right_paths;
-    NonLoopingAT<RIGHT> rcursor(graph, seed_kmer, node_filters, &visited);
-    _assemble_directed<RIGHT>(rcursor, right_paths);
+    NonLoopingAT<TRAVERSAL_RIGHT> rcursor(graph, seed_kmer, node_filters, &visited);
+    _assemble_directed<TRAVERSAL_RIGHT>(rcursor, right_paths);
 
 #if DEBUG_ASSEMBLY
     std::cout << "Assemble Junctions LEFT: " << seed_kmer.repr(_ksize) << std::endl;
 #endif
     StringVector left_paths;
-    NonLoopingAT<LEFT> lcursor(graph, seed_kmer, node_filters, &visited);
-    _assemble_directed<LEFT>(lcursor, left_paths);
+    NonLoopingAT<TRAVERSAL_LEFT> lcursor(graph, seed_kmer, node_filters, &visited);
+    _assemble_directed<TRAVERSAL_LEFT>(lcursor, left_paths);
 
     StringVector paths;
     for (unsigned int i = 0; i < left_paths.size(); i++) {

--- a/lib/assembler.hh
+++ b/lib/assembler.hh
@@ -97,11 +97,11 @@ public:
 // The explicit specializations need to be declared in the same translation unit
 // as their unspecialized declaration.
 template<>
-std::string LinearAssembler::_assemble_directed<LEFT>(AssemblerTraverser<LEFT>
+std::string LinearAssembler::_assemble_directed<TRAVERSAL_LEFT>(AssemblerTraverser<TRAVERSAL_LEFT>
         &cursor) const;
 
 template<>
-std::string LinearAssembler::_assemble_directed<RIGHT>(AssemblerTraverser<RIGHT>
+std::string LinearAssembler::_assemble_directed<TRAVERSAL_RIGHT>(AssemblerTraverser<TRAVERSAL_RIGHT>
         &cursor) const;
 
 

--- a/lib/hashgraph.cc
+++ b/lib/hashgraph.cc
@@ -276,20 +276,20 @@ void Hashgraph::consume_sequence_and_tag(const std::string& seq,
 //
 
 // TODO? Inline in header.
-template<typename ParseFunctor>
+template<typename SeqIO>
 void Hashgraph::consume_fasta_and_tag(
         std::string const &filename,
         unsigned int &total_reads,
         unsigned long long &n_consumed
 )
 {
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
-    consume_fasta_and_tag<ParseFunctor>(parser, total_reads, n_consumed);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    consume_fasta_and_tag<SeqIO>(parser, total_reads, n_consumed);
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void Hashgraph::consume_fasta_and_tag(
-        ReadParserPtr<ParseFunctor>& parser,
+        ReadParserPtr<SeqIO>& parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
 )
@@ -344,7 +344,7 @@ void Hashgraph::divide_tags_into_subsets(unsigned int subset_size,
 // consume_partitioned_fasta: consume a FASTA file of reads
 //
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void Hashgraph::consume_partitioned_fasta(
         const std::string &filename,
         unsigned int &total_reads,
@@ -354,7 +354,7 @@ void Hashgraph::consume_partitioned_fasta(
     total_reads = 0;
     n_consumed = 0;
 
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
     Read read;
 
     string seq = "";

--- a/lib/hashgraph.cc
+++ b/lib/hashgraph.cc
@@ -898,3 +898,8 @@ template void Hashgraph::consume_fasta_and_tag<read_parsers::FastxReader>(
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
+template void Hashgraph::consume_partitioned_fasta<read_parsers::FastxReader>(
+    const std::string &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
+);

--- a/lib/hashgraph.cc
+++ b/lib/hashgraph.cc
@@ -278,19 +278,20 @@ void Hashgraph::consume_sequence_and_tag(const std::string& seq,
 // TODO? Inline in header.
 template<typename ParseFunctor>
 void Hashgraph::consume_fasta_and_tag(
-    std::string const &filename,
-    unsigned int &total_reads, unsigned long long &n_consumed
+        std::string const &filename,
+        unsigned int &total_reads,
+        unsigned long long &n_consumed
 )
 {
-    ParseFunctor reader((std::string&)filename);
-    read_parsers::ReadParser<ParseFunctor> parser(reader);
-    consume_fasta_and_tag(&parser,total_reads, n_consumed);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    consume_fasta_and_tag<ParseFunctor>(parser, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
 void Hashgraph::consume_fasta_and_tag(
-    read_parsers::ReadParser<ParseFunctor>* parser,
-    unsigned int &total_reads, unsigned long long &n_consumed
+        ReadParserPtr<ParseFunctor>& parser,
+        unsigned int &total_reads,
+        unsigned long long &n_consumed
 )
 {
     Read			  read;
@@ -344,15 +345,16 @@ void Hashgraph::divide_tags_into_subsets(unsigned int subset_size,
 //
 
 template<typename ParseFunctor>
-void Hashgraph::consume_partitioned_fasta(const std::string &filename,
+void Hashgraph::consume_partitioned_fasta(
+        const std::string &filename,
         unsigned int &total_reads,
-        unsigned long long &n_consumed)
+        unsigned long long &n_consumed
+)
 {
     total_reads = 0;
     n_consumed = 0;
 
-    ParseFunctor reader((std::string&)filename);
-    read_parsers::ReadParser<ParseFunctor> parser(reader);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
     Read read;
 
     string seq = "";
@@ -365,9 +367,9 @@ void Hashgraph::consume_partitioned_fasta(const std::string &filename,
     // iterate through the FASTA file & consume the reads.
     //
 
-    while(!parser.is_complete())  {
+    while(!parser->is_complete())  {
         try {
-            read = parser.get_next_read();
+            read = parser->get_next_read();
         } catch (NoMoreReadsAvailable &exc) {
             break;
         }
@@ -894,10 +896,11 @@ template void Hashgraph::consume_fasta_and_tag<read_parsers::FastxReader>(
 );
 
 template void Hashgraph::consume_fasta_and_tag<read_parsers::FastxReader>(
-    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    FastxParserPtr& parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
+
 template void Hashgraph::consume_partitioned_fasta<read_parsers::FastxReader>(
     const std::string &filename,
     unsigned int &total_reads,

--- a/lib/hashgraph.cc
+++ b/lib/hashgraph.cc
@@ -283,7 +283,7 @@ void Hashgraph::consume_fasta_and_tag(
         unsigned long long &n_consumed
 )
 {
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     consume_fasta_and_tag<SeqIO>(parser, total_reads, n_consumed);
 }
 
@@ -354,7 +354,7 @@ void Hashgraph::consume_partitioned_fasta(
     total_reads = 0;
     n_consumed = 0;
 
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     Read read;
 
     string seq = "";

--- a/lib/hashgraph.hh
+++ b/lib/hashgraph.hh
@@ -55,11 +55,12 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-namespace read_parsers
-{
-class IParser;
-}  // namespace read_parsers
-}  // namespace khmer
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
+    }
+}
 
 #define MAX_KEEPER_SIZE int(1e6)
 
@@ -170,6 +171,7 @@ public:
     }
 
     // Consume reads & build sparse graph.
+    template<typename ParseFunctor>
     void consume_fasta_and_tag(
         std::string const &filename,
         unsigned int &total_reads,
@@ -179,8 +181,9 @@ public:
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
     // Tag certain ones on the connectivity graph.
+    template<typename ParseFunctor>
     void consume_fasta_and_tag(
-        read_parsers:: IParser * parser,
+        read_parsers::ReadParser<ParseFunctor> * parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
     );
@@ -192,6 +195,7 @@ public:
 
 
     // consume an already-partitioned file & load in the partition IDs
+    template<typename ParseFunctor>
     void consume_partitioned_fasta(const std::string &filename,
                                    unsigned int &total_reads,
                                    unsigned long long &n_consumed);

--- a/lib/hashgraph.hh
+++ b/lib/hashgraph.hh
@@ -183,7 +183,7 @@ public:
     // Tag certain ones on the connectivity graph.
     template<typename ParseFunctor>
     void consume_fasta_and_tag(
-        read_parsers::ReadParser<ParseFunctor> * parser,
+        read_parsers::ReadParserPtr<ParseFunctor>& parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
     );

--- a/lib/hashgraph.hh
+++ b/lib/hashgraph.hh
@@ -57,7 +57,7 @@ namespace khmer
 {
     namespace read_parsers
     {
-        template<typename ParseFunctor> class ReadParser;
+        template<typename SeqIO> class ReadParser;
         class FastxReader;
     }
 }
@@ -171,7 +171,7 @@ public:
     }
 
     // Consume reads & build sparse graph.
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta_and_tag(
         std::string const &filename,
         unsigned int &total_reads,
@@ -181,9 +181,9 @@ public:
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
     // Tag certain ones on the connectivity graph.
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta_and_tag(
-        read_parsers::ReadParserPtr<ParseFunctor>& parser,
+        read_parsers::ReadParserPtr<SeqIO>& parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
     );
@@ -195,7 +195,7 @@ public:
 
 
     // consume an already-partitioned file & load in the partition IDs
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_partitioned_fasta(const std::string &filename,
                                    unsigned int &total_reads,
                                    unsigned long long &n_consumed);

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -114,7 +114,7 @@ void Hashtable::consume_fasta(
     unsigned long long &n_consumed
 )
 {
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     consume_fasta<SeqIO>(parser, total_reads, n_consumed);
 }
 
@@ -379,7 +379,7 @@ uint64_t * Hashtable::abundance_distribution(
     std::string filename,
     Hashtable *  tracking)
 {
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     return abundance_distribution(parser, tracking);
 }
 

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -107,20 +107,20 @@ bool Hashtable::check_and_normalize_read(std::string &read) const
 //
 
 // TODO? Inline in header.
-template<typename ParseFunctor>
+template<typename SeqIO>
 void Hashtable::consume_fasta(
     std::string const &filename,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 )
 {
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
-    consume_fasta<ParseFunctor>(parser, total_reads, n_consumed);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    consume_fasta<SeqIO>(parser, total_reads, n_consumed);
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void Hashtable::consume_fasta(
-    ReadParserPtr<ParseFunctor>& parser,
+    ReadParserPtr<SeqIO>& parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 )
@@ -322,9 +322,9 @@ BoundedCounterType Hashtable::get_max_count(const std::string &s)
     return max_count;
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 uint64_t * Hashtable::abundance_distribution(
-    ReadParserPtr<ParseFunctor>& parser,
+    ReadParserPtr<SeqIO>& parser,
     Hashtable *          tracking)
 {
     uint64_t * dist = new uint64_t[MAX_BIGCOUNT + 1];
@@ -374,12 +374,12 @@ uint64_t * Hashtable::abundance_distribution(
     return dist;
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 uint64_t * Hashtable::abundance_distribution(
     std::string filename,
     Hashtable *  tracking)
 {
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
     return abundance_distribution(parser, tracking);
 }
 

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -115,8 +115,8 @@ void Hashtable::consume_fasta(
 )
 {
     ParseFunctor reader((std::string&)filename);
-    ReadParser<ParseFunctor> parser(reader);
-    consume_fasta(&parser, total_reads, n_consumed);
+    read_parsers::ReadParser<ParseFunctor> parser(reader);
+    consume_fasta<ParseFunctor>(&parser, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
@@ -510,5 +510,16 @@ const
 
     return posns;
 }
+
+template void Hashtable::consume_fasta<read_parsers::FastxReader>(
+    std::string const &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
+);
+template void Hashtable::consume_fasta<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
+);
 
 } // namespace khmer

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -114,14 +114,13 @@ void Hashtable::consume_fasta(
     unsigned long long &n_consumed
 )
 {
-    ParseFunctor reader((std::string&)filename);
-    read_parsers::ReadParser<ParseFunctor> parser(reader);
-    consume_fasta<ParseFunctor>(&parser, total_reads, n_consumed);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    consume_fasta<ParseFunctor>(parser, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
 void Hashtable::consume_fasta(
-    read_parsers::ReadParser<ParseFunctor> * parser,
+    ReadParserPtr<ParseFunctor>& parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 )
@@ -325,7 +324,7 @@ BoundedCounterType Hashtable::get_max_count(const std::string &s)
 
 template<typename ParseFunctor>
 uint64_t * Hashtable::abundance_distribution(
-    read_parsers::ReadParser<ParseFunctor>* parser,
+    ReadParserPtr<ParseFunctor>& parser,
     Hashtable *          tracking)
 {
     uint64_t * dist = new uint64_t[MAX_BIGCOUNT + 1];
@@ -380,9 +379,8 @@ uint64_t * Hashtable::abundance_distribution(
     std::string filename,
     Hashtable *  tracking)
 {
-    ParseFunctor reader((std::string&)filename);
-    ReadParser<ParseFunctor> parser(reader);
-    return abundance_distribution(&parser, tracking);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    return abundance_distribution(parser, tracking);
 }
 
 unsigned long Hashtable::trim_on_abundance(
@@ -511,21 +509,21 @@ const
     return posns;
 }
 
-template void Hashtable::consume_fasta<read_parsers::FastxReader>(
+template void Hashtable::consume_fasta<FastxReader>(
     std::string const &filename,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
-template void Hashtable::consume_fasta<read_parsers::FastxReader>(
-    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+template void Hashtable::consume_fasta<FastxReader>(
+    ReadParserPtr<FastxReader>& parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
-template uint64_t * Hashtable::abundance_distribution<read_parsers::FastxReader>(
-    read_parsers::ReadParser<read_parsers::FastxReader>* parser,
+template uint64_t * Hashtable::abundance_distribution<FastxReader>(
+    ReadParserPtr<FastxReader>& parser,
     Hashtable * tracking
 );
-template uint64_t * Hashtable::abundance_distribution<read_parsers::FastxReader>(
+template uint64_t * Hashtable::abundance_distribution<FastxReader>(
     std::string filename,
     Hashtable * tracking
 );

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -521,5 +521,13 @@ template void Hashtable::consume_fasta<read_parsers::FastxReader>(
     unsigned int &total_reads,
     unsigned long long &n_consumed
 );
+template uint64_t * Hashtable::abundance_distribution<read_parsers::FastxReader>(
+    read_parsers::ReadParser<read_parsers::FastxReader>* parser,
+    Hashtable * tracking
+);
+template uint64_t * Hashtable::abundance_distribution<read_parsers::FastxReader>(
+    std::string filename,
+    Hashtable * tracking
+);
 
 } // namespace khmer

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -52,7 +52,10 @@ Contact: khmer-project@idyll.org
 
 using namespace std;
 using namespace khmer;
-using namespace khmer:: read_parsers;
+using namespace khmer::read_parsers;
+
+namespace khmer
+{
 
 //
 // check_and_process_read: checks for non-ACGT characters before consuming
@@ -104,29 +107,23 @@ bool Hashtable::check_and_normalize_read(std::string &read) const
 //
 
 // TODO? Inline in header.
-void
-Hashtable::
-consume_fasta(
-    std:: string const  &filename,
-    unsigned int	      &total_reads, unsigned long long	&n_consumed
+template<typename ParseFunctor>
+void Hashtable::consume_fasta(
+    std::string const &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
 )
 {
-    IParser *	  parser =
-        IParser::get_parser( filename );
-
-    consume_fasta(
-        parser,
-        total_reads, n_consumed
-    );
-
-    delete parser;
+    ParseFunctor reader((std::string&)filename);
+    ReadParser<ParseFunctor> parser(reader);
+    consume_fasta(&parser, total_reads, n_consumed);
 }
 
-void
-Hashtable::
-consume_fasta(
-    read_parsers:: IParser *  parser,
-    unsigned int		    &total_reads, unsigned long long  &n_consumed
+template<typename ParseFunctor>
+void Hashtable::consume_fasta(
+    read_parsers::ReadParser<ParseFunctor> * parser,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed
 )
 {
     Read			  read;
@@ -326,9 +323,9 @@ BoundedCounterType Hashtable::get_max_count(const std::string &s)
     return max_count;
 }
 
-uint64_t *
-Hashtable::abundance_distribution(
-    read_parsers::IParser * parser,
+template<typename ParseFunctor>
+uint64_t * Hashtable::abundance_distribution(
+    read_parsers::ReadParser<ParseFunctor>* parser,
     Hashtable *          tracking)
 {
     uint64_t * dist = new uint64_t[MAX_BIGCOUNT + 1];
@@ -378,16 +375,14 @@ Hashtable::abundance_distribution(
     return dist;
 }
 
-
+template<typename ParseFunctor>
 uint64_t * Hashtable::abundance_distribution(
     std::string filename,
     Hashtable *  tracking)
 {
-    IParser* parser = IParser::get_parser(filename.c_str());
-
-    uint64_t * distribution = abundance_distribution(parser, tracking);
-    delete parser;
-    return distribution;
+    ParseFunctor reader((std::string&)filename);
+    ReadParser<ParseFunctor> parser(reader);
+    return abundance_distribution(&parser, tracking);
 }
 
 unsigned long Hashtable::trim_on_abundance(
@@ -516,4 +511,4 @@ const
     return posns;
 }
 
-// vim: set sts=2 sw=2:
+} // namespace khmer

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -204,13 +204,13 @@ public:
 
     // Count every k-mer in a FASTA or FASTQ file.
     // Note: Yes, the name 'consume_fasta' is a bit misleading,
-    //	     but the FASTA format is effectively a subset of the FASTQ format
-    //	     and the FASTA portion is what we care about in this case.
+    //       but the FASTA format is effectively a subset of the FASTQ format
+    //       and the FASTA portion is what we care about in this case.
     template<typename ParseFunctor>
     void consume_fasta(
-        std::string const   &filename,
-        unsigned int	    &total_reads,
-        unsigned long long  &n_consumed
+        std::string const &filename,
+        unsigned int &total_reads,
+        unsigned long long &n_consumed
     );
 
     // Count every k-mer from a stream of FASTA or FASTQ reads,
@@ -218,8 +218,8 @@ public:
     template<typename ParseFunctor>
     void consume_fasta(
         read_parsers::ReadParser<ParseFunctor>* parser,
-        unsigned int	    &total_reads,
-        unsigned long long  &n_consumed
+        unsigned int &total_reads,
+        unsigned long long &n_consumed
     );
 
     void set_use_bigcount(bool b)
@@ -291,8 +291,10 @@ public:
 
     // calculate the abundance distribution of kmers in the given file.
     template<typename ParseFunctor>
-    uint64_t * abundance_distribution(read_parsers::ReadParser<ParseFunctor>* parser,
-                                      Hashtable * tracking);
+    uint64_t * abundance_distribution(
+        read_parsers::ReadParser<ParseFunctor>* parser,
+        Hashtable * tracking
+    );
     template<typename ParseFunctor>
     uint64_t * abundance_distribution(std::string filename,
                                       Hashtable * tracking);

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -62,7 +62,7 @@ namespace khmer
 {
     namespace read_parsers
     {
-        template<typename ParseFunctor> class ReadParser;
+        template<typename SeqIO> class ReadParser;
         class FastxReader;
     }
 }
@@ -206,7 +206,7 @@ public:
     // Note: Yes, the name 'consume_fasta' is a bit misleading,
     //       but the FASTA format is effectively a subset of the FASTQ format
     //       and the FASTA portion is what we care about in this case.
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta(
         std::string const &filename,
         unsigned int &total_reads,
@@ -215,9 +215,9 @@ public:
 
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta(
-        read_parsers::ReadParserPtr<ParseFunctor>& parser,
+        read_parsers::ReadParserPtr<SeqIO>& parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
     );
@@ -290,12 +290,12 @@ public:
     BoundedCounterType get_max_count(const std::string &s);
 
     // calculate the abundance distribution of kmers in the given file.
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     uint64_t * abundance_distribution(
-        read_parsers::ReadParserPtr<ParseFunctor>& parser,
+        read_parsers::ReadParserPtr<SeqIO>& parser,
         Hashtable * tracking
     );
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     uint64_t * abundance_distribution(std::string filename,
                                       Hashtable * tracking);
 

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -60,11 +60,12 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-namespace read_parsers
-{
-class IParser;
-}  // namespace read_parsers
-}  // namespace khmer
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
+    }
+}
 
 #define CALLBACK_PERIOD 100000
 
@@ -205,6 +206,7 @@ public:
     // Note: Yes, the name 'consume_fasta' is a bit misleading,
     //	     but the FASTA format is effectively a subset of the FASTQ format
     //	     and the FASTA portion is what we care about in this case.
+    template<typename ParseFunctor>
     void consume_fasta(
         std::string const   &filename,
         unsigned int	    &total_reads,
@@ -213,8 +215,9 @@ public:
 
     // Count every k-mer from a stream of FASTA or FASTQ reads,
     // using the supplied parser.
+    template<typename ParseFunctor>
     void consume_fasta(
-        read_parsers:: IParser *	    parser,
+        read_parsers::ReadParser<ParseFunctor>* parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed
     );
@@ -287,8 +290,10 @@ public:
     BoundedCounterType get_max_count(const std::string &s);
 
     // calculate the abundance distribution of kmers in the given file.
-    uint64_t * abundance_distribution(read_parsers::IParser * parser,
+    template<typename ParseFunctor>
+    uint64_t * abundance_distribution(read_parsers::ReadParser<ParseFunctor>* parser,
                                       Hashtable * tracking);
+    template<typename ParseFunctor>
     uint64_t * abundance_distribution(std::string filename,
                                       Hashtable * tracking);
 

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -217,7 +217,7 @@ public:
     // using the supplied parser.
     template<typename ParseFunctor>
     void consume_fasta(
-        read_parsers::ReadParser<ParseFunctor>* parser,
+        read_parsers::ReadParserPtr<ParseFunctor>& parser,
         unsigned int &total_reads,
         unsigned long long &n_consumed
     );
@@ -292,7 +292,7 @@ public:
     // calculate the abundance distribution of kmers in the given file.
     template<typename ParseFunctor>
     uint64_t * abundance_distribution(
-        read_parsers::ReadParser<ParseFunctor>* parser,
+        read_parsers::ReadParserPtr<ParseFunctor>& parser,
         Hashtable * tracking
     );
     template<typename ParseFunctor>

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -383,7 +383,7 @@ void HLLCounter::consume_fasta(
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     consume_fasta<SeqIO>(parser, stream_records, total_reads, n_consumed);
 }
 

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -376,20 +376,20 @@ unsigned int HLLCounter::consume_string(const std::string &inp)
     return n_consumed;
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void HLLCounter::consume_fasta(
     std::string const &filename,
     bool stream_records,
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
-    consume_fasta<ParseFunctor>(parser, stream_records, total_reads, n_consumed);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    consume_fasta<SeqIO>(parser, stream_records, total_reads, n_consumed);
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void HLLCounter::consume_fasta(
-    ReadParserPtr<ParseFunctor>& parser,
+    ReadParserPtr<SeqIO>& parser,
     bool stream_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)

--- a/lib/hllcounter.cc
+++ b/lib/hllcounter.cc
@@ -58,6 +58,7 @@ Contact: khmer-project@idyll.org
 #define arr_len(a) (a + sizeof a / sizeof a[0])
 
 using namespace khmer;
+using namespace khmer::read_parsers;
 
 std::map<int, std::vector<double> > rawEstimateData;
 std::map<int, std::vector<double> > biasData;
@@ -382,14 +383,13 @@ void HLLCounter::consume_fasta(
     unsigned int &total_reads,
     unsigned long long &n_consumed)
 {
-    ParseFunctor reader((std::string&)filename);
-    read_parsers::ReadParser<ParseFunctor> parser(reader);
-    consume_fasta<ParseFunctor>(&parser, stream_records, total_reads, n_consumed);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    consume_fasta<ParseFunctor>(parser, stream_records, total_reads, n_consumed);
 }
 
 template<typename ParseFunctor>
 void HLLCounter::consume_fasta(
-    read_parsers::ReadParser<ParseFunctor> *parser,
+    ReadParserPtr<ParseFunctor>& parser,
     bool stream_records,
     unsigned int &      total_reads,
     unsigned long long &    n_consumed)
@@ -509,14 +509,14 @@ void HLLCounter::merge(HLLCounter &other)
     }
 }
 
-template void HLLCounter::consume_fasta<read_parsers::FastxReader>(
+template void HLLCounter::consume_fasta<FastxReader>(
     std::string const &,
     bool,
     unsigned int &,
     unsigned long long &
 );
-template void HLLCounter::consume_fasta<read_parsers::FastxReader>(
-    read_parsers::ReadParser<read_parsers::FastxReader> *,
+template void HLLCounter::consume_fasta<FastxReader>(
+    ReadParserPtr<FastxReader>&,
     bool,
     unsigned int &,
     unsigned long long &

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -49,7 +49,7 @@ namespace khmer
 
 namespace read_parsers
 {
-    template<typename ParseFunctor> class ReadParser;
+    template<typename SeqIO> class ReadParser;
     class FastxReader;
 }
 
@@ -61,13 +61,13 @@ public:
 
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta(std::string const &,
                        bool,
                        unsigned int &,
                        unsigned long long &);
-    template<typename ParseFunctor>
-    void consume_fasta(read_parsers::ReadParserPtr<ParseFunctor>&,
+    template<typename SeqIO>
+    void consume_fasta(read_parsers::ReadParserPtr<SeqIO>&,
                        bool,
                        unsigned int &,
                        unsigned long long &);

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -67,7 +67,7 @@ public:
                        unsigned int &,
                        unsigned long long &);
     template<typename ParseFunctor>
-    void consume_fasta(read_parsers::ReadParser<ParseFunctor> *,
+    void consume_fasta(read_parsers::ReadParserPtr<ParseFunctor>&,
                        bool,
                        unsigned int &,
                        unsigned long long &);

--- a/lib/hllcounter.hh
+++ b/lib/hllcounter.hh
@@ -47,7 +47,11 @@ Contact: khmer-project@idyll.org
 namespace khmer
 {
 
-using read_parsers::IParser;
+namespace read_parsers
+{
+    template<typename ParseFunctor> class ReadParser;
+    class FastxReader;
+}
 
 class HLLCounter
 {
@@ -57,11 +61,13 @@ public:
 
     void add(const std::string &);
     unsigned int consume_string(const std::string &);
+    template<typename ParseFunctor>
     void consume_fasta(std::string const &,
                        bool,
                        unsigned int &,
                        unsigned long long &);
-    void consume_fasta(read_parsers::IParser *,
+    template<typename ParseFunctor>
+    void consume_fasta(read_parsers::ReadParser<ParseFunctor> *,
                        bool,
                        unsigned int &,
                        unsigned long long &);

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -96,8 +96,8 @@ private:\
 #   define SAVED_SMALLCOUNT 7
 
 
-#   define TRAVERSE_LEFT 0
-#   define TRAVERSE_RIGHT 1
+#   define TRAVERSAL_LEFT 0
+#   define TRAVERSAL_RIGHT 1
 
 #   define VERBOSE_REPARTITION 0
 

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -96,8 +96,8 @@ private:\
 #   define SAVED_SMALLCOUNT 7
 
 
-#   define LEFT 0
-#   define RIGHT 1
+#   define TRAVERSE_LEFT 0
+#   define TRAVERSE_RIGHT 1
 
 #   define VERBOSE_REPARTITION 0
 

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -74,7 +74,7 @@ void LabelHash::consume_fasta_and_tag_with_labels(
     CallbackFn	      callback,	    void *		callback_data
 )
 {
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     consume_fasta_and_tag_with_labels<SeqIO>(
         parser,
         total_reads, n_consumed,
@@ -156,7 +156,7 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     total_reads = 0;
     n_consumed = 0;
 
-    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>(filename);
     Read read;
 
     std::string seq = "";

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -74,10 +74,9 @@ void LabelHash::consume_fasta_and_tag_with_labels(
     CallbackFn	      callback,	    void *		callback_data
 )
 {
-    ParseFunctor pf((std::string&)filename);
-    ReadParser<ParseFunctor> parser(pf);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
     consume_fasta_and_tag_with_labels<ParseFunctor>(
-        &parser,
+        parser,
         total_reads, n_consumed,
         callback, callback_data
     );
@@ -85,7 +84,7 @@ void LabelHash::consume_fasta_and_tag_with_labels(
 
 template<typename ParseFunctor>
 void LabelHash::consume_fasta_and_tag_with_labels(
-    read_parsers::ReadParser<ParseFunctor> * parser,
+    ReadParserPtr<ParseFunctor>& parser,
     unsigned int		    &total_reads,   unsigned long long	&n_consumed,
     CallbackFn		    callback,	    void *		callback_data
 )
@@ -157,8 +156,7 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     total_reads = 0;
     n_consumed = 0;
 
-    ParseFunctor pf((std::string&)filename);
-    ReadParser<ParseFunctor> parser(pf);
+    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
     Read read;
 
     std::string seq = "";
@@ -171,8 +169,8 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     // iterate through the FASTA file & consume the reads.
     //
     PartitionID p;
-    while(!parser.is_complete())  {
-        read = parser.get_next_read();
+    while(!parser->is_complete())  {
+        read = parser->get_next_read();
         seq = read.sequence;
 
         if (graph->check_and_normalize_read(seq)) {
@@ -614,21 +612,21 @@ void LabelHash::label_across_high_degree_nodes(const char * s,
     }
 }
 
-template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxReader>(
+template void LabelHash::consume_fasta_and_tag_with_labels<FastxReader>(
     std:: string const &filename,
     unsigned int &total_reads,
     unsigned long long &n_consumed,
     CallbackFn callback,
     void * callback_data
 );
-template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxReader>(
-    read_parsers::ReadParser<read_parsers::FastxReader> * parser,
+template void LabelHash::consume_fasta_and_tag_with_labels<FastxReader>(
+    ReadParserPtr<FastxReader>& parser,
     unsigned int &total_reads,
     unsigned long long &n_consumed,
     CallbackFn callback,
     void * callback_data
 );
-template void LabelHash::consume_partitioned_fasta_and_tag_with_labels<read_parsers::FastxReader>(
+template void LabelHash::consume_partitioned_fasta_and_tag_with_labels<FastxReader>(
     const std::string &filename,
     unsigned int &total_reads,
     unsigned long long &n_consumed,

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -67,24 +67,24 @@ namespace khmer
  * function which accepts a consume_sequence function pointer as a parameter
  */
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void LabelHash::consume_fasta_and_tag_with_labels(
     std:: string const  &filename,
     unsigned int	      &total_reads, unsigned long long	&n_consumed,
     CallbackFn	      callback,	    void *		callback_data
 )
 {
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
-    consume_fasta_and_tag_with_labels<ParseFunctor>(
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
+    consume_fasta_and_tag_with_labels<SeqIO>(
         parser,
         total_reads, n_consumed,
         callback, callback_data
     );
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void LabelHash::consume_fasta_and_tag_with_labels(
-    ReadParserPtr<ParseFunctor>& parser,
+    ReadParserPtr<SeqIO>& parser,
     unsigned int		    &total_reads,   unsigned long long	&n_consumed,
     CallbackFn		    callback,	    void *		callback_data
 )
@@ -145,7 +145,7 @@ void LabelHash::consume_fasta_and_tag_with_labels(
 
 }
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     const std::string &filename,
     unsigned int &total_reads,
@@ -156,7 +156,7 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     total_reads = 0;
     n_consumed = 0;
 
-    ReadParserPtr<ParseFunctor> parser = get_parser<ParseFunctor>((std::string&)filename);
+    ReadParserPtr<SeqIO> parser = get_parser<SeqIO>((std::string&)filename);
     Read read;
 
     std::string seq = "";

--- a/lib/labelhash.cc
+++ b/lib/labelhash.cc
@@ -76,14 +76,11 @@ void LabelHash::consume_fasta_and_tag_with_labels(
 {
     ParseFunctor pf((std::string&)filename);
     ReadParser<ParseFunctor> parser(pf);
-
-    consume_fasta_and_tag_with_labels(
+    consume_fasta_and_tag_with_labels<ParseFunctor>(
         &parser,
         total_reads, n_consumed,
         callback, callback_data
     );
-
-    delete parser;
 }
 
 template<typename ParseFunctor>
@@ -630,6 +627,13 @@ template void LabelHash::consume_fasta_and_tag_with_labels<read_parsers::FastxRe
     unsigned long long &n_consumed,
     CallbackFn callback,
     void * callback_data
+);
+template void LabelHash::consume_partitioned_fasta_and_tag_with_labels<read_parsers::FastxReader>(
+    const std::string &filename,
+    unsigned int &total_reads,
+    unsigned long long &n_consumed,
+    CallbackFn callback = NULL,
+    void * callback_datac = NULL
 );
 
 } // namespace khmer

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -50,9 +50,14 @@ Contact: khmer-project@idyll.org
 
 namespace khmer
 {
-class Hashgraph;
+    class Hashgraph;
 
-using read_parsers::IParser;
+    using read_parsers::ReadParser;
+    namespace read_parsers
+    {
+        template<typename ParseFunctor> class ReadParser;
+        class FastxReader;
+    }
 
 class LabelHash
 {
@@ -137,7 +142,7 @@ public:
         return all_labels.size();
     }
 
-
+    template<typename ParseFunctor>
     void consume_fasta_and_tag_with_labels(
         std::string const	  &filename,
         unsigned int	  &total_reads,
@@ -145,13 +150,15 @@ public:
         CallbackFn	  callback	  = NULL,
         void *		  callback_data	  = NULL);
 
+    template<typename ParseFunctor>
     void consume_fasta_and_tag_with_labels(
-        read_parsers:: IParser *	    parser,
+        read_parsers::ReadParser<ParseFunctor> * parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed,
         CallbackFn	    callback	    = NULL,
         void *		    callback_data   = NULL);
 
+    template<typename ParseFunctor>
     void consume_partitioned_fasta_and_tag_with_labels(const std::string &filename,
             unsigned int &total_reads,
             unsigned long long &n_consumed,
@@ -186,7 +193,8 @@ public:
                                         SeenSet& high_degree_nodes,
                                         const Label label);
 };
-}
+
+} // namespace khmer
 
 #define ACQUIRE_TAG_COLORS_SPIN_LOCK \
   while(!__sync_bool_compare_and_swap( &_tag_labels_spin_lock, 0, 1));

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -159,11 +159,12 @@ public:
         void *		    callback_data   = NULL);
 
     template<typename ParseFunctor>
-    void consume_partitioned_fasta_and_tag_with_labels(const std::string &filename,
-            unsigned int &total_reads,
-            unsigned long long &n_consumed,
-            CallbackFn callback = NULL,
-            void * callback_datac = NULL);
+    void consume_partitioned_fasta_and_tag_with_labels(
+        const std::string &filename,
+        unsigned int &total_reads,
+        unsigned long long &n_consumed,
+        CallbackFn callback = NULL,
+        void * callback_datac = NULL);
 
     void consume_sequence_and_tag_with_labels(const std::string& seq,
             unsigned long long& n_consumed,

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -152,7 +152,7 @@ public:
 
     template<typename ParseFunctor>
     void consume_fasta_and_tag_with_labels(
-        read_parsers::ReadParser<ParseFunctor> * parser,
+        read_parsers::ReadParserPtr<ParseFunctor>& parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed,
         CallbackFn	    callback	    = NULL,

--- a/lib/labelhash.hh
+++ b/lib/labelhash.hh
@@ -55,7 +55,7 @@ namespace khmer
     using read_parsers::ReadParser;
     namespace read_parsers
     {
-        template<typename ParseFunctor> class ReadParser;
+        template<typename SeqIO> class ReadParser;
         class FastxReader;
     }
 
@@ -142,7 +142,7 @@ public:
         return all_labels.size();
     }
 
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta_and_tag_with_labels(
         std::string const	  &filename,
         unsigned int	  &total_reads,
@@ -150,15 +150,15 @@ public:
         CallbackFn	  callback	  = NULL,
         void *		  callback_data	  = NULL);
 
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_fasta_and_tag_with_labels(
-        read_parsers::ReadParserPtr<ParseFunctor>& parser,
+        read_parsers::ReadParserPtr<SeqIO>& parser,
         unsigned int	    &total_reads,
         unsigned long long  &n_consumed,
         CallbackFn	    callback	    = NULL,
         void *		    callback_data   = NULL);
 
-    template<typename ParseFunctor>
+    template<typename SeqIO>
     void consume_partitioned_fasta_and_tag_with_labels(
         const std::string &filename,
         unsigned int &total_reads,

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -244,6 +244,15 @@ FastxReader::FastxReader(std::string& infile)
     _init();
 }
 
+FastxReader::FastxReader(FastxReader& other)
+        : _filename(other._filename),
+          _spin_lock(other._spin_lock),
+          _num_reads(other._num_reads),
+          _have_qualities(other._have_qualities)
+{
+    _stream = std::move(other._stream);
+}
+
 FastxReader::~FastxReader()
 {
     seqan::close(_stream);

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -316,13 +316,12 @@ Read FastxReader::get_next_read()
 template<typename ParseFunctor>
 ReadParserPtr<ParseFunctor> get_parser(std::string& filename)
 {
-    return ReadParserPtr(
+    return ReadParserPtr<ParseFunctor>(
         new ReadParser<ParseFunctor>(
             std::unique_ptr<ParseFunctor>(new ParseFunctor(filename))
         )
     );
 }
-auto get_fastx_parser = get_parser<FastxReader>;
 
 // All template instantiations used in the codebase must be declared here.
 template class ReadParser<FastxReader>;

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -45,8 +45,8 @@ namespace khmer
 namespace read_parsers
 {
 
-template<typename ParseFunctor>
-void ReadParser<ParseFunctor>::_init()
+template<typename SeqIO>
+void ReadParser<SeqIO>::_init()
 {
     int regex_rc =
         regcomp(
@@ -76,8 +76,8 @@ void ReadParser<ParseFunctor>::_init()
     }
 }
 
-template<typename ParseFunctor>
-ReadPair ReadParser<ParseFunctor>::_get_next_read_pair_in_ignore_mode()
+template<typename SeqIO>
+ReadPair ReadParser<SeqIO>::_get_next_read_pair_in_ignore_mode()
 {
     ReadPair pair;
     regmatch_t match_1, match_2;
@@ -115,8 +115,8 @@ ReadPair ReadParser<ParseFunctor>::_get_next_read_pair_in_ignore_mode()
     return pair;
 } // _get_next_read_pair_in_ignore_mode
 
-template<typename ParseFunctor>
-ReadPair ReadParser<ParseFunctor>::_get_next_read_pair_in_error_mode()
+template<typename SeqIO>
+ReadPair ReadParser<SeqIO>::_get_next_read_pair_in_error_mode()
 {
     ReadPair pair;
     regmatch_t match_1, match_2;
@@ -147,8 +147,8 @@ ReadPair ReadParser<ParseFunctor>::_get_next_read_pair_in_error_mode()
     return pair;
 } // _get_next_read_pair_in_error_mode
 
-template<typename ParseFunctor>
-bool ReadParser<ParseFunctor>::_is_valid_read_pair(
+template<typename SeqIO>
+bool ReadParser<SeqIO>::_is_valid_read_pair(
     ReadPair &the_read_pair, regmatch_t &match_1, regmatch_t &match_2
 )
 {
@@ -158,41 +158,41 @@ bool ReadParser<ParseFunctor>::_is_valid_read_pair(
                     ==	the_read_pair.second.name.substr( 0, match_1.rm_so ));
 }
 
-template<typename ParseFunctor>
-ReadParser<ParseFunctor>::ReadParser(std::unique_ptr<ParseFunctor> pf)
+template<typename SeqIO>
+ReadParser<SeqIO>::ReadParser(std::unique_ptr<SeqIO> pf)
 {
     _parser = std::move(pf);
     _init();
 }
 
-template<typename ParseFunctor>
-ReadParser<ParseFunctor>::ReadParser(ReadParser& other)
+template<typename SeqIO>
+ReadParser<SeqIO>::ReadParser(ReadParser& other)
 {
     _parser = std::move(other._parser);
     _init();
 }
 
-template<typename ParseFunctor>
-ReadParser<ParseFunctor>::~ReadParser()
+template<typename SeqIO>
+ReadParser<SeqIO>::~ReadParser()
 {
     regfree(&_re_read_2_nosub);
     regfree(&_re_read_1);
     regfree(&_re_read_2);
 }
 
-template<typename ParseFunctor>
-Read ReadParser<ParseFunctor>::get_next_read()
+template<typename SeqIO>
+Read ReadParser<SeqIO>::get_next_read()
 {
     return _parser->get_next_read();
 }
 
-template<typename ParseFunctor>
-ReadPair ReadParser<ParseFunctor>::get_next_read_pair(uint8_t mode)
+template<typename SeqIO>
+ReadPair ReadParser<SeqIO>::get_next_read_pair(uint8_t mode)
 {
-    if (mode == ReadParser<ParseFunctor>::PAIR_MODE_IGNORE_UNPAIRED) {
+    if (mode == ReadParser<SeqIO>::PAIR_MODE_IGNORE_UNPAIRED) {
         return _get_next_read_pair_in_ignore_mode();
     }
-    else if (mode == ReadParser<ParseFunctor>::PAIR_MODE_ERROR_ON_UNPAIRED) {
+    else if (mode == ReadParser<SeqIO>::PAIR_MODE_ERROR_ON_UNPAIRED) {
         return _get_next_read_pair_in_error_mode();
     }
     else {
@@ -202,14 +202,14 @@ ReadPair ReadParser<ParseFunctor>::get_next_read_pair(uint8_t mode)
     }
 }
 
-template<typename ParseFunctor>
-size_t ReadParser<ParseFunctor>::get_num_reads()
+template<typename SeqIO>
+size_t ReadParser<SeqIO>::get_num_reads()
 {
     return _parser->get_num_reads();
 }
 
-template<typename ParseFunctor>
-bool ReadParser<ParseFunctor>::is_complete()
+template<typename SeqIO>
+bool ReadParser<SeqIO>::is_complete()
 {
     return _parser->is_complete();
 }
@@ -313,12 +313,12 @@ Read FastxReader::get_next_read()
     return read;
 }
 
-template<typename ParseFunctor>
-ReadParserPtr<ParseFunctor> get_parser(std::string& filename)
+template<typename SeqIO>
+ReadParserPtr<SeqIO> get_parser(std::string& filename)
 {
-    return ReadParserPtr<ParseFunctor>(
-        new ReadParser<ParseFunctor>(
-            std::unique_ptr<ParseFunctor>(new ParseFunctor(filename))
+    return ReadParserPtr<SeqIO>(
+        new ReadParser<SeqIO>(
+            std::unique_ptr<SeqIO>(new SeqIO(filename))
         )
     );
 }

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -309,7 +309,12 @@ void FastxReader::operator()(Read& read)
     if (ret != 0) {
         throw StreamReadError();
     }
-    read;
+}
+
+ReadParser<FastxReader> * get_fastx_parser(std::string& filename)
+{
+    FastxReader reader(filename);
+    return new ReadParser<FastxReader>(reader);
 }
 
 // All template instantiations used in the codebase must be declared here.

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -253,7 +253,7 @@ FastxReader::FastxReader()
     _init();
 }
 
-FastxReader::FastxReader(std::string& infile)
+FastxReader::FastxReader(const std::string& infile)
         : _filename(infile),
           _spin_lock(0),
           _num_reads(0),
@@ -332,7 +332,7 @@ Read FastxReader::get_next_read()
 }
 
 template<typename SeqIO>
-ReadParserPtr<SeqIO> get_parser(std::string& filename)
+ReadParserPtr<SeqIO> get_parser(const std::string& filename)
 {
     return ReadParserPtr<SeqIO>(
         new ReadParser<SeqIO>(
@@ -343,7 +343,7 @@ ReadParserPtr<SeqIO> get_parser(std::string& filename)
 
 // All template instantiations used in the codebase must be declared here.
 template class ReadParser<FastxReader>;
-template FastxParserPtr get_parser<FastxReader>(std::string& filename);
+template FastxParserPtr get_parser<FastxReader>(const std::string& filename);
 
 } // namespace read_parsers
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -49,6 +49,7 @@ Contact: khmer-project@idyll.org
 #include <iostream>
 #include <string>
 #include <utility>
+#include <memory>
 
 #include "khmer.hh"
 #include "khmer_exception.hh"
@@ -125,7 +126,7 @@ template<typename ParseFunctor>
 class ReadParser
 {
 protected:
-    ParseFunctor _parser;
+    std::unique_ptr<ParseFunctor> _parser;
     regex_t _re_read_2_nosub;
     regex_t _re_read_1;
     regex_t _re_read_2;
@@ -145,7 +146,7 @@ public:
         PAIR_MODE_ERROR_ON_UNPAIRED
     };
 
-    explicit ReadParser(ParseFunctor pf);
+    explicit ReadParser(std::unique_ptr<ParseFunctor> pf);
     explicit ReadParser(ReadParser& other);
     virtual ~ReadParser();
 
@@ -173,7 +174,7 @@ public:
     FastxReader(FastxReader& other);
     ~FastxReader();
 
-    void operator()(Read &read);
+    Read get_next_read();
     bool is_complete();
     size_t get_num_reads();
 }; // class FastxReader
@@ -202,7 +203,15 @@ inline PartitionID _parse_partition_id(std::string name)
     return p;
 }
 
-ReadParser<FastxReader> * get_fastx_parser(std::string& filename);
+// Alias for generic/templated ReadParser pointer
+template<typename T> using ReadParserPtr = std::unique_ptr<ReadParser<T>>;
+
+// Convenience function
+template<typename ParseFunctor>
+ReadParserPtr<ParseFunctor> get_parser(std::string& filename);
+
+// Alias for instantiated ReadParsers
+typedef std::unique_ptr<ReadParser<FastxReader>> FastxParserPtr;
 
 } // namespace read_parsers
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -202,6 +202,8 @@ inline PartitionID _parse_partition_id(std::string name)
     return p;
 }
 
+ReadParser<FastxReader> * get_fastx_parser(std::string& filename);
+
 } // namespace read_parsers
 
 } // namespace khmer

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -38,6 +38,10 @@ Contact: khmer-project@idyll.org
 #ifndef READ_PARSERS_HH
 #define READ_PARSERS_HH
 
+#include <seqan/seq_io.h> // IWYU pragma: keep
+#include <seqan/sequence.h> // IWYU pragma: keep
+#include <seqan/stream.h> // IWYU pragma: keep
+
 #include <regex.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -147,10 +151,6 @@ public:
 
     Read get_next_read();
     ReadPair get_next_read_pair(uint8_t mode = PAIR_MODE_ERROR_ON_UNPAIRED);
-
-    static IParser * const get_parser(
-        std::string const &ifile_name
-    );
 
     size_t get_num_reads();
     bool is_complete();

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -122,11 +122,11 @@ struct Read
 typedef std::pair<Read, Read> ReadPair;
 
 
-template<typename ParseFunctor>
+template<typename SeqIO>
 class ReadParser
 {
 protected:
-    std::unique_ptr<ParseFunctor> _parser;
+    std::unique_ptr<SeqIO> _parser;
     regex_t _re_read_2_nosub;
     regex_t _re_read_1;
     regex_t _re_read_2;
@@ -146,7 +146,7 @@ public:
         PAIR_MODE_ERROR_ON_UNPAIRED
     };
 
-    explicit ReadParser(std::unique_ptr<ParseFunctor> pf);
+    explicit ReadParser(std::unique_ptr<SeqIO> pf);
     explicit ReadParser(ReadParser& other);
     virtual ~ReadParser();
 
@@ -207,8 +207,8 @@ inline PartitionID _parse_partition_id(std::string name)
 template<typename T> using ReadParserPtr = std::unique_ptr<ReadParser<T>>;
 
 // Convenience function
-template<typename ParseFunctor>
-ReadParserPtr<ParseFunctor> get_parser(std::string& filename);
+template<typename SeqIO>
+ReadParserPtr<SeqIO> get_parser(std::string& filename);
 
 // Alias for instantiated ReadParsers
 typedef std::unique_ptr<ReadParser<FastxReader>> FastxParserPtr;

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -83,6 +83,7 @@ struct InvalidReadPair : public  khmer_value_exception {
         khmer_value_exception("Invalid read pair detected.") {}
 };
 
+
 struct Read
 {
     std::string name;
@@ -112,8 +113,6 @@ struct Read
                    << sequence << '\n';
         }
     }
-
-    void write_to(std::ostream&);
 };
 typedef std::pair<Read, Read> ReadPair;
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -182,7 +182,7 @@ private:
 
 public:
     FastxReader();
-    FastxReader(std::string& infile);
+    FastxReader(const std::string& infile);
     FastxReader(FastxReader& other);
     ~FastxReader();
 
@@ -220,7 +220,7 @@ template<typename T> using ReadParserPtr = std::unique_ptr<ReadParser<T>>;
 
 // Convenience function
 template<typename SeqIO>
-ReadParserPtr<SeqIO> get_parser(std::string& filename);
+ReadParserPtr<SeqIO> get_parser(const std::string& filename);
 
 // Alias for instantiated ReadParsers
 typedef std::unique_ptr<ReadParser<FastxReader>> FastxParserPtr;

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -119,7 +119,7 @@ size_t SubsetPartition::output_partitioned_file(
     CallbackFn		callback,
     void *		callback_data)
 {
-    auto parser = read_parsers::get_parser<FastxReader>((std::string&)infilename);
+    auto parser = read_parsers::get_parser<FastxReader>(infilename);
     ofstream outfile(outputfile.c_str());
 
     unsigned int total_reads = 0;

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -119,8 +119,7 @@ size_t SubsetPartition::output_partitioned_file(
     CallbackFn		callback,
     void *		callback_data)
 {
-    FastxReader reader((std::string&)infilename);
-    ReadParser<FastxReader> parser(reader);
+    auto parser = read_parsers::get_parser<FastxReader>((std::string&)infilename);
     ofstream outfile(outputfile.c_str());
 
     unsigned int total_reads = 0;
@@ -141,9 +140,9 @@ size_t SubsetPartition::output_partitioned_file(
     // and output them.
     //
 
-    while(!parser.is_complete()) {
+    while(!parser->is_complete()) {
         try {
-            read = parser.get_next_read();
+            read = parser->get_next_read();
         } catch (NoMoreReadsAvailable &exc) {
             break;
         }

--- a/lib/subset.cc
+++ b/lib/subset.cc
@@ -119,7 +119,8 @@ size_t SubsetPartition::output_partitioned_file(
     CallbackFn		callback,
     void *		callback_data)
 {
-    IParser* parser = IParser::get_parser(infilename);
+    FastxReader reader((std::string&)infilename);
+    ReadParser<FastxReader> parser(reader);
     ofstream outfile(outputfile.c_str());
 
     unsigned int total_reads = 0;
@@ -140,9 +141,9 @@ size_t SubsetPartition::output_partitioned_file(
     // and output them.
     //
 
-    while(!parser->is_complete()) {
+    while(!parser.is_complete()) {
         try {
-            read = parser->get_next_read();
+            read = parser.get_next_read();
         } catch (NoMoreReadsAvailable &exc) {
             break;
         }
@@ -199,17 +200,12 @@ size_t SubsetPartition::output_partitioned_file(
                     callback("output_partitions", callback_data,
                              total_reads, reads_kept);
                 } catch (...) {
-                    delete parser;
-                    parser = NULL;
                     outfile.close();
                     throw;
                 }
             }
         }
     }
-
-    delete parser;
-    parser = NULL;
 
     return partitions.size() + n_singletons;
 }

--- a/lib/traversal.cc
+++ b/lib/traversal.cc
@@ -79,7 +79,7 @@ NodeGatherer<direction>::NodeGatherer(const Hashgraph * ht,
 
 
 template<>
-Kmer NodeGatherer<LEFT>::get_neighbor(const Kmer& node, const char ch)
+Kmer NodeGatherer<TRAVERSAL_LEFT>::get_neighbor(const Kmer& node, const char ch)
 const
 {
     // optimized bit-foo to check for LEFT neighbors in both forward and
@@ -92,7 +92,7 @@ const
 
 
 template<>
-Kmer NodeGatherer<RIGHT>::get_neighbor(const Kmer& node,
+Kmer NodeGatherer<TRAVERSAL_RIGHT>::get_neighbor(const Kmer& node,
                                        const char ch)
 const
 {
@@ -261,7 +261,7 @@ unsigned int Traverser::degree_right(const Kmer& node) const
  ******************************************/
 
 template <>
-std::string AssemblerTraverser<RIGHT>::join_contigs(std::string& contig_a,
+std::string AssemblerTraverser<TRAVERSAL_RIGHT>::join_contigs(std::string& contig_a,
         std::string& contig_b, WordLength offset)
 const
 {
@@ -269,7 +269,7 @@ const
 }
 
 template <>
-std::string AssemblerTraverser<LEFT>::join_contigs(std::string& contig_a,
+std::string AssemblerTraverser<TRAVERSAL_LEFT>::join_contigs(std::string& contig_a,
         std::string& contig_b, WordLength offset)
 const
 {
@@ -334,14 +334,14 @@ char NonLoopingAT<direction>::next_symbol()
     return AssemblerTraverser<direction>::next_symbol();
 }
 
-template class NodeGatherer<LEFT>;
-template class NodeGatherer<RIGHT>;
-template class NodeCursor<LEFT>;
-template class NodeCursor<RIGHT>;
-template class AssemblerTraverser<RIGHT>;
-template class AssemblerTraverser<LEFT>;
-template class NonLoopingAT<RIGHT>;
-template class NonLoopingAT<LEFT>;
+template class NodeGatherer<TRAVERSAL_LEFT>;
+template class NodeGatherer<TRAVERSAL_RIGHT>;
+template class NodeCursor<TRAVERSAL_LEFT>;
+template class NodeCursor<TRAVERSAL_RIGHT>;
+template class AssemblerTraverser<TRAVERSAL_RIGHT>;
+template class AssemblerTraverser<TRAVERSAL_LEFT>;
+template class NonLoopingAT<TRAVERSAL_RIGHT>;
+template class NonLoopingAT<TRAVERSAL_LEFT>;
 
 
 } // namespace khmer

--- a/lib/traversal.hh
+++ b/lib/traversal.hh
@@ -48,11 +48,11 @@ Contact: khmer-project@idyll.org
 namespace khmer
 {
 
-#ifndef LEFT
-#define LEFT 0
+#ifndef TRAVERSAL_LEFT
+#define TRAVERSAL_LEFT 0
 #endif
-#ifndef RIGHT
-#define RIGHT 1
+#ifndef TRAVERSAL_RIGHT
+#define TRAVERSAL_RIGHT 1
 #endif
 
 class Hashgraph;
@@ -204,8 +204,8 @@ class Traverser: public KmerFactory
 protected:
 
     const Hashgraph * graph;
-    NodeGatherer<LEFT> left_gatherer;
-    NodeGatherer<RIGHT> right_gatherer;
+    NodeGatherer<TRAVERSAL_LEFT> left_gatherer;
+    NodeGatherer<TRAVERSAL_RIGHT> right_gatherer;
 
 public:
 


### PR DESCRIPTION
I originally explored this approach in #1451, but got stuck on the templating details. After giving this a rest for a few months, I revisited today and have been able to address the linker issues that plagued me before. I had hoped to avoid using pointers altogether and take a more explicit approach, but this turned out to be untenable. Instead I transitioned to the use of smart pointers with read parsers.

This PR doesn't add BAM support, but it lays the groundwork to do so!

Remaining:

- [x] Replace `typename ParseFunctor` with something else since the functor approach didn't end up working with pointers.
- [x] Figure out why `abundance_distribution` tests are failing.
- [ ] Figure out why `RIGHT` and `LEFT` had conflicts with SeqAn on this branch but not master.

-----

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
