### PR TITLE
Remove debugging output from filter-abundant-single.py

### DIFF
--- a/scripts/filter-abund-single.py
+++ b/scripts/filter-abund-single.py
@@ -176,7 +176,6 @@ def main():
                                         args.variable_coverage,
                                         args.normalize_to)
         if trimmed_record:
-            print((trimmed_record,))
             write_record(trimmed_record, outfp)
 
     log_info('output in {outfile}', outfile=outfile)

--- a/tests/test_filter_abund.py
+++ b/tests/test_filter_abund.py
@@ -410,6 +410,7 @@ def test_filter_abund_1_quiet():
     status, out, err = utils.runscript(script, args, in_dir)
 
     assert len(err) == 0
+    assert len(out) < 1000
 
     outfile = infile + '.abundfilt'
     n_outfile = n_infile + '.abundfilt'
@@ -427,6 +428,7 @@ def test_filter_abund_1_singlefile_quiet():
     (status, out, err) = utils.runscript(script, args, in_dir)
 
     assert len(err) == 0
+    assert len(out) < 1000
 
     outfile = infile + '.abundfilt'
     assert os.path.exists(outfile), outfile


### PR DESCRIPTION
This debugging output was producing 30,000 lines of standard out in the kmer-abundance-distribution.ipynb lesson.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
