### PR TITLE
[MRG] Update log info for trim-low-abund

### DIFF
--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -477,7 +477,12 @@ def main():
     # for max_false_pos see Zhang et al., http://arxiv.org/abs/1309.2975
     log_info('fp rate estimated to be {fpr:1.3f}', fpr=fp_rate)
 
-    log_info('output in *.abundtrim')
+    if args.output is None:
+        log_info('output in *.abundtrim')
+    elif args.output.name == 1:
+        log_info('output streamed to stdout')
+    elif args.output.name:
+        log_info('output in {}'.format(args.output.name))
 
     if args.savegraph:
         log_info("Saving k-mer countgraph to {graph}", graph=args.savegraph)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2576,6 +2576,22 @@ def test_trim_low_abund_stdout():
     _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
 
     assert 'GGTTGACGGGGCTCAGGG' in out
+    # can't test that the correct message appears because we redirect
+    # the output when under testing. Instead check that incorrect message
+    # does not appear.
+    assert 'output in *.abundtrim' not in err
+
+
+def test_trim_low_abund_output_named():
+    # check the output filename is mentioned when it is explicitly set
+    infile = utils.copy_test_data('test-abund-read-2.fa')
+    in_dir = os.path.dirname(infile)
+
+    args = ["-k", "17", "-x", "1e7", "-N", "2", infile,
+            "-o", "explicitname.abundtrim"]
+    _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
+
+    assert 'output in explicitname.abundtrim' in err
 
 
 def test_trim_low_abund_diginorm_coverage_err():


### PR DESCRIPTION
Fixes #973 Change log output to inform user that data has been streamed to
stdout or explicitly named files, isntead of using a generic
message.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
