### PR TITLE
Update release checklist

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,9 @@
+Shannon EK Joslin <sejoslin@ucdavis.edu>
+Ali <aaliyari@ucdavis.edu>
+Russell <russell@vort.org>
+Ryan Shean <ryanshean1@gmail.com>
+Nicole Kingsley <nbkingsley@ucdavis.edu>
+Lisa Cohen <ljcohen@ucdavis.edu>
 Michael R. Crusoe <mcrusoe@msu.edu>
 Michael R. Crusoe <mcrusoe@msu.edu> <michael.crusoe@gmail.com>
 Michael R. Crusoe <mcrusoe@msu.edu> <mcruseo@msu.edu>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include ChangeLog ez_setup.py IDEAS Makefile README.rst setup.cfg
+include ChangeLog ez_setup.py IDEAS Makefile README.md setup.cfg
 include versioneer.py MANIFEST.in CITATION CONTRIBUTING.md Doxyfile.in
 include LICENSE TODO .ycm_extra_conf.py
 recursive-include lib *.hh *.cc [Mm]akefile* get_version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include ChangeLog ez_setup.py IDEAS Makefile README.md setup.cfg
 include versioneer.py MANIFEST.in CITATION CONTRIBUTING.md Doxyfile.in
 include LICENSE TODO .ycm_extra_conf.py
 recursive-include lib *.hh *.cc [Mm]akefile* get_version.py
+recursive-include khmer *.hh
 recursive-include third-party *.cc *.1 *.xsl README* sample* words* *.sh *.c
 recursive-include third-party manual* [Mm]akefile* *.pl *.dsp CHANGES *.txt *.h
 recursive-include third-party ChangeLog FAQ INDEX configure *.xsl

--- a/doc/dev/release.rst
+++ b/doc/dev/release.rst
@@ -74,17 +74,19 @@ release makers, following this checklist by MRC.
         git log --minimal --patch `git describe --tags --always --abbrev=0`..HEAD
 
 #. Review the issue list for any new bugs that will not be fixed in this
-   release. Add them to ``doc/known-issues.txt``
+   release. Add them to ``doc/user/known-issues.rst``
 
-#. Check for new authors. Update ``.mailmap`` to normalize their email address
+#. Check for new authors (``git log --format='%aN' v2.0... | sort -u`` lists all
+   committers since the v2.0 tag). Update ``.mailmap`` to normalize their email address
    and name spelling. If they want to opt out update the ``list-*`` Makefile
    targets to exclude them. Run ``make list-citation`` and adapt the output to
    the relevant parts of ``CITATION``, ``setup.py``, ``doc/index.rst``.
 
-#. Verify that the build is clean: http://ci.oxli.org/job/khmer-master/
+#. Verify that the build is clean: https://api.travis-ci.org/dib-lab/khmer.svg?branch=master
 
 #. Run through the `API examples <../user/api-examples.html>`__ to verify they
-   are still valid.
+   are still valid. You need to install khmer to do this, use for example
+   your normal development setup/virtualenv for that.
 
 #. Submit a build to Coverity Scan if it hasn't been done
    recently. You can get the token from

--- a/doc/dev/release.rst
+++ b/doc/dev/release.rst
@@ -126,9 +126,9 @@ release makers, following this checklist by MRC.
         normalize-by-median.py --version 2>&1 | grep khmer\ ${new_version}-${rc} && \
                 echo 1st manual version check passed
         pip uninstall -y khmer; pip uninstall -y khmer; make install
-        mkdir ../not-khmer # if there is a subdir named 'khmer' nosetest will execute tests
-        # there instead of the installed khmer module's tests
-        pushd ../not-khmer; nosetests khmer --attr '!known_failing'; popd
+        mkdir ../not-khmer # make sure py.test executes tests
+                           # from the installed khmer module
+        pushd ../not-khmer; pytest --pyargs khmer -m 'not known_failing'; popd
 
 
         # Secondly we test via pip
@@ -143,10 +143,10 @@ release makers, following this checklist by MRC.
         make test
         cp dist/khmer*tar.gz ../../../testenv3/
         pip uninstall -y khmer; pip uninstall -y khmer; make install
-        cd ../.. # no subdir named khmer here, safe for nosetesting installed khmer module
+        cd ../.. # no subdir named khmer here, safe for testing installed khmer module
         normalize-by-median.py --version 2>&1 | grep khmer\ ${new_version}-${rc} && \
                 echo 2nd manual version check passed
-        nosetests khmer --attr '!known_failing'
+        pytest --pyargs khmer -m 'not known_failing'
 
         # Is the distribution in testenv2 complete enough to build another
         # functional distribution?
@@ -155,14 +155,14 @@ release makers, following this checklist by MRC.
         source bin/activate
         pip install -U setuptools==3.4.1
         pip install khmer*tar.gz
