### PR TITLE
Move seqan includes to read_parsers impl file (PIMPL philosophy)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include versioneer.py MANIFEST.in CITATION CONTRIBUTING.md Doxyfile.in
 include LICENSE TODO .ycm_extra_conf.py authors.csv
 recursive-include lib *.hh *.cc [Mm]akefile* get_version.py
 recursive-include khmer *.hh
+recursive-include khmer/_oxli *.pxd *.cpp
 recursive-include third-party *.cc *.1 *.xsl README* sample* words* *.sh *.c
 recursive-include third-party manual* [Mm]akefile* *.pl *.dsp CHANGES *.txt *.h
 recursive-include third-party ChangeLog FAQ INDEX configure *.xsl

--- a/include/oxli/read_parsers.hh
+++ b/include/oxli/read_parsers.hh
@@ -38,10 +38,6 @@ Contact: khmer-project@idyll.org
 #ifndef READ_PARSERS_HH
 #define READ_PARSERS_HH
 
-#include <seqan/seq_io.h> // IWYU pragma: keep
-#include <seqan/sequence.h> // IWYU pragma: keep
-#include <seqan/stream.h> // IWYU pragma: keep
-
 #include <regex.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -55,6 +51,11 @@ Contact: khmer-project@idyll.org
 #include "oxli.hh"
 #include "oxli_exception.hh"
 
+
+namespace seqan
+{
+    class SequenceStream; // forward dec seqan dep
+}
 
 namespace oxli
 {
@@ -175,7 +176,7 @@ class FastxReader
 {
 private:
     std::string _filename;
-    seqan::SequenceStream _stream;
+    std::unique_ptr<seqan::SequenceStream> _stream;
     uint32_t _spin_lock;
     size_t _num_reads;
     bool _have_qualities;


### PR DESCRIPTION
Fixes liboxli and header install.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
