### PR TITLE
Handle all the pep8 reports

### DIFF
--- a/khmer/utils.py
+++ b/khmer/utils.py
@@ -35,7 +35,7 @@
 """Helpful methods for performing common argument-checking tasks in scripts."""
 from __future__ import print_function, unicode_literals
 from khmer._oxli.parsing import (check_is_left, check_is_right, check_is_pair,
-                           UnpairedReadsError, _split_left_right)
+                                 UnpairedReadsError, _split_left_right)
 
 
 def print_error(msg):

--- a/setup.py
+++ b/setup.py
@@ -126,12 +126,14 @@ def check_for_openmp():
 
     return exit_code == 0
 
+
 def distutils_dir_name(dname):
     """Returns the name of a distutils build directory"""
     f = "{dirname}.{platform}-{version[0]}.{version[1]}"
     return f.format(dirname=dname,
                     platform=sysconfig.get_platform(),
                     version=sys.version_info)
+
 
 def build_dir():
     return path_join("build", distutils_dir_name("temp"))
@@ -193,14 +195,18 @@ for cython_ext in glob.glob(os.path.join("khmer", "_oxli", "*.pyx")):
             "sources": [cython_ext],
             "extra_compile_args": EXTRA_COMPILE_ARGS,
             "extra_link_args": EXTRA_LINK_ARGS,
-            "extra_objects": [path_join(build_dir(), splitext(p)[0]+'.o')  for p in SOURCES],
+            "extra_objects": [
+                path_join(build_dir(), splitext(p)[0]+'.o') for p in SOURCES
+            ],
             "depends": [],
             "include_dirs": ["include", "."],
             "language": "c++",
             "define_macros": [("VERSION", versioneer.get_version()), ],
         }
-    
-    ext_name = "khmer._oxli.{0}".format(splitext(os.path.basename(cython_ext))[0])
+
+    ext_name = "khmer._oxli.{0}".format(
+        splitext(os.path.basename(cython_ext))[0]
+    )
     EXTENSION_MODS.append(Extension(ext_name, ** CY_EXTENSION_MOD_DICT))
 
 SCRIPTS = []
@@ -307,23 +313,27 @@ class KhmerBuildExt(_build_ext):  # pylint: disable=R0904
                     ' configure || bash ./configure --static ) && make -f '
                     'Makefile.pic PIC']
             spawn(cmd=zcmd, dry_run=self.dry_run)
-            #self.extensions[0].extra_objects.extend(
+            # self.extensions[0].extra_objects.extend(
             for ext in self.extensions:
                 ext.extra_objects.extend(
-                path_join("third-party", "zlib", bn + ".lo") for bn in [
-                    "adler32", "compress", "crc32", "deflate", "gzclose",
-                    "gzlib", "gzread", "gzwrite", "infback", "inffast",
-                    "inflate", "inftrees", "trees", "uncompr", "zutil"])
+                    path_join("third-party", "zlib", bn + ".lo") for bn in [
+                        "adler32", "compress", "crc32", "deflate", "gzclose",
+                        "gzlib", "gzread", "gzwrite", "infback", "inffast",
+                        "inflate", "inftrees", "trees", "uncompr", "zutil"
+                    ]
+                )
         if "bz2" not in self.libraries:
             bz2cmd = ['bash', '-c', 'cd ' + BZIP2DIR + ' && make -f '
                       'Makefile-libbz2_so all']
             spawn(cmd=bz2cmd, dry_run=self.dry_run)
-            #self.extensions[0].extra_objects.extend(
+            # self.extensions[0].extra_objects.extend(
             for ext in self.extensions:
                 ext.extra_objects.extend(
-                path_join("third-party", "bzip2", bn + ".o") for bn in [
-                    "blocksort", "huffman", "crctable", "randtable",
-                    "compress", "decompress", "bzlib"])
+                    path_join("third-party", "bzip2", bn + ".o") for bn in [
+                        "blocksort", "huffman", "crctable", "randtable",
+                        "compress", "decompress", "bzlib"
+                    ]
+                )
         _build_ext.run(self)
 
 CMDCLASS.update({'build_ext': KhmerBuildExt})

--- a/tests/graph_features.py
+++ b/tests/graph_features.py
@@ -523,5 +523,3 @@ def tandem_repeat_structure(request, linear_structure):
         request.applymarker(pytest.mark.xfail)
 
     return graph, sequence, tandem_repeats
-
-

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -54,6 +54,7 @@ import screed
 from .graph_features import *
 from .graph_features import K
 
