### PR TITLE
[MRG] Switch SmallCounttable to murmurhash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ under semantic versioning, but will be in future versions of khmer.
   class.
 - Renamed `consume_fasta` and related functions to `consume_seqfile`, with
   support for reading sequences from additional formats pending.
+- `Counttable` and `SmallCounttable` now use murmur hash 3 as hash function.
+  This means they support kmers longer than 32 bases but means the hashes are
+  no longer reversible.
 
 ### Fixed
 - Bug in compressed(gzip) streaming output from scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ under semantic versioning, but will be in future versions of khmer.
 - Added `cleaned_seq` attribute to `khmer.Read` class which provides a cleaned
   version of the sequence of each read.
 - Added --summary-info to trim-low-abund.py to record run information in a file.
+- `Nodetable`, `Counttable` and `SmallCounttable` use murmur hash 3 as hash
+  function. This means they support kmers longer than 32 bases but means
+  the hashes are not reversible.
 
 ### Changed
 - Suppress display of -x and -N command line options in script help messages.
@@ -47,9 +50,6 @@ under semantic versioning, but will be in future versions of khmer.
   class.
 - Renamed `consume_fasta` and related functions to `consume_seqfile`, with
   support for reading sequences from additional formats pending.
-- `Counttable` and `SmallCounttable` now use murmur hash 3 as hash function.
-  This means they support kmers longer than 32 bases but means the hashes are
-  no longer reversible.
 
 ### Fixed
 - Bug in compressed(gzip) streaming output from scripts

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -105,6 +105,18 @@ def load_nodegraph(filename):
     return nodegraph
 
 
