### PR TITLE
Fixing unexpected behavior w.r.t. reverse_hash and table sketches

### DIFF
--- a/lib/hashtable.hh
+++ b/lib/hashtable.hh
@@ -367,6 +367,31 @@ class SmallCounttable : public khmer::Hashtable
 public:
     explicit SmallCounttable(WordLength ksize, std::vector<uint64_t> sizes)
         : Hashtable(ksize, new NibbleStorage(sizes)) { } ;
+
+    inline
+    virtual
+    HashIntoType
+    hash_dna(const char * kmer) const {
+        if (!(strlen(kmer) >= _ksize)) {
+            throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
+        }
+        return _hash_murmur(kmer, _ksize);
+    }
+
+    inline virtual HashIntoType
+    hash_dna_top_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual HashIntoType
+    hash_dna_bottom_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual std::string
+    unhash_dna(HashIntoType hashval) const {
+        throw khmer_exception("not implemented");
+    }
 };
 
 // Hashtable-derived class with BitStorage.
@@ -375,6 +400,31 @@ class Nodetable : public Hashtable
 public:
     explicit Nodetable(WordLength ksize, std::vector<uint64_t> sizes)
         : Hashtable(ksize, new BitStorage(sizes)) { } ;
+
+    inline
+    virtual
+    HashIntoType
+    hash_dna(const char * kmer) const {
+        if (!(strlen(kmer) >= _ksize)) {
+            throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
+        }
+        return _hash_murmur(kmer, _ksize);
+    }
+
+    inline virtual HashIntoType
+    hash_dna_top_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual HashIntoType
+    hash_dna_bottom_strand(const char * kmer) const {
+        throw khmer_exception("not implemented");
+    }
+
+    inline virtual std::string
+    unhash_dna(HashIntoType hashval) const {
+        throw khmer_exception("not implemented");
+    }
 };
 
 }

--- a/tests/test_counttable.py
+++ b/tests/test_counttable.py
@@ -61,3 +61,22 @@ def test_get_kmer_hashes():
 def test_kmer_revcom_hash(kmer):
     a = khmer.Counttable(21, 1e4, 3)
     assert a.hash(kmer) == a.hash(khmer.reverse_complement(kmer))
+
+
+@pytest.mark.parametrize('ksize,sketch_allocator', [
+    (21, khmer.Nodetable),
+    (21, khmer.Counttable),
+    (21, khmer.SmallCounttable),
+    (49, khmer.Nodetable),
+    (49, khmer.Counttable),
+    (49, khmer.SmallCounttable),
+])
+def test_reverse_hash(ksize, sketch_allocator):
+    multiplier = int(ksize / len('GATTACA'))
+    kmer = 'GATTACA' * multiplier
+
+    sketch = sketch_allocator(ksize, 1e4, 4)
+    kmer_hash = sketch.hash(kmer)
+    with pytest.raises(ValueError) as ve:
+        _ = sketch.reverse_hash(kmer_hash)
+    assert 'not implemented' in str(ve)


### PR DESCRIPTION
The [Node|Count|SmallCount]table data structures use the irreversible MurmurHash (or at least they *should* be: see #1689). Therefore, any call to `table.reverse_hash(hashval)` should result in a `ValueError`. Currently this is only the case for `Counttable`.

This PR introduces a regression test that should pass once everything is functioning properly.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