+
 def teardown():
     utils.cleanup()
 

--- a/tests/test_cython_assembly.py
+++ b/tests/test_cython_assembly.py
@@ -116,7 +116,6 @@ class TestLinearAssembler_RightBranching:
         asm = khmer.LinearAssembler(graph)
         path = asm.assemble(revcomp(contig[0:K]))
 
-
         assert len(path) == HDN.pos + K
         assert utils._equals_rc(path, contig[:len(path)])
 
@@ -187,7 +186,8 @@ class TestLinearAssembler_LeftBranching:
         assert utils._equals_rc(path, contig[HDN.pos:])
 
     def test_from_branch_to_ends_with_stopbf(self, left_tip_structure):
-        # block the tip with the stop_filter. should return a full length contig.
+        # block the tip with the stop_filter.
+        # should return a full length contig.
         graph, contig, L, HDN, R, tip = left_tip_structure
 
         stop_filter = khmer.Nodegraph(K, 1e5, 4)
@@ -201,7 +201,8 @@ class TestLinearAssembler_LeftBranching:
         assert utils._equals_rc(path, contig)
 
     def test_from_branch_to_ends_with_stopbf_revcomp(self, left_tip_structure):
-        # block the tip with the stop_filter. should return a full length contig.
+        # block the tip with the stop_filter.
+        # should return a full length contig.
         graph, contig, L, HDN, R, tip = left_tip_structure
 
         stop_filter = khmer.Nodegraph(K, 1e5, 4)
@@ -222,10 +223,8 @@ class TestLinearAssembler_LeftBranching:
         stop_filter.count(L)          # ...and block original path
         asm = khmer.LinearAssembler(graph, stop_filter=stop_filter)
 
-
         path = asm.assemble(contig[-K:])
         assert len(path) == len(contig) - HDN.pos + 1
-
 
         # should be the tip k-kmer, plus the last base of the HDN thru
         # the end of the contig
@@ -243,5 +242,3 @@ class TestLinearAssembler_LeftBranching:
 
         assert len(path) == K
         assert utils._equals_rc(path, HDN)
-
-

--- a/tests/test_cython_parsing.py
+++ b/tests/test_cython_parsing.py
@@ -25,7 +25,7 @@ def teardown():
 @pytest.fixture
 def create_fastx(tmpdir, as_str=True):
     def func(reads, fmt='fa'):
-        assert fmt in ['fa','fq']
+        assert fmt in ['fa', 'fq']
         fastx_fn = tmpdir.join('test.'+fmt)
         for record in reads:
             if fmt == 'fa':
@@ -34,8 +34,8 @@ def create_fastx(tmpdir, as_str=True):
                                mode='a')
             else:
                 fastx_fn.write('@{0}\n{1}\n+\n{2}\n'.format(record.name,
-                                                        record.sequence,
-                                                        record.quality),
+                                                            record.sequence,
+                                                            record.quality),
                                mode='a')
         return str(fastx_fn) if as_str else fastx_fn
     return func
@@ -52,10 +52,10 @@ def sequences_eq(seqs_A, seqs_B):
 
 def test_FastxParser(create_fastx):
     expected = [Sequence('seq1/1', 'A' * 5),
-              Sequence('seq1/2', 'A' * 4),
-              Sequence('seq2/1', 'A' * 5),
-              Sequence('seq3/1', 'A' * 3),
-              Sequence('seq3/2', 'A' * 5)]
+                Sequence('seq1/2', 'A' * 4),
+                Sequence('seq2/1', 'A' * 5),
+                Sequence('seq3/1', 'A' * 3),
+                Sequence('seq3/2', 'A' * 5)]
     parser = FastxParser(create_fastx(expected))
     result = list(parser)
 
@@ -65,8 +65,8 @@ def test_FastxParser(create_fastx):
 
 def test_SanitizedFastxParser_convert_Ns(create_fastx):
     '''Test that A's are converted to N's'''
-    expected= [Sequence('seq1/1', 'N' * 5),
-              Sequence('seq1/2', 'N' * 4)]
+    expected = [Sequence('seq1/1', 'N' * 5),
+                Sequence('seq1/2', 'N' * 4)]
     parser = SanitizedFastxParser(create_fastx(expected),
                                   alphabet='DNAN_SIMPLE')
     result = list(parser)
@@ -78,8 +78,8 @@ def test_SanitizedFastxParser_convert_Ns(create_fastx):
 
 
 def test_SanitizedFastxParser_no_convert_Ns(create_fastx):
