### PR TITLE
Catch error trying to delete tempdir on NFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ under semantic versioning, but will be in future versions of khmer.
 
 ## [Unreleased]
 ### Added
-- New `--keep-temp` option for `trim-low-abund.py` that does not delete the
-  temporary directory created by the script. This sidesteps NFS-related issues
-  we've seen on multiple HPC file systems.
 - New `--no-reformat` option for `interleave-reads.py` script disables default
   read name correction behavior.
 - New `HashSet` data structure for managing collections of k-mer hashes and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ under semantic versioning, but will be in future versions of khmer.
 
 ## [Unreleased]
 ### Added
+- New `--keep-temp` option for `trim-low-abund.py` that does not delete the
+  temporary directory created by the script. This sidesteps NFS-related issues
+  we've seen on multiple HPC file systems.
 - New `--no-reformat` option for `interleave-reads.py` script disables default
   read name correction behavior.
 - New `HashSet` data structure for managing collections of k-mer hashes and

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -136,6 +136,8 @@ def get_parser():
     parser.add_argument('--tempdir', '-T', type=str, default='./',
                         help="Set location of temporary directory for "
                         "second pass")
+    parser.add_argument('--keep-temp', action='store_true', help='do not '
+                        'delete temporary files or directories')
     add_output_compression_type(parser)
 
     parser.add_argument('--diginorm', default=False, action='store_true',
@@ -439,8 +441,12 @@ def main():
         if not args.output:
             trimfp.close()
 
-    log_info('removing temp directory & contents ({temp})', temp=tempdir)
-    shutil.rmtree(tempdir)
+    if args.keep_temp:
+        log_info('--keep-temp mode, not removing temp directory "{temp}"',
+                 temp=tempdir)
+    else:
+        log_info('removing temp directory & contents ({temp})', temp=tempdir)
+        shutil.rmtree(tempdir)
 
     trimmed_reads = trimmer.trimmed_reads
 

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -136,8 +136,6 @@ def get_parser():
     parser.add_argument('--tempdir', '-T', type=str, default='./',
                         help="Set location of temporary directory for "
                         "second pass")
-    parser.add_argument('--keep-temp', action='store_true', help='do not '
-                        'delete temporary files or directories')
     add_output_compression_type(parser)
 
     parser.add_argument('--diginorm', default=False, action='store_true',
@@ -441,12 +439,12 @@ def main():
         if not args.output:
             trimfp.close()
 
-    if args.keep_temp:
-        log_info('--keep-temp mode, not removing temp directory "{temp}"',
-                 temp=tempdir)
-    else:
+    try:
         log_info('removing temp directory & contents ({temp})', temp=tempdir)
         shutil.rmtree(tempdir)
+    except OSError as oe:
+        log_info('WARNING: unable to remove {temp} (probably an NFS issue); '
+                 'please remove manually', temp=tempdir)
 
     trimmed_reads = trimmer.trimmed_reads
 


### PR DESCRIPTION
Issue #1402 manifests itself consistently on various HPC systems, both in the tests and when `trim-low-abund.py` is run interactively. I've had a few successful runs now by simply commenting out the code that deletes the temp directory at the end of the script. This PR puts a little bit of lipstick on that pig, making a backwards-compatible addition to the command-line interface. This (hopefully) isn't a permanent solution, but I don't have the time or interest to research the problem more thoroughly right now.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
