### PR TITLE
Fix generation of coverage for c++ code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 # for a PR. So we disable build-on-push for all branches
 # except the ones whitelisted here.
 branches:
-  only: 
+  only:
     - master
 
 matrix:
@@ -69,6 +69,7 @@ script:
 
 # generate all the diagnostic reports
 after_success:
+  - make clean
   - PYTEST_ADDOPTS=-qqq make coverage-gcovr.xml coverage.xml
   # Fix suggested by http://diff-cover.readthedocs.io/en/latest/#troubleshooting
   - git fetch origin master:refs/remotes/origin/master

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ clean: FORCE
 	rm -f diff-cover.html
 	rm -Rf build dist
 	rm -rf __pycache__/ .eggs/ khmer.egg-info/
+	-rm *.gcov
 
 debug: FORCE
 	export CFLAGS="-pg -fprofile-arcs -D_GLIBCXX_DEBUG_PEDANTIC \


### PR DESCRIPTION
Addresses https://github.com/dib-lab/khmer/pull/1511#issuecomment-279251128 where @ctb noticed that we do not generate coverage for c++ code anymore.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?

