### PR TITLE
Cherry pick merger of AssemblerTraverser with NonLoopingAT

### DIFF
--- a/lib/assembler.hh
+++ b/lib/assembler.hh
@@ -81,14 +81,14 @@ public:
 
     explicit LinearAssembler(const Hashgraph * ht);
 
-    std::string assemble(const Kmer seed_kmer,
-                         const Hashgraph * stop_bf = 0) const;
+    virtual std::string assemble(const Kmer seed_kmer,
+                                 const Hashgraph * stop_bf = 0) const;
 
-    std::string assemble_right(const Kmer seed_kmer,
-                               const Hashgraph * stop_bf = 0) const;
+    virtual std::string assemble_right(const Kmer seed_kmer,
+                                       const Hashgraph * stop_bf = 0) const;
 
-    std::string assemble_left(const Kmer seed_kmer,
-                              const Hashgraph * stop_bf = 0) const;
+    virtual std::string assemble_left(const Kmer seed_kmer,
+                                      const Hashgraph * stop_bf = 0) const;
 
     template <bool direction>
     std::string _assemble_directed(AssemblerTraverser<direction>& cursor) const;
@@ -140,7 +140,7 @@ public:
                           const Hashgraph * stop_bf=0) const;
 
     template <bool direction>
-    void _assemble_directed(NonLoopingAT<direction>& start_cursor,
+    void _assemble_directed(AssemblerTraverser<direction>& start_cursor,
                             StringVector& paths) const;
 
 };
@@ -169,7 +169,7 @@ public:
     BoundedCounterType get_junction_count(Kmer kmer_a, Kmer kmer_b) const;
 
     template <bool direction>
-    void _assemble_directed(NonLoopingAT<direction>& start_cursor,
+    void _assemble_directed(AssemblerTraverser<direction>& start_cursor,
                             StringVector& paths) const;
 
 };

--- a/lib/kmer_filters.cc
+++ b/lib/kmer_filters.cc
@@ -144,7 +144,7 @@ KmerFilter get_stop_bf_filter(const Hashtable * stop_bf)
 }
 
 
-KmerFilter get_visited_filter(const SeenSet * visited)
+KmerFilter get_visited_filter(std::shared_ptr<SeenSet> visited)
 {
 #if DEBUG_FILTERS
     std::cout << "Create new visited filter with " << visited <<

--- a/lib/kmer_filters.hh
+++ b/lib/kmer_filters.hh
@@ -61,7 +61,7 @@ KmerFilter get_simple_label_intersect_filter(const LabelSet& src_labels,
 
 KmerFilter get_stop_bf_filter(const Hashtable * stop_bf);
 
-KmerFilter get_visited_filter(const SeenSet * visited);
+KmerFilter get_visited_filter(std::shared_ptr<SeenSet> visited);
 
 KmerFilter get_junction_count_filter(const Kmer& src_node,
                                      Countgraph * junctions,

--- a/lib/traversal.cc
+++ b/lib/traversal.cc
@@ -78,6 +78,13 @@ NodeGatherer<direction>::NodeGatherer(const Hashgraph * ht,
 }
 
 
+template <bool direction>
+WordLength NodeGatherer<direction>::ksize() const
+{
+    return graph->ksize();
+}
+
+
 template<>
 Kmer NodeGatherer<TRAVERSAL_LEFT>::get_neighbor(const Kmer& node, const char ch)
 const
@@ -214,6 +221,13 @@ void Traverser::push_filter(KmerFilter filter)
 }
 
 
+KmerFilter Traverser::pop_filter()
+{
+    left_gatherer.pop_filter();
+    return right_gatherer.pop_filter();
+}
+
+
 unsigned int Traverser::traverse(const Kmer& node,
                                  KmerQueue& node_q) const
 {
@@ -260,6 +274,35 @@ unsigned int Traverser::degree_right(const Kmer& node) const
  * AssemblerTraverser
  ******************************************/
 
+template<bool direction>
+AssemblerTraverser<direction>::AssemblerTraverser(const Hashgraph * ht,
+                                                  Kmer start_kmer,
+                                                  KmerFilterList filters) :
+        NodeCursor<direction>(ht, start_kmer, filters)
+{
+    visited = std::make_shared<SeenSet>();
+    AssemblerTraverser<direction>::push_filter(get_visited_filter(visited));
+}
+
+template<bool direction>
+AssemblerTraverser<direction>::AssemblerTraverser(const Hashgraph * ht,
+                                                  Kmer start_kmer,
+                                                  KmerFilterList filters,
+                                                  std::shared_ptr<SeenSet> visited) :
+        NodeCursor<direction>(ht, start_kmer, filters), visited(visited)
+{
+    AssemblerTraverser<direction>::push_filter(get_visited_filter(visited));
+}
+
+template<bool direction>
+AssemblerTraverser<direction>::AssemblerTraverser(const AssemblerTraverser<direction>& other) : 
+    AssemblerTraverser<direction>(other.graph,
+                                  other.cursor,
+                                  other.filters,
+                                  other.visited)
+{
+}
+
 template <>
 std::string AssemblerTraverser<TRAVERSAL_RIGHT>::join_contigs(std::string& contig_a,
         std::string& contig_b, WordLength offset)
@@ -284,6 +327,7 @@ char AssemblerTraverser<direction>::next_symbol()
     Kmer neighbor;
     Kmer cursor_next;
 
+    visited->insert(this->cursor);
     for (auto base : alphabets::DNA_SIMPLE) {
         // Get the putative neighbor for this base at the cursor position
         neighbor = NodeCursor<direction>::get_neighbor(this->cursor, base);
@@ -310,29 +354,6 @@ char AssemblerTraverser<direction>::next_symbol()
     }
 }
 
-/******************************************
- * NonLoopingAT
- ******************************************/
-
-template<bool direction>
-NonLoopingAT<direction>::NonLoopingAT(const Hashgraph * ht,
-                                      Kmer start_kmer,
-                                      KmerFilterList filters,
-                                      SeenSet * visited) :
-    AssemblerTraverser<direction>(ht, start_kmer, filters), visited(visited)
-{
-    AssemblerTraverser<direction>::push_filter(get_visited_filter(visited));
-}
-
-template<bool direction>
-char NonLoopingAT<direction>::next_symbol()
-{
-#if DEBUG_TRAVERSAL
-    std::cout << "Insert cursor to visited filter" << std::endl;
-#endif
-    visited->insert(this->cursor);
-    return AssemblerTraverser<direction>::next_symbol();
-}
 
 template class NodeGatherer<TRAVERSAL_LEFT>;
 template class NodeGatherer<TRAVERSAL_RIGHT>;
@@ -340,8 +361,6 @@ template class NodeCursor<TRAVERSAL_LEFT>;
 template class NodeCursor<TRAVERSAL_RIGHT>;
 template class AssemblerTraverser<TRAVERSAL_RIGHT>;
 template class AssemblerTraverser<TRAVERSAL_LEFT>;
-template class NonLoopingAT<TRAVERSAL_RIGHT>;
-template class NonLoopingAT<TRAVERSAL_LEFT>;
 
 
 } // namespace khmer

--- a/lib/traversal.hh
+++ b/lib/traversal.hh
@@ -87,6 +87,8 @@ public:
 
     explicit NodeGatherer(const Hashgraph * ht, KmerFilter filter);
 
+    WordLength ksize() const;
+
     /**
      * @brief Push a new filter on to the filter stack.
      */
@@ -218,6 +220,7 @@ public:
                        KmerFilter filter);
 
     void push_filter(KmerFilter filter);
