### PR TITLE
Add missing header to build dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ clean: FORCE
 	rm -f diff-cover.html
 	rm -Rf build dist
 	rm -rf __pycache__/ .eggs/ khmer.egg-info/
-	-rm *.gcov
+	-rm -f *.gcov
 
 debug: FORCE
 	export CFLAGS="-pg -fprofile-arcs -D_GLIBCXX_DEBUG_PEDANTIC \

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,8 @@ BUILD_DEPENDS.extend(path_join("lib", bn + ".hh") for bn in [
     "hllcounter", "khmer_exception", "read_aligner", "subset", "read_parsers",
     "kmer_filters", "traversal", "assembler", "alphabets", "storage"])
 BUILD_DEPENDS.extend(path_join("khmer", bn + ".hh") for bn in [
-    "_cpy_counttable", "_cpy_hashgraph", "_cpy_nodetable"])
+    "_cpy_counttable", "_cpy_hashgraph", "_cpy_nodetable",
+    "_cpy_smallcounttable", "_cpy_smallcountgraph"])
 
 SOURCES = ["khmer/_khmer.cc"]
 SOURCES.extend(path_join("lib", bn + ".cc") for bn in [


### PR DESCRIPTION
Potentially fixes #1611 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
