### PR TITLE
[MRG] Add tests for corrupted FASTA file content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ script:
 
 # generate all the diagnostic reports
 after_success:
+  - cd $TRAVIS_BUILD_DIR && echo $TRAVIS_BUILD_DIR
   - make clean
   - PYTEST_ADDOPTS=-qqq make coverage-gcovr.xml coverage.xml
   # Fix suggested by http://diff-cover.readthedocs.io/en/latest/#troubleshooting

--- a/lib/read_parsers.cc
+++ b/lib/read_parsers.cc
@@ -240,8 +240,9 @@ void FastxReader::_init()
 {
     seqan::open(_stream, _filename.c_str());
     if (!seqan::isGood(_stream)) {
-        std::string message = "Could not open ";
-        message = message + _filename + " for reading.";
+        std::string message = "File ";
+        message = message + _filename + " contains badly formatted sequence";
+        message = message + " or does not exist.";
         throw InvalidStream(message);
     } else if (seqan::atEnd(_stream)) {
         std::string message = "File ";

--- a/tests/test_read_parsers.py
+++ b/tests/test_read_parsers.py
@@ -483,5 +483,25 @@ def test_clean_seq():
         clean = read.sequence.upper().replace("N", "A")
         assert clean == read.cleaned_seq
 
+
+def test_error_badly_formatted_file():
+    fname = utils.get_temp_filename('badly-formatted.fa')
+    with open(fname, 'w') as f:
+        f.write("not-sequence")
+
+    with pytest.raises(OSError) as e:
+        ReadParser(fname)
+
+    assert e.match("contains badly formatted sequence")
+
+
+def test_error_file_does_not_exist():
+    fname = utils.get_temp_filename('does-not-exist.fa')
+
+    with pytest.raises(OSError) as e:
+        ReadParser(fname)
+
+    assert e.match("does not exist")
+
 # vim: set filetype=python tabstop=4 softtabstop=4 shiftwidth=4 expandtab:
 # vim: set textwidth=79:


### PR DESCRIPTION
Fixes #1666 and #1119 

Update the error message to give the user a better chance of figuring out what the problem is.

Right now we can't tell the difference between a file that doesn't exist and a file that contains nonsense. Looking into detecting the difference between these two cases.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
