### PR TITLE
[RFC] Eliminates requirement for network access after `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ dist/khmer-$(VERSION).tar.gz: $(SOURCES)
 clean: FORCE
 	cd src/oxli && $(MAKE) clean || true
 	cd tests && rm -rf khmertest_* || true
-	rm -f pytest_runner-*.egg pytests.xml
+	rm -f pytests.xml
 	rm -f $(EXTENSION_MODULE)
 	rm -f khmer/*.pyc scripts/*.pyc tests/*.pyc oxli/*.pyc \
 		sandbox/*.pyc khmer/__pycache__/* sandbox/__pycache__/* \
@@ -140,7 +140,7 @@ clean: FORCE
 	rm -Rf .coverage coverage-gcovr.xml coverage.xml
 	rm -f diff-cover.html
 	rm -Rf build dist
-	rm -rf __pycache__/ .eggs/ khmer.egg-info/
+	rm -rf __pycache__/ khmer.egg-info/
 	@find ./ -type d -name __pycache__ -exec rm -rf {} +
 	@find ./khmer/ -type f -name *$(MODEXT) -exec rm -f {} +
 	-rm -f *.gcov

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ PYSOURCES=$(filter-out khmer/_version.py, \
 SOURCES=$(PYSOURCES) $(CPPSOURCES) $(CYSOURCES) setup.py
 
 DEVPKGS=pep8==1.6.2 diff_cover autopep8 pylint coverage gcovr pytest \
-	pydocstyle screed pyenchant Cython==0.25.2
+	'pytest-runner>=2.0,<3dev' pydocstyle screed pyenchant Cython==0.25.2
 
 GCOVRURL=git+https://github.com/nschum/gcovr.git@never-executed-branches
 


### PR DESCRIPTION
See #1706. No need to delete the `.eggs` directory.

An alternative or complementary change: perhaps we should just add pytest-runner to th DEVPKGS list so that it is explicitly installed when `make install-dependencies` is run, so that we don't have to resort to egg trickery?

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
