### PR TITLE
[MRG] Add support for run time info to json or tsv in trim-low-abund

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ under semantic versioning, but will be in future versions of khmer.
   SmallCounttable and SmallCountgraph.
 - Added `cleaned_seq` attribute to `khmer.Read` class which provides a cleaned
   version of the sequence of each read.
+- Added --summary-info to trim-low-abund.py to record run information in a file.
 
 ### Changed
 - Suppress display of -x and -N command line options in script help messages.

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -521,7 +521,8 @@ def main():
         ct.save(args.savegraph)
 
     if args.summary_info is not None:
-        # when the output is stdout the name is == 1
+        # note that when streaming to stdout the name of args.output will
+        # be set to 1
         if args.output is not None and args.output.name != 1:
             base = args.output.name
         # no explicit name or stdout stream -> use a default name

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -50,6 +50,7 @@ import os
 import json
 import khmer
 import tempfile
+import time
 import shutil
 import textwrap
 
@@ -519,23 +520,25 @@ def main():
         log_info("Saving k-mer countgraph to {graph}", graph=args.savegraph)
         ct.save(args.savegraph)
 
-    if args.output is not None and args.output.name != 1:
-        base = args.output.name
-    # no explicit name or stdout stream get a default name
-    else:
-        base = 'trim-low-abund'
-    store_provenance_info({'fpr': fp_rate,
-                           'reads': n_reads,
-                           'basepairs': n_bp,
-                           'reads_written': written_reads,
-                           'basepairs_written': written_bp,
-                           'reads_skipped': n_skipped,
-                           'basepairs_skipped': bp_skipped,
-                           'reads_removed': n_reads - written_reads,
-                           'reads_trimmed': trimmed_reads,
-                           'basepairs_removed_or_trimmed': n_bp - written_bp,
-                           },
-                          fname=base, format=args.summary_info)
+    if args.summary_info is not None:
+        # when the output is stdout the name is == 1
+        if args.output is not None and args.output.name != 1:
+            base = args.output.name
+        # no explicit name or stdout stream -> use a default name
+        else:
+            base = 'trim-low-abund-{}'.format(time.strftime("%Y-%m-%dT%H:%M:%S"))
+        store_provenance_info({'fpr': fp_rate,
+                               'reads': n_reads,
+                               'basepairs': n_bp,
+                               'reads_written': written_reads,
+                               'basepairs_written': written_bp,
+                               'reads_skipped': n_skipped,
+                               'basepairs_skipped': bp_skipped,
+                               'reads_removed': n_reads - written_reads,
+                               'reads_trimmed': trimmed_reads,
+                               'basepairs_removed_or_trimmed': n_bp - written_bp,
+                               },
+                              fname=base, format=args.summary_info)
 
 
 if __name__ == '__main__':

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -526,19 +526,21 @@ def main():
             base = args.output.name
         # no explicit name or stdout stream -> use a default name
         else:
-            base = 'trim-low-abund-{}'.format(time.strftime("%Y-%m-%dT%H:%M:%S"))
-        store_provenance_info({'fpr': fp_rate,
-                               'reads': n_reads,
-                               'basepairs': n_bp,
-                               'reads_written': written_reads,
-                               'basepairs_written': written_bp,
-                               'reads_skipped': n_skipped,
-                               'basepairs_skipped': bp_skipped,
-                               'reads_removed': n_reads - written_reads,
-                               'reads_trimmed': trimmed_reads,
-                               'basepairs_removed_or_trimmed': n_bp - written_bp,
-                               },
-                              fname=base, format=args.summary_info)
+            base = 'trim-low-abund-{}'.format(
+                time.strftime("%Y-%m-%dT%H:%M:%S"))
+
+        info = {'fpr': fp_rate,
+                'reads': n_reads,
+                'basepairs': n_bp,
+                'reads_written': written_reads,
+                'basepairs_written': written_bp,
+                'reads_skipped': n_skipped,
+                'basepairs_skipped': bp_skipped,
+                'reads_removed': n_reads - written_reads,
+                'reads_trimmed': trimmed_reads,
+                'basepairs_removed_or_trimmed': n_bp - written_bp
+                }
+        store_provenance_info(info, fname=base, format=args.summary_info)
 
 
 if __name__ == '__main__':

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -38,15 +38,13 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import csv
 import json
 import sys
 import os
-import shutil
 import stat
 import threading
-import gzip
 import io
-import re
 
 import pytest
 from . import khmer_tst_utils as utils
@@ -2565,9 +2563,52 @@ def test_trim_low_abund_trimtest_savegraph():
             assert record.sequence == \
                 'GGTTGACGGGGCTCAGGGGGCGGCTGACTCCGAGAGACAGCA'
 
+
+def test_trim_low_abund_no_summary_info_by_default():
+    infile = utils.copy_test_data("test-abund-read-2.fa")
+    in_dir = os.path.dirname(infile)
+
+    args = ["-k", "17", "-x", "1e7", "-N", "2", "-o", "summary", infile]
+    _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
+
+    summary_fname = os.path.join(in_dir, "summary.info.json")
+    print(os.path.exists(summary_fname))
+    assert not os.path.exists(summary_fname), summary_fname
+
+
+def test_trim_low_abund_summary_info_json():
+    # test JSON file with summary info is created
+    infile = utils.copy_test_data("test-abund-read-2.fa")
+    in_dir = os.path.dirname(infile)
+
+    args = ["-k", "17", "-x", "1e7", "-N", "2", "--summary-info", "json",
+            "-o", "summary", infile]
+    _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
+
+    summary_fname = os.path.join(in_dir, "summary.info.json")
+    assert os.path.exists(summary_fname), summary_fname
+    with open(summary_fname) as f:
+        assert json.load(f), 'summary file does not contain valid JSON'
+
+
+def test_trim_low_abund_summary_info_tsv():
+    # test TSV file with summary info is created
+    infile = utils.copy_test_data("test-abund-read-2.fa")
+    in_dir = os.path.dirname(infile)
+
+    args = ["-k", "17", "-x", "1e7", "-N", "2", "--summary-info", "tsv",
+            "-o", "summary", infile]
+    _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
+
+    summary_fname = os.path.join(in_dir, "summary.info.tsv")
+    assert os.path.exists(summary_fname), summary_fname
+    with open(summary_fname) as f:
+        reader = csv.DictReader(f, dialect='excel-tab')
+        lines = [row for row in reader]
+        assert len(lines) == 1
+
+
 # test that -o/--out option outputs to STDOUT
-
-
 def test_trim_low_abund_stdout():
     infile = utils.copy_test_data('test-abund-read-2.fa')
     in_dir = os.path.dirname(infile)


### PR DESCRIPTION
Related to #974 and #975. This lets the user output a file recording information about the run to a JSON or TSV file.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