-        pip install nose
+        pip install pytest
         tar xzf khmer*tar.gz
         cd khmer*
         make dist
         make test
         pip uninstall -y khmer; pip uninstall -y khmer; make install
         mkdir ../not-khmer
-        pushd ../not-khmer ; nosetests khmer --attr '!known_failing' ; popd
+        pushd ../not-khmer ; pytest --pyargs khmer -m 'not known_failing' ; popd
 
 #. Publish the new release on the testing PyPI server.  You will need
    to change your PyPI credentials as documented here:
@@ -179,15 +179,15 @@ release makers, following this checklist by MRC.
         cd ../../testenv4
         source bin/activate
         pip install -U setuptools==3.4.1
-        pip install screed nose
+        pip install screed pytest
         pip install -i https://testpypi.python.org/pypi --pre --no-clean khmer
-        nosetests khmer --attr '!known_failing'
+        pytest --pyargs khmer -m 'not known_failing'
         normalize-by-median.py --version 2>&1 | grep khmer\ ${new_version}-${rc} && \
                 echo 3rd manual version check passed
         cd build/khmer
         make test
 
-#. Do any final testing (BaTLab and/or acceptance tests).
+#. Do any final acceptance tests.
 
 #. Make sure any release notes are merged into doc/release-notes/.
 

--- a/doc/dev/release.rst
+++ b/doc/dev/release.rst
@@ -97,20 +97,6 @@ release makers, following this checklist by MRC.
    are still valid. You need to install khmer to do this, use for example
    your normal development setup/virtualenv for that.
 
-#. Submit a build to Coverity Scan if it hasn't been done
-   recently. You can get the token from
-   https://gitlab.msu.edu/ged-lab/ged-internal-docs/wikis/coverity-scan
-   or https://scan.coverity.com/projects/621?tab=project_settings
-
-   ::
-
-        virtualenv coverityenv
-        source coverityenv/bin/activate
-        make install-dependencies
-        make clean
-        cov_analysis_dir=~/src/coverity/cov-analysis-linux64-7.5.0/ make coverity-build
-        COVERITY_TOKEN=${COVERITY_TOKEN} make coverity-upload
-
 #. Set your new version number and release candidate::
 
         new_version=1.3

--- a/doc/dev/release.rst
+++ b/doc/dev/release.rst
@@ -49,6 +49,15 @@ How to make a khmer release candidate
 Michael R. Crusoe, Luiz Irber, and C. Titus Brown have all been
 release makers, following this checklist by MRC.
 
+#. Announce a few days ahead of time that you will cut a release. This will
+   slow down the rate at which PRs are being merged. When all outstanding PRs
+   scheduled for this release have been merged, announce it. From now on no
+   more merges to master. PRs to fix oversights or bugs follow the usual rule
+   of "author can't merge". When you reach the end of this checklist announce
+   it. Back to normal. If completing this checklist takes longer than a few
+   hours consider allowing merges to master, and starting from the top with
+   cutting a release.
+
 #. The below should be done in a clean checkout::
 
         cd `mktemp -d`

--- a/sort-authors-list.py
+++ b/sort-authors-list.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # This file is part of khmer, https://github.com/dib-lab/khmer/, and is
 # Copyright (C) 2015, The Regents of the University of California.
 #

--- a/sort-authors-list.py
+++ b/sort-authors-list.py
@@ -32,16 +32,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Contact: khmer-project@idyll.org
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from nameparser import HumanName
 import codecs
 import textwrap
 
-import sys
-import codecs
-sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 authors = []
 
@@ -56,17 +51,17 @@ authors.append((HumanName("C. Titus Brown"), "titus@idyll.org"))
 
 # print(authors)
 
-bibtex = u'   author = \"'
+bibtex = '   author = \"'
 
 for tup in authors:
     name = tup[0]
     name.string_format = "{last}, {first} {middle} and"
-    bibtex += unicode(name) + " "
+    bibtex += str(name) + " "
 
 bibtex = bibtex[:-5] + '"'  # remove last 'and' and close the quote
 
-print(u'  @article{khmer2015,')
-for line in textwrap.wrap(unicode(bibtex), 77):
+print('  @article{khmer2015,')
+for line in textwrap.wrap(str(bibtex), 77):
     print('  ' + line)
 
 print(
@@ -83,10 +78,9 @@ doclist = u':Authors: '
 for tup in authors:
     name = tup[0]
     name.string_format = "{first} {middle} {last}"
-    doclist += unicode(name) + ", "
+    doclist += str(name) + ", "
 
 doclist = doclist[:-2]
 
-for line in textwrap.wrap(unicode(doclist), 71):
+for line in textwrap.wrap(str(doclist), 71):
     print('        ' + line)
-


### PR DESCRIPTION
Updated the sort-authors script to use python3 and went
through the beginning of the checklist.

Fixes #1403 #1646 #372

- [x] incorporate #1646 (pytest on installed code)
- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
