### PR TITLE
[MRG] Add function to calculate Nodegraph size matched to a Countgraph

### DIFF
--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -569,6 +569,27 @@ def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
         return khmer.Countgraph(ksize, tablesize, args.n_tables)
 
 
+def create_matching_nodegraph(args, multiplier=1.0):
+    """Create a Nodegraph matched in size to a Countgraph
+
+    Use this to create Nodegraphs for kmer tracking and similar. The
+    created Nodegraph will have a similar number of buckets in its
+    tables as your Countgraph.
+    """
+    tablesize = 0
+    # the use of 'countgraph' and 'smallcountgraph' is on PURPOSE
+    # as we want to find out how big the corresponding countgraphs
+    # would be so we can make a matching Nodegraph
+    if args.small_count:
+        tablesize = calculate_graphsize(args, 'smallcountgraph',
+                                        multiplier=multiplier)
+    else:
+        tablesize = calculate_graphsize(args, 'countgraph',
+                                        multiplier=multiplier)
+    print('NG tablesize:', tablesize)
+    return khmer.Nodegraph(args.ksize, tablesize, args.n_tables)
+
+
 def report_on_config(args, graphtype='countgraph'):
     """Print out configuration.
 

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -510,8 +510,8 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
         max_memory = args.max_memory_usage
         if max_memory > 1e8:
             max_memory -= 3e7
-        tablesize = (khmer._buckets_per_byte[graphtype] *
-                     max_memory / args.n_tables / float(multiplier))
+        tablesize = float(multiplier) * (khmer._buckets_per_byte[graphtype] *
+                                         max_memory / args.n_tables)
     else:
         tablesize = args.max_tablesize
 

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -504,8 +504,10 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
         raise ValueError('unknown graph type: ' + graphtype)
 
     if args.max_memory_usage:
-        tablesize = float(multiplier) * (khmer._buckets_per_byte[graphtype] *
-                                         args.max_memory_usage / args.n_tables)
+        # subtract about 30MB for the python interpreter
+        max_memory = args.max_memory_usage - 3e7
+        tablesize = (khmer._buckets_per_byte[graphtype] *
+                     max_memory / args.n_tables / float(multiplier))
     else:
         tablesize = args.max_tablesize
 

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -504,8 +504,8 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
         raise ValueError('unknown graph type: ' + graphtype)
 
     if args.max_memory_usage:
-        tablesize = (khmer._buckets_per_byte[graphtype] *
-                     args.max_memory_usage / args.n_tables / float(multiplier))
+        tablesize = float(multiplier) * (khmer._buckets_per_byte[graphtype] *
+                                         args.max_memory_usage / args.n_tables)
     else:
         tablesize = args.max_tablesize
 
@@ -569,25 +569,15 @@ def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
         return khmer.Countgraph(ksize, tablesize, args.n_tables)
 
 
-def create_matching_nodegraph(args, multiplier=1.0):
+def create_matching_nodegraph(countgraph):
     """Create a Nodegraph matched in size to a Countgraph
 
     Use this to create Nodegraphs for kmer tracking and similar. The
