### PR TITLE
[MRG] add GraphLabels.link_tag_and_label to CPython API

### DIFF
--- a/include/khmer/_cpy_graphlabels.hh
+++ b/include/khmer/_cpy_graphlabels.hh
@@ -62,6 +62,10 @@ labelhash_get_tag_labels(khmer_KGraphLabels_Object * me, PyObject * args);
 
 
 PyObject *
+labelhash_link_tag_and_label(khmer_KGraphLabels_Object * me, PyObject * args);
+
+
+PyObject *
 labelhash_n_labels(khmer_KGraphLabels_Object * me, PyObject * args);
 
 

--- a/include/khmer/_cpy_graphlabels.hh
+++ b/include/khmer/_cpy_graphlabels.hh
@@ -3,13 +3,14 @@
 
 #include <Python.h>
 #include "_cpy_utils.hh"
+#include "_cpy_hashgraph.hh"
 #include "oxli/labelhash.hh"
 
 
 namespace khmer {
 
 typedef struct {
-    PyObject_HEAD
+    khmer_KHashgraph_Object khashgraph;
     oxli::LabelHash * labelhash;
 } khmer_KGraphLabels_Object;
 

--- a/khmer/_oxli/graphs.pxd
+++ b/khmer/_oxli/graphs.pxd
@@ -31,6 +31,7 @@ cdef extern from "khmer/_cpy_khmer.hh":
         CpCountgraph * countgraph
 
     ctypedef struct CPyGraphLabels_Object "khmer::khmer_KGraphLabels_Object":
+        CPyHashgraph_Object khashgraph
         CpLabelHash * labelhash
 
 

--- a/src/khmer/_cpy_graphlabels.cc
+++ b/src/khmer/_cpy_graphlabels.cc
@@ -85,8 +85,8 @@ void khmer_graphlabels_dealloc(khmer_KGraphLabels_Object * obj)
     Py_TYPE(obj)->tp_free((PyObject*)obj);
 }
 