+def load_nodetable(filename):
+    """Load a nodetable object from the given filename and return it.
+
+    Keyword argument:
+    filename -- the name of the nodegraph file
+    """
+    nodetable = _Nodetable(1, [1])
+    nodetable.load(filename)
+
+    return nodetable
+
+
 def load_countgraph(filename, small=False):
     """Load a countgraph object from the given filename and return it.
 
@@ -341,6 +353,7 @@ class Counttable(_Counttable):
 
 
 class SmallCounttable(_SmallCounttable):
+
     def __new__(cls, k, starting_size, n_tables):
         primes = get_n_primes_near_x(n_tables, starting_size)
         counttable = _SmallCounttable.__new__(cls, k, primes)

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -507,57 +507,6 @@ const
     return posns;
 }
 
-class MurmurKmerHashIterator : public KmerHashIterator
-{
-    const char * _seq;
-    const char _ksize;
-    unsigned int index;
-    unsigned int length;
-    bool _initialized;
-public:
-    MurmurKmerHashIterator(const char * seq, unsigned char k) :
-        _seq(seq), _ksize(k), index(0), _initialized(false) {
-        length = strlen(_seq);
-    };
-
-    HashIntoType first() { _initialized = true; return next(); }
-
-    HashIntoType next() {
-        if (!_initialized) { _initialized = true; }
-
-        if (done()) {
-            throw khmer_exception("past end of iterator");
-        }
-
-        std::string kmer;
-        kmer.assign(_seq + index, _ksize);
-        index += 1;
-        return _hash_murmur(kmer, _ksize);
-    }
-
-    bool done() const {
-        return (index + _ksize > length);
-    }
-
-    unsigned int get_start_pos() const {
-        if (!_initialized) { return 0; }
-        return index - 1;
-    }
-    unsigned int get_end_pos() const {
-        if (!_initialized) { return _ksize; }
-        return index + _ksize - 1;
-    }
-};
-
-KmerHashIteratorPtr Counttable::new_kmer_iterator(const char * sp) const {
-    KmerHashIterator * ki = new MurmurKmerHashIterator(sp, _ksize);
-    return unique_ptr<KmerHashIterator>(ki);
-}
-
-KmerHashIteratorPtr SmallCounttable::new_kmer_iterator(const char * sp) const {
-    KmerHashIterator * ki = new MurmurKmerHashIterator(sp, _ksize);
-    return unique_ptr<KmerHashIterator>(ki);
-}
 
 template void Hashtable::consume_seqfile<FastxReader>(
     std::string const &filename,

--- a/lib/hashtable.cc
+++ b/lib/hashtable.cc
@@ -554,6 +554,11 @@ KmerHashIteratorPtr Counttable::new_kmer_iterator(const char * sp) const {
     return unique_ptr<KmerHashIterator>(ki);
 }
 
+KmerHashIteratorPtr SmallCounttable::new_kmer_iterator(const char * sp) const {
+    KmerHashIterator * ki = new MurmurKmerHashIterator(sp, _ksize);
+    return unique_ptr<KmerHashIterator>(ki);
+}
+
 template void Hashtable::consume_seqfile<FastxReader>(
     std::string const &filename,
     unsigned int &total_reads,

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -63,11 +63,11 @@ using namespace std;
 
 namespace khmer
 {
-    namespace read_parsers
-    {
-        template<typename SeqIO> class ReadParser;
-        class FastxReader;
-    }
+namespace read_parsers
+{
+template<typename SeqIO> class ReadParser;
+class FastxReader;
+}
 }
 
 #define CALLBACK_PERIOD 100000
@@ -117,12 +117,14 @@ protected:
     explicit Hashtable(const Hashtable&);
     Hashtable& operator=(const Hashtable&);
 
-    virtual KmerHashIteratorPtr new_kmer_iterator(const char * sp) const {
+    virtual KmerHashIteratorPtr new_kmer_iterator(const char * sp) const
+    {
         KmerHashIterator * ki = new TwoBitKmerHashIterator(sp, _ksize);
         return unique_ptr<KmerHashIterator>(ki);
     }
 
-    virtual KmerHashIteratorPtr new_kmer_iterator(const std::string& s) const {
+    virtual KmerHashIteratorPtr new_kmer_iterator(const std::string& s) const
+    {
         return new_kmer_iterator(s.c_str());
     }
 
@@ -336,14 +338,22 @@ class MurmurKmerHashIterator : public KmerHashIterator
     bool _initialized;
 public:
     MurmurKmerHashIterator(const char * seq, unsigned char k) :
-        _seq(seq), _ksize(k), index(0), _initialized(false) {
+        _seq(seq), _ksize(k), index(0), _initialized(false)
+    {
         length = strlen(_seq);
     };
 
-    HashIntoType first() { _initialized = true; return next(); }
+    HashIntoType first()
+    {
+        _initialized = true;
+        return next();
+    }
 
-    HashIntoType next() {
-        if (!_initialized) { _initialized = true; }
+    HashIntoType next()
+    {
+        if (!_initialized) {
+            _initialized = true;
+        }
 
         if (done()) {
             throw khmer_exception("past end of iterator");
@@ -355,16 +365,23 @@ public:
         return _hash_murmur(kmer, _ksize);
     }
 
-    bool done() const {
+    bool done() const
+    {
         return (index + _ksize > length);
     }
 
-    unsigned int get_start_pos() const {
-        if (!_initialized) { return 0; }
+    unsigned int get_start_pos() const
+    {
+        if (!_initialized) {
+            return 0;
+        }
         return index - 1;
     }
-    unsigned int get_end_pos() const {
-        if (!_initialized) { return _ksize; }
+    unsigned int get_end_pos() const
+    {
+        if (!_initialized) {
+            return _ksize;
+        }
         return index + _ksize - 1;
     }
 };
@@ -379,7 +396,8 @@ public:
     inline
     virtual
     HashIntoType
-    hash_dna(const char * kmer) const {
+    hash_dna(const char * kmer) const
+    {
         if (!(strlen(kmer) >= _ksize)) {
             throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
         }
@@ -387,21 +405,25 @@ public:
     }
 
     inline virtual HashIntoType
-    hash_dna_top_strand(const char * kmer) const {
+    hash_dna_top_strand(const char * kmer) const
+    {
         throw khmer_exception("not implemented");
     }
 
     inline virtual HashIntoType
-    hash_dna_bottom_strand(const char * kmer) const {
+    hash_dna_bottom_strand(const char * kmer) const
+    {
         throw khmer_exception("not implemented");
     }
 
     inline virtual std::string
-    unhash_dna(HashIntoType hashval) const {
+    unhash_dna(HashIntoType hashval) const
+    {
         throw khmer_exception("not implemented");
     }
 
-    virtual KmerHashIteratorPtr new_kmer_iterator(const char * sp) const {
+    virtual KmerHashIteratorPtr new_kmer_iterator(const char * sp) const
+    {
         KmerHashIterator * ki = new MurmurKmerHashIterator(sp, _ksize);
         return unique_ptr<KmerHashIterator>(ki);
     }

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -367,6 +367,33 @@ class SmallCounttable : public khmer::Hashtable
 public:
     explicit SmallCounttable(WordLength ksize, std::vector<uint64_t> sizes)
         : Hashtable(ksize, new NibbleStorage(sizes)) { } ;
+
+    inline
+    virtual
+    HashIntoType
+    hash_dna(const char * kmer) const {
+        if (!(strlen(kmer) >= _ksize)) {
+            throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
+        }
+        return _hash_murmur(kmer, _ksize);
+    }
+
+    inline virtual HashIntoType
+    hash_dna_top_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual HashIntoType
+    hash_dna_bottom_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual std::string
+    unhash_dna(HashIntoType hashval) const {
+        throw khmer_exception("not implemented");
+    }
+
+    virtual KmerHashIteratorPtr new_kmer_iterator(const char * sp) const;
 };
 
 // Hashtable-derived class with BitStorage.

--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -199,11 +199,11 @@ public:
         return store->get_count(khash);
     }
 
-    void save(std::string filename)
+    virtual void save(std::string filename)
     {
         store->save(filename, _ksize);
     }
-    void load(std::string filename)
+    virtual void load(std::string filename)
     {
         store->load(filename, _ksize);
         _init_bitstuff();
@@ -427,6 +427,16 @@ public:
         KmerHashIterator * ki = new MurmurKmerHashIterator(sp, _ksize);
         return unique_ptr<KmerHashIterator>(ki);
     }
+
+    virtual void save(std::string filename)
+    {
+        store->save(filename, _ksize);
+    }
+    virtual void load(std::string filename)
+    {
+        store->load(filename, _ksize);
+        _init_bitstuff();
+    }
 };
 
 // Hashtable-derived class with ByteStorage.
@@ -442,15 +452,15 @@ class SmallCounttable : public khmer::MurmurHashtable
 {
 public:
     explicit SmallCounttable(WordLength ksize, std::vector<uint64_t> sizes)
-        : MurmurHashtable(ksize, new NibbleStorage(sizes)) { } ;
+          : MurmurHashtable(ksize, new NibbleStorage(sizes)) { };
 };
 
 // Hashtable-derived class with BitStorage.
-class Nodetable : public Hashtable
+class Nodetable : public khmer::MurmurHashtable
 {
 public:
     explicit Nodetable(WordLength ksize, std::vector<uint64_t> sizes)
-        : Hashtable(ksize, new BitStorage(sizes)) { } ;
+        : MurmurHashtable(ksize, new BitStorage(sizes)) { } ;
 };
 
 }

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -94,7 +94,9 @@ private:\
 #   define SAVED_SUBSET 5
 #   define SAVED_LABELSET 6
 #   define SAVED_SMALLCOUNT 7
-
+#   define SAVED_COUNTING_HT_MURMUR 8
+#   define SAVED_HASHBITS_MURMUR 9
+#   define SAVED_SMALLCOUNT_MURMUR 10
 
 #   define TRAVERSAL_LEFT 0
 #   define TRAVERSAL_RIGHT 1

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -94,9 +94,6 @@ private:\
 #   define SAVED_SUBSET 5
 #   define SAVED_LABELSET 6
 #   define SAVED_SMALLCOUNT 7
-#   define SAVED_COUNTING_HT_MURMUR 8
-#   define SAVED_HASHBITS_MURMUR 9
-#   define SAVED_SMALLCOUNT_MURMUR 10
 
 #   define TRAVERSAL_LEFT 0
 #   define TRAVERSAL_RIGHT 1

--- a/lib/storage.cc
+++ b/lib/storage.cc
@@ -908,7 +908,8 @@ void NibbleStorage::load(std::string infilename, WordLength& ksize)
                   + strerror(errno);
         }
         throw khmer_file_exception(err);
-    } catch (const std::exception &e) {
+    }
+     catch (const std::exception &e) {
         std::string err = "Error reading from k-mer count file: " + infilename + " "
                           + strerror(errno);
         throw khmer_file_exception(err);

--- a/lib/storage.cc
+++ b/lib/storage.cc
@@ -908,8 +908,7 @@ void NibbleStorage::load(std::string infilename, WordLength& ksize)
                   + strerror(errno);
         }
         throw khmer_file_exception(err);
-    }
-     catch (const std::exception &e) {
+    } catch (const std::exception &e) {
         std::string err = "Error reading from k-mer count file: " + infilename + " "
                           + strerror(errno);
         throw khmer_file_exception(err);

--- a/tests/test_counttable.py
+++ b/tests/test_counttable.py
@@ -61,3 +61,22 @@ def test_get_kmer_hashes():
 def test_kmer_revcom_hash(kmer):
     a = khmer.Counttable(21, 1e4, 3)
     assert a.hash(kmer) == a.hash(khmer.reverse_complement(kmer))
+
+
+@pytest.mark.parametrize('ksize,sketch_allocator', [
+    (21, khmer.Nodetable),
+    (21, khmer.Counttable),
+    (21, khmer.SmallCounttable),
+    (49, khmer.Nodetable),
+    (49, khmer.Counttable),
+    (49, khmer.SmallCounttable),
+])
+def test_reverse_hash(ksize, sketch_allocator):
+    multiplier = int(ksize / len('GATTACA'))
+    kmer = 'GATTACA' * multiplier
+
+    sketch = sketch_allocator(ksize, 1e4, 4)
+    kmer_hash = sketch.hash(kmer)
+    with pytest.raises(ValueError) as ve:
+        _ = sketch.reverse_hash(kmer_hash)
+    assert 'not implemented' in str(ve)

--- a/tests/test_nibblestorage.py
+++ b/tests/test_nibblestorage.py
@@ -37,6 +37,8 @@ from __future__ import absolute_import
 
 import random
 
+import pytest
+
 from khmer import SmallCounttable
 
 from . import khmer_tst_utils as utils
@@ -50,8 +52,8 @@ def test_single_add():
     assert sct.get("AAAA") == 1
 
 
-def test_split_byte():
-    # check the byte is correctly split
+def test_split_byte_murmur():
+    # check the byte is correctly split when using murmur hash
     sct = SmallCounttable(4, 4, 1)
 
     # these kmers were carefully chosen to have hash values that produce

--- a/tests/test_nibblestorage.py
+++ b/tests/test_nibblestorage.py
@@ -54,11 +54,13 @@ def test_split_byte():
     # check the byte is correctly split
     sct = SmallCounttable(4, 4, 1)
 
-    a = "AAAA"
-    b = "AAAT"
+    # these kmers were carefully chosen to have hash values that produce
+    # consecutive indices in the count table.
+    a = "AAAC"
+    b = "AAAG"
 
-    assert sct.get_kmer_hashes(a) == [0]
-    assert sct.get_kmer_hashes(b) == [1]
+    assert sct.get_kmer_hashes(a) == [11898086063751343884]
+    assert sct.get_kmer_hashes(b) == [10548630838975263317]
 
     sct.add(a)
 

--- a/tests/test_nibblestorage.py
+++ b/tests/test_nibblestorage.py
@@ -37,8 +37,6 @@ from __future__ import absolute_import
 
 import random
 
-import pytest
-
 from khmer import SmallCounttable
 
 from . import khmer_tst_utils as utils

--- a/tests/test_tabletype.py
+++ b/tests/test_tabletype.py
@@ -385,8 +385,10 @@ def test_save_load(tabletype):
         loaded = khmer.load_countgraph(savefile, small=True)
     elif tabletype == _SmallCounttable:
         loaded = khmer.load_counttable(savefile, small=True)
-    elif tabletype in (_Nodegraph, _Nodetable):
+    elif tabletype == _Nodegraph:
         loaded = khmer.load_nodegraph(savefile)
+    elif tabletype == _Nodetable:
+        loaded = khmer.load_nodetable(savefile)
     else:
         raise Exception("unknown tabletype")
 


### PR DESCRIPTION
Fixes #1659 `SmallCounttable` uses murmurhash now. We can't inherit from `Counttable` because that would lock us into the storage used by that. So went with the approach of copying the hashing stuff.

Does someone know if having mixins works as nicely in c++ as it does in python? Then we could have a `MurmurHashMixin` to add the functionality.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?