-    created Nodegraph will have a similar number of buckets in its
-    tables as your Countgraph.
+    created Nodegraph will have the same number of buckets in its
+    tables as `countgraph`.
     """
-    tablesize = 0
-    # the use of 'countgraph' and 'smallcountgraph' is on PURPOSE
-    # as we want to find out how big the corresponding countgraphs
-    # would be so we can make a matching Nodegraph
-    if args.small_count:
-        tablesize = calculate_graphsize(args, 'smallcountgraph',
-                                        multiplier=multiplier)
-    else:
-        tablesize = calculate_graphsize(args, 'countgraph',
-                                        multiplier=multiplier)
-    print('NG tablesize:', tablesize)
-    return khmer.Nodegraph(args.ksize, tablesize, args.n_tables)
+    tablesizes = countgraph.hashsizes()
+    return khmer._Nodegraph(countgraph.ksize(), tablesizes)
 
 
 def report_on_config(args, graphtype='countgraph'):

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -504,14 +504,8 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
         raise ValueError('unknown graph type: ' + graphtype)
 
     if args.max_memory_usage:
-        # subtract about 30MB for the python interpreter if user is requesting
-        # a large amount of memory that suggests they want to limit the
-        # total amount of RAM used for purposes of not running out of memory
-        max_memory = args.max_memory_usage
-        if max_memory > 1e8:
-            max_memory -= 3e7
         tablesize = float(multiplier) * (khmer._buckets_per_byte[graphtype] *
-                                         max_memory / args.n_tables)
+                                         args.max_memory_usage / args.n_tables)
     else:
         tablesize = args.max_tablesize
 

--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -504,8 +504,12 @@ def calculate_graphsize(args, graphtype, multiplier=1.0):
         raise ValueError('unknown graph type: ' + graphtype)
 
     if args.max_memory_usage:
-        # subtract about 30MB for the python interpreter
-        max_memory = args.max_memory_usage - 3e7
+        # subtract about 30MB for the python interpreter if user is requesting
+        # a large amount of memory that suggests they want to limit the
+        # total amount of RAM used for purposes of not running out of memory
+        max_memory = args.max_memory_usage
+        if max_memory > 1e8:
+            max_memory -= 3e7
         tablesize = (khmer._buckets_per_byte[graphtype] *
                      max_memory / args.n_tables / float(multiplier))
     else:

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -130,7 +130,8 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     log_info('making countgraph')
     # In case the user specified a maximum memory use 8/9 of that
     # for the countgraph and 1/9 for the tracking nodegraph
-    countgraph = khmer_args.create_countgraph(args, multiplier=8/9.)
+    # except `multiplier` is a divisor so use 9/8
+    countgraph = khmer_args.create_countgraph(args, multiplier=9/8.)
     countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -133,7 +133,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')
-    tracking = khmer_args.create_nodegraph(args, multiplier=1.1)
+    tracking = khmer_args.create_matching_nodegraph(args, multiplier=1.1)
 
     log_info('kmer_size: {ksize}', ksize=countgraph.ksize())
     log_info('k-mer countgraph sizes: {sizes}', sizes=countgraph.hashsizes())

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -128,7 +128,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
                               'cumulative_fraction'])
 
     log_info('making countgraph')
-    # In case the user specified a maximum memory use 8/9 of that
+    # In case the user specified a maximum memory usage, use 8/9 of that
     # for the countgraph and 1/9 for the tracking nodegraph
     # except `multiplier` is a divisor so use 9/8
     countgraph = khmer_args.create_countgraph(args, multiplier=9/8.)

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -130,8 +130,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     log_info('making countgraph')
     # In case the user specified a maximum memory usage, use 8/9 of that
     # for the countgraph and 1/9 for the tracking nodegraph
-    # except `multiplier` is a divisor so use 9/8
-    countgraph = khmer_args.create_countgraph(args, multiplier=9/8.)
+    countgraph = khmer_args.create_countgraph(args, multiplier=8/9.)
     countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -55,8 +55,7 @@ from khmer.khmer_args import (build_counting_args, add_threading_args,
                               report_on_config, calculate_graphsize,
                               sanitize_help)
 from khmer.kfile import (check_input_files, check_space_for_graph)
-from khmer.khmer_logger import (configure_logging, log_info, log_error,
-                                log_warn)
+from khmer.khmer_logger import configure_logging, log_info, log_error
 
 
 def get_parser():
@@ -129,11 +128,13 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
                               'cumulative_fraction'])
 
     log_info('making countgraph')
-    countgraph = khmer_args.create_countgraph(args, multiplier=1.1)
+    # In case the user specified a maximum memory use 8/9 of that
+    # for the countgraph and 1/9 for the tracking nodegraph
+    countgraph = khmer_args.create_countgraph(args, multiplier=8/9.)
     countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')
-    tracking = khmer_args.create_matching_nodegraph(args, multiplier=1.1)
+    tracking = khmer_args.create_matching_nodegraph(countgraph)
 
     log_info('kmer_size: {ksize}', ksize=countgraph.ksize())
     log_info('k-mer countgraph sizes: {sizes}', sizes=countgraph.hashsizes())

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -128,9 +128,10 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
                               'cumulative_fraction'])
 
     log_info('making countgraph')
-    # In case the user specified a maximum memory usage, use 8/9 of that
-    # for the countgraph and 1/9 for the tracking nodegraph
-    countgraph = khmer_args.create_countgraph(args, multiplier=8/9.)
+    # In case the user specified a maximum memory usage, use 8/(9+eps) of that
+    # for the countgraph and 1/(9+eps) for the tracking nodegraph
+    # `eps` is used to account for the memory used by the python interpreter
+    countgraph = khmer_args.create_countgraph(args, multiplier=8/(9. + 0.3))
     countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -40,6 +40,7 @@ from __future__ import absolute_import
 import khmer
 from khmer import ReadParser
 from khmer import reverse_complement as revcomp
+from khmer.khmer_args import create_matching_nodegraph
 
 import screed
 
@@ -1103,3 +1104,17 @@ def test_assemble_linear_path_bad_seed():
 
     path = nodegraph.assemble_linear_path('GATTACA' * 3)
     assert path == ''
+
+
+@pytest.mark.parametrize('ntables,targetsize', [
+    (4, 1e5),
+    (6, 1e5),
+    (8, 1e5),
+    (5, 1e6),
+    (7, 1e6),
+    (9, 1e6),
+])
+def test_create_matching_nodegraph(ntables, targetsize):
+    cg = khmer.Countgraph(31, targetsize, ntables)
+    ng = create_matching_nodegraph(cg)
+    assert cg.hashsizes() == ng.hashsizes()

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -110,10 +110,8 @@ def test_check_tablespace(graph_type, buckets_per_byte):
 
 @pytest.mark.parametrize('graph_type,exp_buckets', [
     ('countgraph', '3.0 million buckets'),
-    # these slightly weird values come because we subtract some space
-    # for the python interpreter
-    ('smallcountgraph', '5.9 million buckets'),
-    ('nodegraph', '23.8 million buckets'),
+    ('smallcountgraph', '6.0 million buckets'),
+    ('nodegraph', '24.0 million buckets'),
 ])
 def test_check_tablespace_nodegraph(graph_type, exp_buckets):
     parser = khmer_args.build_counting_args()

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -110,8 +110,10 @@ def test_check_tablespace(graph_type, buckets_per_byte):
 
 @pytest.mark.parametrize('graph_type,exp_buckets', [
     ('countgraph', '3.0 million buckets'),
-    ('smallcountgraph', '6.0 million buckets'),
-    ('nodegraph', '24.0 million buckets'),
+    # these slightly weird values come because we subtract some space
+    # for the python interpreter
+    ('smallcountgraph', '5.9 million buckets'),
+    ('nodegraph', '23.8 million buckets'),
 ])
 def test_check_tablespace_nodegraph(graph_type, exp_buckets):
     parser = khmer_args.build_counting_args()

--- a/tests/test_script_arguments.py
+++ b/tests/test_script_arguments.py
@@ -331,7 +331,7 @@ def test_create_countgraph_4_multiplier():
                               False, 0)
 
     countgraph = khmer_args.create_countgraph(args, multiplier=2.0)
-    assert sum(countgraph.hashsizes()) < max_mem / 2.0, \
+    assert sum(countgraph.hashsizes()) < max_mem * 2.0, \
         sum(countgraph.hashsizes())
 
 
@@ -441,7 +441,7 @@ def test_create_nodegraph_4_multiplier():
                               False, 0)
 
     nodegraph = khmer_args.create_nodegraph(args, multiplier=2.0)
-    assert sum(nodegraph.hashsizes()) / 8.0 < max_mem / 2.0, \
+    assert sum(nodegraph.hashsizes()) / 8.0 < max_mem * 2.0, \
         sum(nodegraph.hashsizes())
 
 


### PR DESCRIPTION
Fixes #1408 

Sometimes you want a Nodegraph with roughly the same number of
buckets as a Countgraph you are using.

Is having the number of buckets in the `Nodegraph` match those of the `Countgraph` actually what people want?

Still needs a bit of fine tuning/understanding how/why the sizes differ slightly in the two cases (`-x` vs `-M`).

There is also the option that we interpret `-M` as the absolute upper total memory used by everything in this script. In which case we need to be a bit smarter when calculating table sizes as they have to take into account what comes later in the script. Essentially making it specific for each script :-/

- [x] Implement this for all scripts that use more than one Countgraph/table
- [x] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
