### PR TITLE
Add close method to ReadParser

### DIFF
--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -284,6 +284,10 @@ static bool convert_Pytablesizes_to_vector(PyListObject * sizes_list_o,
 }
 
 
+static
+read_parsers::IParser *
+_PyObject_to_khmer_ReadParser(PyObject * py_object);
+
 /***********************************************************************/
 
 //
@@ -791,6 +795,16 @@ ReadParser_iter_read_pairs(PyObject * self, PyObject * args )
 }
 
 
+PyObject *
+ReadParser_close(PyObject * self, PyObject * args)
+{
+    read_parsers::IParser* rparser = _PyObject_to_khmer_ReadParser(self);
+    rparser->close();
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
 static PyMethodDef _ReadParser_methods [ ] = {
     {
         "iter_reads",       (PyCFunction)ReadParser_iter_reads,
@@ -799,6 +813,10 @@ static PyMethodDef _ReadParser_methods [ ] = {
     {
         "iter_read_pairs",  (PyCFunction)ReadParser_iter_read_pairs,
         METH_VARARGS,       "Iterates over paired reads as pairs."
+    },
+    {
+        "close",  (PyCFunction)ReadParser_close,
+        METH_NOARGS,       "Close associated files."
     },
     { NULL, NULL, 0, NULL } // sentinel
 };

--- a/khmer/_khmer.cc
+++ b/khmer/_khmer.cc
@@ -284,9 +284,7 @@ static bool convert_Pytablesizes_to_vector(PyListObject * sizes_list_o,
 }
 
 
-static
-read_parsers::IParser *
-_PyObject_to_khmer_ReadParser(PyObject * py_object);
+static FastxParserPtr& _PyObject_to_khmer_ReadParser(PyObject * py_object);
 
 /***********************************************************************/
 
@@ -798,7 +796,7 @@ ReadParser_iter_read_pairs(PyObject * self, PyObject * args )
 PyObject *
 ReadParser_close(PyObject * self, PyObject * args)
 {
-    read_parsers::IParser* rparser = _PyObject_to_khmer_ReadParser(self);
+    FastxParserPtr& rparser = _PyObject_to_khmer_ReadParser(self);
     rparser->close();
 
     Py_INCREF(Py_None);
@@ -884,7 +882,8 @@ void _init_ReadParser_Type_constants()
 
     // Place pair mode constants into class dictionary.
     int result;
-    PyObject *value = PyLong_FromLong(ReadParser<FastxReader>::PAIR_MODE_IGNORE_UNPAIRED);
+    PyObject *value = PyLong_FromLong(
+                          ReadParser<FastxReader>::PAIR_MODE_IGNORE_UNPAIRED);
     if (value == NULL) {
         Py_DECREF(cls_attrs_DICT);
         return;
@@ -2324,7 +2323,7 @@ CPYCHECKER_TYPE_OBJECT_FOR_TYPEDEF("khmer_KHashtable_Object")
 = {
     PyVarObject_HEAD_INIT(NULL, 0)       /* init & ob_size */
     "_khmer.KHashtable   ",              /*tp_name*/
-    sizeof(khmer_KHashtable_Object)   ,  /*tp_basicsize*/
+    sizeof(khmer_KHashtable_Object),     /*tp_basicsize*/
     0,                                   /*tp_itemsize*/
     0,                                   /*tp_dealloc*/
     0,                                   /*tp_print*/
@@ -2954,7 +2953,7 @@ labelhash_consume_fasta_and_tag_with_labels(khmer_KGraphLabels_Object * me,
     //Py_BEGIN_ALLOW_THREADS
     try {
         hb->consume_fasta_and_tag_with_labels<FastxReader>(filename, total_reads,
-                                                           n_consumed);
+                n_consumed);
     } catch (khmer_file_exception &exc) {
         exc_string = exc.what();
         file_exception = exc_string.c_str();
@@ -3784,8 +3783,9 @@ static PyObject * hllcounter_consume_fasta(khmer_KHLLCounter_Object * me,
     unsigned long long  n_consumed    = 0;
     unsigned int        total_reads   = 0;
     try {
-        me->hllcounter->consume_fasta<FastxReader>(filename, stream_records, total_reads,
-                                      n_consumed);
+        me->hllcounter->consume_fasta<FastxReader>(filename, stream_records,
+                total_reads,
+                n_consumed);
     } catch (khmer_file_exception &exc) {
         PyErr_SetString(PyExc_OSError, exc.what());
         return NULL;

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -232,6 +232,12 @@ bool ReadParser<SeqIO>::is_complete()
     return _parser->is_complete();
 }
 
+template<typename SeqIO>
+void ReadParser<SeqIO>::close()
+{
+    _parser->close();
+}
+
 void FastxReader::_init()
 {
     seqan::open(_stream, _filename.c_str());
@@ -284,6 +290,10 @@ bool FastxReader::is_complete()
 size_t FastxReader::get_num_reads()
 {
     return _num_reads;
+}
+
+void FastxParser::close() {
+    seqan::close(_stream);
 }
 
 Read FastxReader::get_next_read()

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -209,11 +209,9 @@ ReadPair ReadParser<SeqIO>::get_next_read_pair(uint8_t mode)
 {
     if (mode == ReadParser<SeqIO>::PAIR_MODE_IGNORE_UNPAIRED) {
         return _get_next_read_pair_in_ignore_mode();
-    }
-    else if (mode == ReadParser<SeqIO>::PAIR_MODE_ERROR_ON_UNPAIRED) {
+    } else if (mode == ReadParser<SeqIO>::PAIR_MODE_ERROR_ON_UNPAIRED) {
         return _get_next_read_pair_in_error_mode();
-    }
-    else {
+    } else {
         std::ostringstream oss;
         oss << "Unknown pair reading mode: " << mode;
         throw UnknownPairReadingMode(oss.str());
@@ -254,25 +252,25 @@ void FastxReader::_init()
 }
 
 FastxReader::FastxReader()
-        : _filename("-"), _spin_lock(0), _num_reads(0), _have_qualities(false)
+    : _filename("-"), _spin_lock(0), _num_reads(0), _have_qualities(false)
 {
     _init();
 }
 
 FastxReader::FastxReader(const std::string& infile)
-        : _filename(infile),
-          _spin_lock(0),
-          _num_reads(0),
-          _have_qualities(false)
+    : _filename(infile),
+      _spin_lock(0),
+      _num_reads(0),
+      _have_qualities(false)
 {
     _init();
 }
 
 FastxReader::FastxReader(FastxReader& other)
-        : _filename(other._filename),
-          _spin_lock(other._spin_lock),
-          _num_reads(other._num_reads),
-          _have_qualities(other._have_qualities)
+    : _filename(other._filename),
+      _spin_lock(other._spin_lock),
+      _num_reads(other._num_reads),
+      _have_qualities(other._have_qualities)
 {
     _stream = std::move(other._stream);
 }
@@ -292,7 +290,8 @@ size_t FastxReader::get_num_reads()
     return _num_reads;
 }
 
-void FastxParser::close() {
+void FastxReader::close()
+{
     seqan::close(_stream);
 }
 
@@ -345,10 +344,10 @@ template<typename SeqIO>
 ReadParserPtr<SeqIO> get_parser(const std::string& filename)
 {
     return ReadParserPtr<SeqIO>(
-        new ReadParser<SeqIO>(
-            std::unique_ptr<SeqIO>(new SeqIO(filename))
-        )
-    );
+               new ReadParser<SeqIO>(
+                   std::unique_ptr<SeqIO>(new SeqIO(filename))
+               )
+           );
 }
 
 // All template instantiations used in the codebase must be declared here.

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -167,6 +167,7 @@ public:
 
     size_t get_num_reads();
     bool is_complete();
+    void close();
 }; // class ReadParser
 
 
@@ -189,6 +190,7 @@ public:
     Read get_next_read();
     bool is_complete();
     size_t get_num_reads();
+    void close();
 }; // class FastxReader
 
 

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -93,8 +93,7 @@ struct InvalidReadPair : public  khmer_value_exception {
 unsigned char _to_valid_dna(const unsigned char c);
 
 
-struct Read
-{
+struct Read {
     std::string name;
     std::string description;
     std::string sequence;

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -414,7 +414,8 @@ def main():
         # so pairs will stay together if not orphaned.  This is in contrast
         # to the first loop.  Hence, force_single=True below.
 
-        paired_iter = broken_paired_reader(ReadParser(pass2filename),
+        read_parser = ReadParser(pass2filename)
+        paired_iter = broken_paired_reader(read_parser,
                                            min_length=K,
                                            force_single=True)
 
@@ -431,6 +432,8 @@ def main():
             write_record(read, trimfp)
             written_reads += 1
             written_bp += len(read)
+
+        read_parser.close()
 
         log_info('removing {pass2}', pass2=pass2filename)
         os.unlink(pass2filename)


### PR DESCRIPTION
Fixes #1603 which also solves #1602 

Needs someone with NFS access to test that this really solves the problem.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
