### PR TITLE
write test for consume_partitioned_fasta on unpartitioned file

### DIFF
--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -208,9 +208,11 @@ inline PartitionID _parse_partition_id(std::string name)
     if (*s == '\t') {
         p = (PartitionID) atoi(s + 1);
     } else {
-        std::cerr << "consume_partitioned_fasta barfed on read "
-                  << name << "\n";
-        throw khmer_exception();
+        std::string err;
+        err = "consume_partitioned_fasta cannot find partition ID for read";
+        err += name;
+
+        throw khmer_value_exception(err);
     }
 
     return p;

--- a/lib/read_parsers.hh
+++ b/lib/read_parsers.hh
@@ -209,7 +209,7 @@ inline PartitionID _parse_partition_id(std::string name)
         p = (PartitionID) atoi(s + 1);
     } else {
         std::string err;
-        err = "consume_partitioned_fasta cannot find partition ID for read";
+        err = "consume_partitioned_fasta cannot find partition ID for read ";
         err += name;
 
         throw khmer_value_exception(err);

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -337,6 +337,14 @@ def test_load_partitioned():
     assert nodegraph.get(third_s)
 
 
+def test_consume_partitioned_fail():
+    inpfile = utils.get_test_data('test-reads.fa')
+    nodegraph = khmer._Nodegraph(32, [1])
+
+    with pytest.raises(ValueError):
+        nodegraph.consume_partitioned_fasta(inpfile)
+
+
 def test_count_within_radius_simple():
     inpfile = utils.get_test_data('all-A.fa')
     nodegraph = khmer._Nodegraph(4, [3, 5])


### PR DESCRIPTION
`consume_partitioned_fasta` raises `khmer_exception` and not `khmer_value_exception` when consuming an unpartitioned file. `khmer_exception` is, however, unhandled at the Python layer. This fixes the exception.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
