### PR TITLE
Add conversion of README text from md to rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,12 +192,20 @@ if "-rc" in versioneer.get_version():
 else:
     CLASSIFIERS.append("Development Status :: 5 - Production/Stable")
 
+# Before making a new release make sure to install pypandoc. Pypi does not
+# render markdown which is why we convert to rst here.
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    long_description = open('README.md').read()
+
 SETUP_METADATA = \
     {
         "name": "khmer",
         "version": versioneer.get_version(),
         "description": 'khmer k-mer counting library',
-        "long_description": open("README.md").read(),
+        "long_description": long_description,
         "author": "Michael R. Crusoe, Hussien F. Alameldin, Sherine Awad, "
                   "Elmar Bucher, Adam Caldwell, Reed Cartwright, "
                   "Amanda Charbonneau, Bede Constantinides, Greg Edvenson, "


### PR DESCRIPTION
Implements [@standage's idea](https://github.com/dib-lab/khmer/issues/1393#issuecomment-300236583) for converting our readme from MD to RST locally. We need to do this if we want the PyPI page to look nice as it seems PyPI won't be rendering markdown any time soon.

Compare `python setup.py --long-description` with and without pandoc installed.

Wondering if there is a way to automatically pull in pypandoc when "making a release". I thought that `'setup_requires'` would take care of this but that only get's executed when `setup()` is called.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