+    KmerFilter pop_filter();
 
     unsigned int traverse(const Kmer& node,
                           KmerQueue& node_q) const;
@@ -244,8 +247,23 @@ template <bool direction>
 class AssemblerTraverser: public NodeCursor<direction>
 {
 
+protected:
+    std::shared_ptr<SeenSet> visited;
+
 public:
     using NodeCursor<direction>::NodeCursor;
+    
+    explicit AssemblerTraverser(const Hashgraph * ht,
+                                Kmer start_kmer,
+                                KmerFilterList filters);
+
+    explicit AssemblerTraverser(const Hashgraph * ht,
+                                Kmer start_kmer,
+                                KmerFilterList filters,
+                                std::shared_ptr<SeenSet> visited);
+
+    AssemblerTraverser(const AssemblerTraverser& other);
+
 
     /**
      * @brief Get the next symbol.
@@ -274,30 +292,6 @@ public:
                              WordLength offset = 0) const;
 };
 
-
-/**
- * @brief An AssemblerTraverser which does not traverse to Kmers it has already encountered.
- *
- * Simply adds a new filter to check if the Kmer has been seen, and adds the Kmer to the set
- * of seen Kmers after calling ::next_symbol.
- *
- * @tparam direction The direction to assemble.
- */
-template<bool direction>
-class NonLoopingAT: public AssemblerTraverser<direction>
-{
-protected:
-
-    SeenSet * visited;
-
-public:
-
-    explicit NonLoopingAT(const Hashgraph * ht,
-                          Kmer start_kmer,
-                          KmerFilterList filters,
-                          SeenSet * visited);
-    virtual char next_symbol();
-};
 
 }
 #endif

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -520,6 +520,18 @@ def tandem_repeat_structure(request, linear_structure):
     return graph, sequence, tandem_repeats
 
 
+@pytest.fixture
+def circular_linear_structure(request, linear_structure):
+    graph, sequence = linear_structure
+
+    sequence += sequence
+
+    if hdn_counts(sequence, graph):
+        request.applymarker(pytest.mark.xfail)
+
+    return graph, sequence
+
+
 class TestNonBranching:
 
     def test_all_start_positions(self, linear_structure):
@@ -550,6 +562,14 @@ class TestNonBranching:
             path = asm.assemble(contig[start:start + K], direction='R')
             print(path, ', ', contig[:start])
             assert utils._equals_rc(path, contig[start:]), start
+
+    def test_circular(self, circular_linear_structure):
+        graph, contig = circular_linear_structure
+        asm = khmer.LinearAssembler(graph)
+
+        path = asm.assemble(contig[:K], direction='R')
+        print(path, ',', contig)
+        assert utils._equals_rc(path, contig[:len(path)])
 
 
 class TestLinearAssembler_RightBranching:


### PR DESCRIPTION
A more comprehensive version of #1680. Removes NonLoopingAT entirely, instead merging its functionality in to LinearAssembler.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
