### PR TITLE
Add coment about gcc version requirement

### DIFF
--- a/doc/dev/coding-guidelines-and-review.rst
+++ b/doc/dev/coding-guidelines-and-review.rst
@@ -46,8 +46,9 @@ C++ standards
 -------------
 
 Any feature in C++11 is fine to use. Specifically we support features found in
-GCC 4.8.2. See https://github.com/dib-lab/khmer/issues/598 for an in-depth
-discussion.
+GCC 4.8.2. Our automated tests use gcc 4.8.4 on linux. See
+https://github.com/dib-lab/khmer/issues/598 for an in-depth discussion. Please
+do not use features from C++14 or newer.
 
 Coding standards
 ----------------


### PR DESCRIPTION
Related to #1574. When looking for docs on the minimum gcc version I found that the docs already contain info. Added a sentence stating which version we use on travis.

- [x] Is it mergeable?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
