### PR TITLE
[WIP] Enable automatic detecting and loading all filter/sketch types

### DIFF
--- a/include/oxli/oxli.hh
+++ b/include/oxli/oxli.hh
@@ -87,13 +87,20 @@ private:\
 
 #   define SAVED_SIGNATURE "OXLI"
 #   define SAVED_FORMAT_VERSION 4
-#   define SAVED_COUNTING_HT 1
-#   define SAVED_HASHBITS 2
 #   define SAVED_TAGS 3
 #   define SAVED_STOPTAGS 4
 #   define SAVED_SUBSET 5
 #   define SAVED_LABELSET 6
-#   define SAVED_SMALLCOUNT 7
+
+typedef enum saved_sketch_type {
+    SAVED_NODETABLE,
+    SAVED_COUNTTABLE,
+    SAVED_SMALLCOUNTTABLE,
+    // The following are set explicitly for backwards compatibility
+    SAVED_NODEGRAPH = 2,
+    SAVED_COUNTGRAPH = 1,
+    SAVED_SMALLCOUNTGRAPH = 7
+} saved_sketch_type;
 
 #   define TRAVERSAL_LEFT 0
 #   define TRAVERSAL_RIGHT 1

--- a/src/khmer/_cpy_khmer.cc
+++ b/src/khmer/_cpy_khmer.cc
@@ -350,13 +350,13 @@ MOD_INIT(_khmer)
     }
 
     PyObject * filetype_dict = Py_BuildValue("{s,i,s,i,s,i,s,i,s,i,s,i,s,i}",
-                               "COUNTING_HT", SAVED_COUNTING_HT,
-                               "HASHBITS", SAVED_HASHBITS,
+                               "COUNTING_HT", SAVED_COUNTGRAPH,
+                               "HASHBITS", SAVED_NODEGRAPH,
                                "TAGS", SAVED_TAGS,
                                "STOPTAGS", SAVED_STOPTAGS,
                                "SUBSET", SAVED_SUBSET,
                                "LABELSET", SAVED_LABELSET,
-                               "SMALLCOUNT", SAVED_SMALLCOUNT);
+                               "SMALLCOUNT", SAVED_SMALLCOUNTGRAPH);
     if (PyModule_AddObject( m, "FILETYPES", filetype_dict ) < 0) {
         return MOD_ERROR_VAL;
     }

--- a/src/oxli/storage.cc
+++ b/src/oxli/storage.cc
@@ -113,7 +113,7 @@ void BitStorage::save(std::string outfilename, WordLength ksize)
     unsigned char version = SAVED_FORMAT_VERSION;
     outfile.write((const char *) &version, 1);
 
-    unsigned char ht_type = SAVED_HASHBITS;
+    unsigned char ht_type = SAVED_NODEGRAPH;
     outfile.write((const char *) &ht_type, 1);
 
     outfile.write((const char *) &save_ksize, sizeof(save_ksize));
@@ -200,7 +200,7 @@ void BitStorage::load(std::string infilename, WordLength &ksize)
                 << " while reading k-mer graph from " << infilename
                 << "; should be " << (int) SAVED_FORMAT_VERSION;
             throw oxli_file_exception(err.str());
-        } else if (!(ht_type == SAVED_HASHBITS)) {
+        } else if (!(ht_type == SAVED_NODEGRAPH)) {
             std::ostringstream err;
             err << "Incorrect file format type " << (int) ht_type
                 << " while reading k-mer graph from " << infilename;
@@ -330,7 +330,7 @@ ByteStorageFileReader::ByteStorageFileReader(
                 << " while reading k-mer count file from " << infilename
                 << "; should be " << (int) SAVED_FORMAT_VERSION;
             throw oxli_file_exception(err.str());
-        } else if (!(ht_type == SAVED_COUNTING_HT)) {
+        } else if (!(ht_type == SAVED_COUNTGRAPH)) {
             std::ostringstream err;
             err << "Incorrect file format type " << (int) ht_type
                 << " while reading k-mer count file from " << infilename;
@@ -446,7 +446,7 @@ ByteStorageGzFileReader::ByteStorageGzFileReader(
             SAVED_SIGNATURE;
         throw oxli_file_exception(err.str());
     } else if (!(version == SAVED_FORMAT_VERSION)
-               || !(ht_type == SAVED_COUNTING_HT)) {
+               || !(ht_type == SAVED_COUNTGRAPH)) {
         if (!(version == SAVED_FORMAT_VERSION)) {
             std::ostringstream err;
             err << "Incorrect file format version " << (int) version
@@ -454,7 +454,7 @@ ByteStorageGzFileReader::ByteStorageGzFileReader(
                 << "; should be " << (int) SAVED_FORMAT_VERSION;
             gzclose(infile);
             throw oxli_file_exception(err.str());
-        } else if (!(ht_type == SAVED_COUNTING_HT)) {
+        } else if (!(ht_type == SAVED_COUNTGRAPH)) {
             std::ostringstream err;
             err << "Incorrect file format type " << (int) ht_type
                 << " while reading k-mer count file from " << infilename;
@@ -599,7 +599,7 @@ ByteStorageFileWriter::ByteStorageFileWriter(
     unsigned char version = SAVED_FORMAT_VERSION;
     outfile.write((const char *) &version, 1);
 
-    unsigned char ht_type = SAVED_COUNTING_HT;
+    unsigned char ht_type = SAVED_COUNTGRAPH;
     outfile.write((const char *) &ht_type, 1);
 
     unsigned char use_bigcount = 0;
@@ -666,7 +666,7 @@ ByteStorageGzFileWriter::ByteStorageGzFileWriter(
     unsigned char version = SAVED_FORMAT_VERSION;
     gzwrite(outfile, (const char *) &version, 1);
 
-    unsigned char ht_type = SAVED_COUNTING_HT;
+    unsigned char ht_type = SAVED_COUNTGRAPH;
     gzwrite(outfile, (const char *) &ht_type, 1);
 
     unsigned char use_bigcount = 0;
@@ -786,7 +786,7 @@ void NibbleStorage::save(std::string outfilename, WordLength ksize)
     unsigned char version = SAVED_FORMAT_VERSION;
     outfile.write((const char *) &version, 1);
 
-    unsigned char ht_type = SAVED_SMALLCOUNT;
+    unsigned char ht_type = SAVED_SMALLCOUNTGRAPH;
     outfile.write((const char *) &ht_type, 1);
 
     outfile.write((const char *) &save_ksize, sizeof(save_ksize));
@@ -860,7 +860,7 @@ void NibbleStorage::load(std::string infilename, WordLength& ksize)
                 << " while reading k-mer count file from " << infilename
                 << "; should be " << (int) SAVED_FORMAT_VERSION;
             throw oxli_file_exception(err.str());
-        } else if (!(ht_type == SAVED_SMALLCOUNT)) {
+        } else if (!(ht_type == SAVED_SMALLCOUNTGRAPH)) {
             std::ostringstream err;
             err << "Incorrect file format type " << (int) ht_type
                 << " while reading k-mer count file from " << infilename;


### PR DESCRIPTION
See #1716.

So far this PR replaces the *ad hoc* `ht_type` defines with an enumerated type, and adds values for the \*table types. Now the question is how to distinguish between \*graph and \*table types in the storage class, which by design is agnostic to this.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
