### PR TITLE
[WIP] Add error handling for reading in unicode authors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,8 @@ else:
 #     correctly for the citation information, but this requires a non-standard
 #     library that we don't want to add as a dependency for `setup.py`.
 #     -- Daniel Standage, 2017-05-21
-with open('authors.csv', 'r') as csvin:
+with open(
+    'authors.csv', 'r', encoding="ascii", errors="surrogateescape") as csvin:
     authors = csv.reader(csvin)
     authorstr = ', '.join([row[0] for row in authors])
     authorstr = 'Daniel Standage, ' + authorstr + ', C. Titus Brown'


### PR DESCRIPTION
Fixes #1735 

On machines that use ASCII encoding we can not execute the setup.py
because it reads in the author list which contains unicode characters.
This is fixed by replacing the decoding unicode characters to the
private use area of unicode.

I have a feeling this will not work on python 2 though.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