-    expected= [Sequence('seq1/1', 'N' * 5),
-              Sequence('seq1/2', 'N' * 4)]
+    expected = [Sequence('seq1/1', 'N' * 5),
+                Sequence('seq1/2', 'N' * 4)]
     parser = SanitizedFastxParser(create_fastx(expected),
                                   alphabet='DNAN_SIMPLE',
                                   convert_n=False)
@@ -91,11 +91,10 @@ def test_SanitizedFastxParser_no_convert_Ns(create_fastx):
     assert result[1].sequence == 'N' * 4
 
 
-
 def test_SanitizedFastxParser_invalid(create_fastx):
     '''Test that parser detects invalid sequence'''
     expected = [Sequence('seq1/1', 'XXX'),
-              Sequence('seq1/2', 'A' * 4)]
+                Sequence('seq1/2', 'A' * 4)]
     parser = SanitizedFastxParser(create_fastx(expected))
     result = list(parser)
 
@@ -106,8 +105,8 @@ def test_SanitizedFastxParser_invalid(create_fastx):
 
 def test_SanitizedFastxParser_lowercase(create_fastx):
     reads = [Sequence('seq1/1', 'acgtn'),
-              Sequence('seq1/2', 'AcGtN'),
-              Sequence('seq1/2', 'aCgTn')]
+             Sequence('seq1/2', 'AcGtN'),
+             Sequence('seq1/2', 'aCgTn')]
 
     parser = SanitizedFastxParser(create_fastx(reads), convert_n=False)
     result = list(parser)
@@ -126,6 +125,7 @@ def test_alphabet_wrapper():
     with pytest.raises(ValueError):
         Alphabets.get('TEST')
 
+
 def gather_paired(stream, **kw):
     itr = BrokenPairedReader(stream, **kw)
 
@@ -133,23 +133,24 @@ def gather_paired(stream, **kw):
     m = 0
     num = 0
     for num, is_pair, read1, read2 in itr:
