### PR TITLE
Add test that parses stdout from trim-low-abund.py

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2616,7 +2616,10 @@ def test_trim_low_abund_stdout():
     args = ["-k", "17", "-x", "1e7", "-N", "2", infile, "-o", "-"]
     _, out, err = utils.runscript('trim-low-abund.py', args, in_dir)
 
-    assert 'GGTTGACGGGGCTCAGGG' in out
+    # attempt to parse output to check it is in FASTA format
+    stream = io.StringIO(out)
+    assert list(screed.fasta.fasta_iter(stream)), "can't parse stdout"
+
     # can't test that the correct message appears because we redirect
     # the output when under testing. Instead check that incorrect message
     # does not appear.


### PR DESCRIPTION
Fixes #975

Explicitly check that the output of trim-low-abund can be parsed as
FASTA when it is being redirected to stdout.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
