### PR TITLE
Add comment to the Makefile to document where to change things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 VERSION=$(shell ./setup.py version | grep Version | awk '{print $$4}' \
 	| sed 's/+/-/')
 
+# The following four variables are only used by cppcheck. If you want to
+# change how things are compiled edit `setup.cfg` or `setup.py`.
 DEFINES += -DNDEBUG -DVERSION=$(VERSION) -DSEQAN_HAS_BZIP2=1 \
 	   -DSEQAN_HAS_ZLIB=1 -UNO_UNIQUE_RC
 


### PR DESCRIPTION
Fixes #1552

I added a comment in the Makefile pointing people at `setup.{py,cfg}`. That is the place to edit stuff if you want to influence how things are compiled. The variables in `Makefile` are only used by `cppcheck` but I guess most people start by looking in the `Makefile` and then get confused why it doesn't seem to do anything. Ideally we could extract the values from `setup.cfg` instead of duplicating them, but my `distutils` foo is not strong enough for that. Any ideas?

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