-        #print(num, is_pair, read1, read2)
-        x.append((read1.name if read1 is not None else None, \
+        # print(num, is_pair, read1, read2)
+        x.append((read1.name if read1 is not None else None,
                   read2.name if read2 is not None else None))
         m += 1
 
     return x, num, m
 
+
 class Test_BrokenPairedReader(object):
     reads = [Sequence(name='seq1/1', sequence='A' * 5),
-              Sequence(name='seq1/2', sequence='A' * 4),
-              Sequence(name='seq2/1', sequence='A' * 5),
-              Sequence(name='seq3/1', sequence='A' * 3),
-              Sequence(name='seq3/2', sequence='A' * 5)]
-    
+             Sequence(name='seq1/2', sequence='A' * 4),
+             Sequence(name='seq2/1', sequence='A' * 5),
+             Sequence(name='seq3/1', sequence='A' * 3),
+             Sequence(name='seq3/2', sequence='A' * 5)]
+
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testDefault(self, parser, create_fastx):
-        x, n, m = gather_paired(parser(create_fastx(self.reads)), 
+        x, n, m = gather_paired(parser(create_fastx(self.reads)),
                                 min_length=1)
 
         expected = [('seq1/1', 'seq1/2'),
@@ -161,7 +162,7 @@ class Test_BrokenPairedReader(object):
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testMinLength(self, parser, create_fastx):
-        x, n, m = gather_paired(parser(create_fastx(self.reads)), 
+        x, n, m = gather_paired(parser(create_fastx(self.reads)),
                                 min_length=3)
 
         expected = [('seq1/1', 'seq1/2'),
@@ -173,7 +174,7 @@ class Test_BrokenPairedReader(object):
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testMinLength_2(self, parser, create_fastx):
-        x, n, m = gather_paired(parser(create_fastx(self.reads)), 
+        x, n, m = gather_paired(parser(create_fastx(self.reads)),
                                 min_length=4)
 
         expected = [('seq1/1', 'seq1/2'),
@@ -185,7 +186,7 @@ class Test_BrokenPairedReader(object):
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testForceSingle(self, parser, create_fastx):
-        x, n, m = gather_paired(parser(create_fastx(self.reads)), 
+        x, n, m = gather_paired(parser(create_fastx(self.reads)),
                                 force_single=True)
 
         expected = [('seq1/1', None),
@@ -199,7 +200,7 @@ class Test_BrokenPairedReader(object):
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testForceSingleAndMinLength(self, parser, create_fastx):
-        x, n, m = gather_paired(parser(create_fastx(self.reads)), 
+        x, n, m = gather_paired(parser(create_fastx(self.reads)),
                                 min_length=5, force_single=True)
 
         expected = [('seq1/1', None),
@@ -212,11 +213,11 @@ class Test_BrokenPairedReader(object):
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testRequirePairedAndMinLength_HalfPass(self, parser, create_fastx):
         reads = [Sequence('seq1/1', 'A' * 5),
-                  Sequence('seq1/2', 'A' * 4),
-                  Sequence('seq3/1', 'A' * 3),
-                  Sequence('seq3/2', 'A' * 5)]
+                 Sequence('seq1/2', 'A' * 4),
+                 Sequence('seq3/1', 'A' * 3),
+                 Sequence('seq3/2', 'A' * 5)]
 
-        reader = BrokenPairedReader(parser(create_fastx(reads)), 
+        reader = BrokenPairedReader(parser(create_fastx(reads)),
                                     min_length=4, require_paired=True)
 
         result = []
@@ -230,13 +231,13 @@ class Test_BrokenPairedReader(object):
         assert r == reads[1]
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
-    def testRequirePairedAndMinLength_SwappedHalfPass(self, parser, create_fastx):
+    def testRequirePairedAndMinLen_SwapHalfPass(self, parser, create_fastx):
         reads = [Sequence('seq1/1', 'A' * 5),
-                  Sequence('seq1/2', 'A' * 4),
-                  Sequence('seq3/1', 'A' * 5),
-                  Sequence('seq3/2', 'A' * 3)]
+                 Sequence('seq1/2', 'A' * 4),
+                 Sequence('seq3/1', 'A' * 5),
+                 Sequence('seq3/2', 'A' * 3)]
 
-        reader = BrokenPairedReader(parser(create_fastx(reads)), 
+        reader = BrokenPairedReader(parser(create_fastx(reads)),
                                     min_length=4, require_paired=True)
 
         result = []
@@ -252,11 +253,11 @@ class Test_BrokenPairedReader(object):
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
     def testRequirePairedAndMinLength_NeitherPass(self, parser, create_fastx):
         reads = [Sequence('seq1/1', 'A' * 5),
-                  Sequence('seq1/2', 'A' * 4),
-                  Sequence('seq3/1', 'A' * 3),
-                  Sequence('seq3/2', 'A' * 3)]
+                 Sequence('seq1/2', 'A' * 4),
+                 Sequence('seq3/1', 'A' * 3),
+                 Sequence('seq3/2', 'A' * 3)]
 
-        reader = BrokenPairedReader(parser(create_fastx(reads)), 
+        reader = BrokenPairedReader(parser(create_fastx(reads)),
                                     min_length=4, require_paired=True)
 
         result = []
@@ -270,13 +271,13 @@ class Test_BrokenPairedReader(object):
         assert r == reads[1]
 
     @pytest.mark.parametrize("parser", [FastxParser, SanitizedFastxParser])
-    def testRequirePairedAndMinLength_SwappedNeitherPass(self, parser, create_fastx):
+    def testRequirePairedAndMinLen_SwapNeitherPass(self, parser, create_fastx):
         reads = [Sequence('seq1/1', 'A' * 3),
-                  Sequence('seq1/2', 'A' * 3),
-                  Sequence('seq3/1', 'A' * 5),
-                  Sequence('seq3/2', 'A' * 5)]
+                 Sequence('seq1/2', 'A' * 3),
+                 Sequence('seq3/1', 'A' * 5),
+                 Sequence('seq3/2', 'A' * 5)]
 
-        reader = BrokenPairedReader(parser(create_fastx(reads)), 
+        reader = BrokenPairedReader(parser(create_fastx(reads)),
                                     min_length=4, require_paired=True)
 
         result = []
@@ -396,6 +397,3 @@ def test_check_is_left():
 
     assert check_is_left(
         '@HWI-ST412:261:d15khacxx:8:1101:3149:2157 1:N:0:ATCACG')
-
-
-

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -280,4 +280,3 @@ def test_check_file_status_kfile_force():
         sys.stderr = old_stderr
 
     assert "does not exist" in capture.getvalue(), capture.getvalue()
-


### PR DESCRIPTION
This PR eliminates all the pep8 reports in #1595. At first the `make pep8` target was reporting a bunch of errors for files we're not explicitly checking, but this mysteriously went away after I handled all of the files we *do* check.

Ready for review @camillescott.