### PR TITLE
[WIP] Add tests for small-count vs bigcount CLI conflict

### DIFF
--- a/khmer/khmer_args.py
+++ b/khmer/khmer_args.py
@@ -569,7 +569,10 @@ def create_countgraph(args, ksize=None, multiplier=1.0, fp_rate=0.1):
     else:
         tablesize = calculate_graphsize(args, 'countgraph',
                                         multiplier=multiplier)
-        return khmer.Countgraph(ksize, tablesize, args.n_tables)
+        cg = khmer.Countgraph(ksize, tablesize, args.n_tables)
+        if hasattr(args, 'bigcount'):
+            cg.set_use_bigcount(args.bigcount)
+        return cg
 
 
 def create_matching_nodegraph(countgraph):

--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -132,7 +132,6 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
     # for the countgraph and 1/(9+eps) for the tracking nodegraph
     # `eps` is used to account for the memory used by the python interpreter
     countgraph = khmer_args.create_countgraph(args, multiplier=8 / (9. + 0.3))
-    countgraph.set_use_bigcount(args.bigcount)
 
     log_info('building k-mer tracking graph')
     tracking = khmer_args.create_matching_nodegraph(countgraph)

--- a/scripts/load-into-counting.py
+++ b/scripts/load-into-counting.py
@@ -136,7 +136,6 @@ def main():
 
     log_info('making countgraph')
     countgraph = khmer_args.create_countgraph(args)
-    countgraph.set_use_bigcount(args.bigcount)
 
     filename = None
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -78,6 +78,20 @@ def test_load_into_counting():
     assert os.path.exists(outfile)
 
 
+def test_load_into_counting_smallcount():
+    script = 'load-into-counting.py'
+    args = ['-x', '1e3', '--small-count']
+
+    outfile = utils.get_temp_filename('out.ct')
+    infile = utils.get_test_data('test-abund-read-2.fa')
+
+    args.extend([outfile, infile])
+
+    (status, out, err) = utils.runscript(script, args)
+    assert 'Total number of unique k-mers: 83' in err, err
+    assert os.path.exists(outfile)
+
+
 def test_load_into_counting_quiet():
     script = 'load-into-counting.py'
     args = ['-q', '-x', '1e3', '-N', '2', '-k', '20']
@@ -1427,6 +1441,17 @@ def test_abundance_dist_single_nobigcount():
         assert line == '1,96,96,0.98', line
         line = fp.readline().strip()
         assert line == '255,2,98,1.0', line
+
+
+def test_abundance_dist_single_smallcount():
+    infile = utils.copy_test_data('test-abund-read-2.fa')
+    outfile = utils.get_temp_filename('test.dist')
+    in_dir = os.path.dirname(infile)
+
+    script = 'abundance-dist-single.py'
+    args = ['-x', '1e7', '-N', '2', '-k', '17', '-z', '--small-count',
+            infile, outfile]
+    utils.runscript(script, args, in_dir)
 
 
 def test_abundance_dist_single_nosquash():


### PR DESCRIPTION
Fixes #1722 

The two arguments conflict with each other as you can not set
"bigcount" on a graph or table that uses smallcount. This adds
tests and modifies the code to check if smallcount is set or
not.

Should we add a warning message or abort if the CLI arguments are asking
for smallcount and big count at the same time? Right now it will just run and
ignore the request for big counting.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
