### PR TITLE
[MRG] Pin cython version until cython issue 1790 is resolved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ help: Makefile
 install-dep: install-dependencies
 
 install-dependencies:
-	pip install --upgrade --ignore-installed $(DEVPKGS)
-	pip install --upgrade --requirement doc/requirements.txt
+	pip install $(DEVPKGS)
+	pip install --requirement doc/requirements.txt
 
 ## sharedobj   : build khmer shared object file
 sharedobj: $(EXTENSION_MODULE)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 sphinxcontrib-autoprogram==0.1.2
 setuptools>=3.4.1
 guzzle_sphinx_theme==0.7.11
-Cython>=0.25.2
+Cython==0.25.2

--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,7 @@ SETUP_METADATA = \
         "packages": ['khmer', 'khmer.tests', 'oxli', 'khmer._oxli'],
         "package_data": {'khmer/_oxli': ['*.pxd']},
         "package_dir": {'khmer.tests': 'tests'},
-        "install_requires": ['screed >= 1.0', 'bz2file', 'Cython>=0.25.2'],
+        "install_requires": ['screed >= 1.0', 'bz2file', 'Cython==0.25.2'],
         "setup_requires": ["pytest-runner>=2.0,<3dev", "setuptools>=18.0"],
         "extras_require": {':python_version=="2.6"': ['argparse>=1.2.1'],
                            'docs': ['sphinx', 'sphinxcontrib-autoprogram'],


### PR DESCRIPTION
See discussion here: https://github.com/cython/cython/issues/1790

I propose we pin the version of cython for the time being. Sounds like this is a bug in cython -> behaviour in 0.25.2 is correct and will be restored in a future version.

- [x] Is it mergeable?
- [ ] `make test` Did it pass the tests?