- PyObject * khmer_graphlabels_new(PyTypeObject *type, PyObject *args,
-                                        PyObject *kwds)
+PyObject * khmer_graphlabels_new(PyTypeObject *type, PyObject *args,
+                                 PyObject *kwds)
 {
     khmer_KGraphLabels_Object *self;
     self = (khmer_KGraphLabels_Object*)type->tp_alloc(type, 0);
@@ -95,6 +95,7 @@ void khmer_graphlabels_dealloc(khmer_KGraphLabels_Object * obj)
         PyObject * hashgraph_o;
         Hashgraph * hashgraph = NULL; // @CTB
 
+        // GraphLabels takes a single argument, a hashgraph descendant.
         if (!PyArg_ParseTuple(args, "O", &hashgraph_o)) {
             Py_DECREF(self);
             return NULL;
@@ -112,6 +113,10 @@ void khmer_graphlabels_dealloc(khmer_KGraphLabels_Object * obj)
             Py_DECREF(self);
             return NULL;
         }
+        // set 'base' for CPython-style inheritance.
+        self->khashgraph.khashtable.hashtable =
+            dynamic_cast<Hashtable*>(hashgraph);
+        self->khashgraph.hashgraph = dynamic_cast<Hashgraph*>(hashgraph);
 
         try {
             self->labelhash = new LabelHash(hashgraph);

--- a/src/khmer/_cpy_graphlabels.cc
+++ b/src/khmer/_cpy_graphlabels.cc
@@ -58,6 +58,7 @@ PyMethodDef khmer_graphlabels_methods[] = {
     {"consume_partitioned_fasta_and_tag_with_labels", (PyCFunction)labelhash_consume_partitioned_fasta_and_tag_with_labels, METH_VARARGS, "" },
     {"sweep_tag_neighborhood", (PyCFunction)labelhash_sweep_tag_neighborhood, METH_VARARGS, "" },
     {"get_tag_labels", (PyCFunction)labelhash_get_tag_labels, METH_VARARGS, ""},
+    {"link_tag_and_label", (PyCFunction)labelhash_link_tag_and_label, METH_VARARGS, ""},
     {"consume_sequence_and_tag_with_labels", (PyCFunction)labelhash_consume_sequence_and_tag_with_labels, METH_VARARGS, "" },
     {"n_labels", (PyCFunction)labelhash_n_labels, METH_VARARGS, ""},
     {"get_all_labels", (PyCFunction)labelhash_get_all_labels, METH_VARARGS, "" },
@@ -387,6 +388,30 @@ labelhash_get_tag_labels(khmer_KGraphLabels_Object * me, PyObject * args)
     }
 
     return x;
+}
+
+
+PyObject *
+labelhash_link_tag_and_label(khmer_KGraphLabels_Object * me, PyObject * args)
+{
+    LabelHash * labelhash = me->labelhash;
+
+    PyObject * tag_o;
+    HashIntoType tag;
+    Label label;
+
+    if (!PyArg_ParseTuple(args, "OK", &tag_o, &label)) {
+        return NULL;
+    }
+    if (!ht_convert_PyObject_to_HashIntoType(tag_o, tag,
+            labelhash->graph)) {
+        return NULL;
+    }
+
+    labelhash->link_tag_and_label(tag, label);
+
+    Py_INCREF(Py_None);
+    return Py_None;
 }
 
 

--- a/src/khmer/_cpy_hashgraph.cc
+++ b/src/khmer/_cpy_hashgraph.cc
@@ -934,12 +934,15 @@ hashgraph_add_stop_tag(khmer_KHashgraph_Object * me, PyObject * args)
 {
     Hashgraph * hashgraph = me->hashgraph;
 
-    const char * kmer_s = NULL;
-    if (!PyArg_ParseTuple(args, "s", &kmer_s)) {
+    PyObject * kmer_o;
+    if (!PyArg_ParseTuple(args, "O", &kmer_o)) {
         return NULL;
     }
 
-    HashIntoType kmer = hashgraph->hash_dna(kmer_s);
+    HashIntoType kmer;
+    if (!ht_convert_PyObject_to_HashIntoType(kmer_o, kmer, hashgraph)) {
+        return NULL;
+    }
     hashgraph->add_stop_tag(kmer);
 
     Py_RETURN_NONE;

--- a/src/khmer/_cpy_hashgraph.cc
+++ b/src/khmer/_cpy_hashgraph.cc
@@ -913,13 +913,17 @@ hashgraph_add_tag(khmer_KHashgraph_Object * me, PyObject * args)
 {
     Hashgraph * hashgraph = me->hashgraph;
 
-    const char * kmer_s = NULL;
-    if (!PyArg_ParseTuple(args, "s", &kmer_s)) {
+    PyObject * tag_o;
+    if (!PyArg_ParseTuple(args, "O", &tag_o)) {
         return NULL;
     }
 
-    HashIntoType kmer = hashgraph->hash_dna(kmer_s);
-    hashgraph->add_tag(kmer);
+    HashIntoType tag;
+    if (!ht_convert_PyObject_to_HashIntoType(tag_o, tag, hashgraph)) {
+        return NULL;
+    }
+
+    hashgraph->add_tag(tag);
 
     Py_RETURN_NONE;
 }

--- a/src/oxli/labelhash.cc
+++ b/src/oxli/labelhash.cc
@@ -200,7 +200,6 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     printdbg(deleted parser and exiting)
 }
 
-// @cswelcher: double-check -- is it valid to pull the address from a reference?
 void LabelHash::link_tag_and_label(const HashIntoType kmer,
                                    const Label kmer_label)
 {

--- a/src/oxli/labelhash.cc
+++ b/src/oxli/labelhash.cc
@@ -200,6 +200,9 @@ void LabelHash::consume_partitioned_fasta_and_tag_with_labels(
     printdbg(deleted parser and exiting)
 }
 
+// Note: this function assumes that 'kmer' is already in graph->all_tags;
+// see usage elsewhere in this code.
+
 void LabelHash::link_tag_and_label(const HashIntoType kmer,
                                    const Label kmer_label)
 {

--- a/tests/test_labelhash.py
+++ b/tests/test_labelhash.py
@@ -205,7 +205,7 @@ def test_link_tag_and_label():
     lb = GraphLabels(20, 1, 1)
 
     tag = 173473779682
-    lb.graph.add_tag(tag)                 # this should work w/o .graph., yes?
+    lb.add_tag(tag)
     lb.link_tag_and_label(tag, 1)
 
     labels = lb.get_tag_labels(tag)
@@ -216,8 +216,8 @@ def test_link_tag_and_label():
 def test_link_tag_and_label_using_string():
     lb = GraphLabels(20, 1, 1)
 
-    kmer = lb.graph.reverse_hash(173473779682)
-    lb.graph.add_tag(kmer)                 # this should work w/o .graph., yes?
+    kmer = lb.reverse_hash(173473779682)
+    lb.add_tag(kmer)
     lb.link_tag_and_label(kmer, 1)
 
     labels = lb.get_tag_labels(kmer)
@@ -229,8 +229,8 @@ def test_link_tag_and_label_using_string_2():
     lb = GraphLabels(20, 1, 1)
 
     tag = 173473779682
-    kmer = lb.graph.reverse_hash(tag)
-    lb.graph.add_tag(kmer)                # this should work w/o .graph., yes?
+    kmer = lb.reverse_hash(tag)
+    lb.add_tag(kmer)
     lb.link_tag_and_label(kmer, 1)
 
     labels = lb.get_tag_labels(tag)       # <-- use 'tag' instead of 'kmer'
@@ -245,14 +245,14 @@ def test_consume_seqfile_and_tag_with_labels():
 
     total_reads, _ = lb.consume_seqfile_and_tag_with_labels(filename)
     print("doing get")
-    assert lb.graph.get(read_1[:20])
+    assert lb.get(read_1[:20])
     assert total_reads == 3
     print("doing n_labels")
     print(lb.n_labels())
     print("doing all labels")
     print(lb.get_all_labels())
     print("get tagset")
-    for tag in lb.graph.get_tagset():
+    for tag in lb.get_tagset():
         print("forward hash")
         print(tag, khmer.forward_hash(tag, 20))
     for record in screed.open(filename):
@@ -296,7 +296,7 @@ def test_consume_sequence_and_tag_with_labels():
 def test_sweep_tag_neighborhood():
     lb = GraphLabels(20, 1e7, 4)
     filename = utils.get_test_data('single-read.fq')
-    lb.graph.consume_seqfile_and_tag(filename)
+    lb.consume_seqfile_and_tag(filename)
 
     tags = lb.sweep_tag_neighborhood('CAGGCGCCCACCACCGTGCCCTCCAACCTGATGGT')
     assert len(tags) == 1

--- a/tests/test_labelhash.py
+++ b/tests/test_labelhash.py
@@ -201,6 +201,43 @@ def test_get_tag_labels():
     assert labels.pop() == 0
 
 
+def test_link_tag_and_label():
+    lb = GraphLabels(20, 1, 1)
+
+    tag = 173473779682
+    lb.graph.add_tag(tag)                 # this should work w/o .graph., yes?
+    lb.link_tag_and_label(tag, 1)
+
+    labels = lb.get_tag_labels(tag)
+    assert len(labels) == 1
+    assert labels.pop() == 1
+
+
+def test_link_tag_and_label_using_string():
+    lb = GraphLabels(20, 1, 1)
+
+    kmer = lb.graph.reverse_hash(173473779682)
+    lb.graph.add_tag(kmer)                 # this should work w/o .graph., yes?
+    lb.link_tag_and_label(kmer, 1)
+
+    labels = lb.get_tag_labels(kmer)
+    assert len(labels) == 1
+    assert labels.pop() == 1
+
+
+def test_link_tag_and_label_using_string_2():
+    lb = GraphLabels(20, 1, 1)
+
+    tag = 173473779682
+    kmer = lb.graph.reverse_hash(tag)
+    lb.graph.add_tag(kmer)                # this should work w/o .graph., yes?
+    lb.link_tag_and_label(kmer, 1)
+
+    labels = lb.get_tag_labels(tag)       # <-- use 'tag' instead of 'kmer'
+    assert len(labels) == 1
+    assert labels.pop() == 1
+
+
 def test_consume_seqfile_and_tag_with_labels():
     lb = GraphLabels(20, 1e7, 4)
     read_1 = 'ACGTAACCGGTTAAACCCGGGTTTAAAACCCCGGGGTTTT'

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -69,6 +69,46 @@ def test_bad_create():
         assert 'tablesizes needs to be one or more numbers' in str(err)
 
 
+def test_add_tag():
+    nodegraph = khmer._Nodegraph(6, [1])
+
+    assert nodegraph.n_tags() == 0
+    nodegraph.add_tag('AATAAG')
+    assert nodegraph.n_tags() == 1
+
+    print(nodegraph.get_tagset())
+    assert nodegraph.get_tagset() == ['AATAAG']
+
+
+def test_add_tag_hashval():
+    nodegraph = khmer._Nodegraph(6, [1])
+
+    assert nodegraph.n_tags() == 0
+    kmer = nodegraph.hash('AATAAG')
+    nodegraph.add_tag(kmer)
+    assert nodegraph.n_tags() == 1
+
+    print(nodegraph.get_tagset())
+    assert nodegraph.get_tagset() == ['AATAAG']
+
+
+def test_add_stop_tag():
+    nodegraph = khmer._Nodegraph(6, [1])
+
+    nodegraph.add_stop_tag('AATAAG')
+    print(nodegraph.get_stop_tags())
+    assert nodegraph.get_stop_tags() == ['AATAAG']
+
+
+def test_add_stop_tag_hashval():
+    nodegraph = khmer._Nodegraph(6, [1])
+
+    kmer = nodegraph.hash('AATAAG')
+    nodegraph.add_stop_tag(kmer)
+    print(nodegraph.get_stop_tags())
+    assert nodegraph.get_stop_tags() == ['AATAAG']
+
+
 def test__get_set_tag_density():
     nodegraph = khmer._Nodegraph(32, [1])
     orig = nodegraph._get_tag_density()


### PR DESCRIPTION
This PR:

* adds the C++ `LabelHash.link_tag_and_labels(tag, label)` function into the Python API for `GraphLabels` objects. 
* updates the `add_tag` and `add_stop_tag` methods on CPython class `Hashgraph` descendants to take either k-mer hashes OR strings as inputs, and supplies explicit tests for this behavior.
* fixes a problem where `GraphLabels` objects *didn't actually inherit from `Hashgraph`* despite being labeled as such in the CPython inheritance hierarchy, and it brings the Cython wrapping/definitions into concordance with the CPython hierarchy.
* add/fixes tests relying on the inheritance hierarchy.

Checklist:

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
