### PR TITLE
Switch coverage computation to linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       dist: trusty
       env:
         - TESTATTR="'not huge and not known_failing'"
+        - COVERAGE="false"
       addons:
         apt:
           packages:
@@ -39,6 +40,7 @@ matrix:
       dist: trusty
       env:
         - TESTATTR="'not huge and not known_failing'"
+        - COVERAGE="true"
       addons:
         apt:
           packages:
@@ -51,6 +53,7 @@ matrix:
       osx_image: xcode7.3
       env:
         - TESTATTR="'not linux and not known_failing and not huge'"
+        - COVERAGE="false"
       before_install:
         - source ci_scripts/install.sh
 
@@ -80,9 +83,7 @@ after_success:
   - make pydocstyle
   # do the docs build?
   - make doc
-  # XXX Do not upload results from travis yet. Currently jenkins is considered
-  # XXX the source of truth about coverage
-  # only upload one coverage report to codecov as it merges all reports
-  # from all builds into one.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install codecov; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi
+  # only upload a coverage report from one travis run to codecov as
+  # it merges all reports from all builds into one.
+  - if [[ "$COVERAGE" == "true" ]]; then pip install codecov; fi
+  - if [[ "$COVERAGE" == "true" ]]; then codecov -X pycov search gcov -f coverage.xml coverage-gcovr.xml; fi


### PR DESCRIPTION
Let's see what happens if we compute coverage on linux instead of OSX. Related to #1528.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
