### PR TITLE
Drop Python 2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,6 @@ branches:
 matrix:
   fast_finish: true
   include:
-    - os: linux
-      python: "2.7"
-      # Tell travis we want debian trusty
-      sudo: required
-      dist: trusty
-      env:
-        - TESTATTR="'not huge and not known_failing'"
-      addons:
-        apt:
-          packages:
-            - astyle
-            - cppcheck
-            - enchant
 
     - os: linux
       python: "3.5"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ under semantic versioning, but will be in future versions of khmer.
   `include/khmer`.
 - Moved liboxli headers to include/oxli and implementations to src/oxli.
 - Removed CPython assembler wrappers.
+- Dropped support for Python 2.
+- Changed to absolute imports.
 
 ## [2.1.1] - 2017-05-25
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean: FORCE
 	rm -f $(EXTENSION_MODULE)
 	rm -f khmer/*.pyc scripts/*.pyc tests/*.pyc oxli/*.pyc \
 		sandbox/*.pyc khmer/__pycache__/* sandbox/__pycache__/* \
-		khmer/_oxli/*.cpp
+		khmer/_oxli/*.cpp khmer/_oxli/*.so
 	./setup.py clean --all || true
 	rm -f coverage-debug
 	rm -Rf .coverage coverage-gcovr.xml coverage.xml

--- a/ci_scripts/install.sh
+++ b/ci_scripts/install.sh
@@ -23,7 +23,7 @@ conda update --yes conda
 popd
 
 # Create a fresh environment
-conda create -n testenv --yes python=2.7
+conda create -n testenv --yes python=3
 
 source activate testenv
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,7 +53,7 @@ shotgun data.  You can read more about khmer in `our software paper
 khmer is free and open source software.
 
 **To install khmer**, you will need a Linux or Mac computer, together with
-Python 2.7 or Python 3.x.   See :doc:`our installation docs <user/install>`
+Python >= 3.5.   See :doc:`our installation docs <user/install>`
 for detailed instructions.
 
 **To use khmer**, you will generally need to work at the UNIX command

--- a/khmer/__init__.py
+++ b/khmer/__init__.py
@@ -87,7 +87,7 @@ del get_versions
 
 _buckets_per_byte = {
     # calculated by hand from settings in third-part/cqf/gqf.h
-    'qfcounttable': 1/1.26,
+    'qfcounttable': 1 / 1.26,
     'countgraph': 1,
     'smallcountgraph': 2,
     'nodegraph': 8,

--- a/khmer/_oxli/assembly.pxd
+++ b/khmer/_oxli/assembly.pxd
@@ -3,9 +3,9 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libc.stdint cimport uint16_t
 
-from oxli_types cimport *
-from hashing cimport CpKmer, Kmer
-from graphs cimport (CpHashgraph, CpHashtable, CpLabelHash, 
+from khmer._oxli.oxli_types cimport *
+from khmer._oxli.hashing cimport CpKmer, Kmer
+from khmer._oxli.graphs cimport (CpHashgraph, CpHashtable, CpLabelHash, 
                      get_hashgraph_ptr, get_labelhash_ptr)
 
 

--- a/khmer/_oxli/assembly.pyx
+++ b/khmer/_oxli/assembly.pyx
@@ -1,9 +1,8 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 
 from cython.operator cimport dereference as deref
 
-from utils cimport _bstring
+from khmer._oxli.utils cimport _bstring
 
 
 cdef class LinearAssembler:

--- a/khmer/_oxli/graphs.pxd
+++ b/khmer/_oxli/graphs.pxd
@@ -5,10 +5,10 @@ from libcpp.set cimport set
 from libcpp.memory cimport unique_ptr, shared_ptr, weak_ptr
 from libc.stdint cimport uint8_t, uint32_t, uint64_t, uintptr_t
 
-from oxli_types cimport *
-from hashing cimport CpKmer, KmerSet
-from parsing cimport CpReadParser, CpSequence
-from utils cimport oxli_raise_py_error
+from khmer._oxli.oxli_types cimport *
+from khmer._oxli.hashing cimport CpKmer, KmerSet
+from khmer._oxli.parsing cimport CpReadParser, CpSequence
+from khmer._oxli.utils cimport oxli_raise_py_error
 
 
 # All we really need are the PyObject struct definitions

--- a/khmer/_oxli/graphs.pyx
+++ b/khmer/_oxli/graphs.pyx
@@ -1,4 +1,3 @@
-# cython: c_string_type=unicode, c_string_encoding=utf8
 from math import log
 
 from cython.operator cimport dereference as deref
@@ -7,15 +6,15 @@ from libc.stdint cimport uint64_t
 from libcpp.memory cimport unique_ptr
 from libcpp.vector cimport vector
 
-from utils cimport _bstring
-from utils import get_n_primes_near_x
-from parsing cimport (CpFastxReader, CPyReadParser_Object, get_parser,
+from khmer._oxli.utils cimport _bstring
+from khmer._oxli.utils import get_n_primes_near_x
+from khmer._oxli.parsing cimport (CpFastxReader, CPyReadParser_Object, get_parser,
                       CpReadParser, FastxParserPtr)
-from oxli_types cimport MAX_BIGCOUNT
-from .._khmer import Countgraph as PyCountgraph
-from .._khmer import Nodegraph as PyNodegraph
-from .._khmer import GraphLabels as PyGraphLabels
-from .._khmer import ReadParser
+from khmer._oxli.oxli_types cimport MAX_BIGCOUNT
+from khmer._khmer import Countgraph as PyCountgraph
+from khmer._khmer import Nodegraph as PyNodegraph
+from khmer._khmer import GraphLabels as PyGraphLabels
+from khmer._khmer import ReadParser
 
 
 CYTHON_TABLES = (Hashtable, Nodetable, Counttable, SmallCounttable,

--- a/khmer/_oxli/hashing.pxd
+++ b/khmer/_oxli/hashing.pxd
@@ -4,7 +4,7 @@ from libcpp.queue cimport queue
 from libcpp.set cimport set
 from libcpp.string cimport string
 
-from oxli_types cimport *
+from khmer._oxli.oxli_types cimport *
 
 cdef extern from "oxli/kmer_hash.hh" namespace "oxli":
     cdef cppclass CpKmer "oxli::Kmer":

--- a/khmer/_oxli/hashing.pyx
+++ b/khmer/_oxli/hashing.pyx
@@ -1,12 +1,11 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 
 from libcpp.string cimport string
 from libcpp.memory cimport make_shared
 from libc.stdint cimport uint64_t
 from cython.operator cimport dereference as deref
 
-from oxli_types cimport *
+from khmer._oxli.oxli_types cimport *
 
 cdef class Kmer:
 

--- a/khmer/_oxli/hllcounter.pxd
+++ b/khmer/_oxli/hllcounter.pxd
@@ -4,9 +4,9 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libc.stdint cimport uint64_t, uint8_t
 
-from oxli_types cimport *
-from parsing cimport CpReadParser
-from utils cimport oxli_raise_py_error
+from khmer._oxli.oxli_types cimport *
+from khmer._oxli.parsing cimport CpReadParser
+from khmer._oxli.utils cimport oxli_raise_py_error
 
 
 cdef extern from "oxli/hllcounter.hh" namespace "oxli":

--- a/khmer/_oxli/hllcounter.pyx
+++ b/khmer/_oxli/hllcounter.pyx
@@ -1,9 +1,8 @@
-# cython: c_string_type=unicode, c_string_encoding=utf8
 from cython.operator cimport dereference as deref, address
 from libcpp.vector cimport vector
 
-from parsing cimport CpFastxReader
-from .utils cimport _bstring, _ustring
+from khmer._oxli.parsing cimport CpFastxReader
+from khmer._oxli.utils cimport _bstring, _ustring
 
 cdef class HLLCounter:
     """HyperLogLog counter.

--- a/khmer/_oxli/parsing.pxd
+++ b/khmer/_oxli/parsing.pxd
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 
 from __future__ import unicode_literals
 
@@ -10,7 +9,7 @@ from libcpp.memory cimport unique_ptr, shared_ptr, weak_ptr
 from libcpp.utility cimport pair
 from libcpp.string cimport string
 
-from .utils cimport oxli_raise_py_error
+from khmer._oxli.utils cimport oxli_raise_py_error
 
 
 '''

--- a/khmer/_oxli/parsing.pyx
+++ b/khmer/_oxli/parsing.pyx
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -11,7 +10,7 @@ from libcpp.string cimport string
 
 import sys
 
-from .utils cimport _bstring, _ustring
+from khmer._oxli.utils cimport _bstring, _ustring
 
 
 cdef class Alphabets:

--- a/khmer/_oxli/traversal.pxd
+++ b/khmer/_oxli/traversal.pxd
@@ -1,7 +1,7 @@
 from libc.stdint cimport uint32_t
 
-from hashing cimport CpKmer, KmerFilter, KmerQueue
-from graphs cimport CpHashgraph
+from khmer._oxli.hashing cimport CpKmer, KmerFilter, KmerQueue
+from khmer._oxli.graphs cimport CpHashgraph
 
 cdef extern from "oxli/traversal.hh" namespace "oxli":
     cdef cppclass CpTraverser "oxli::Traverser":

--- a/khmer/_oxli/utils.pxd
+++ b/khmer/_oxli/utils.pxd
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 from libcpp.vector cimport vector
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool

--- a/khmer/_oxli/utils.pyx
+++ b/khmer/_oxli/utils.pyx
@@ -1,5 +1,4 @@
 # -*- coding: UTF-8 -*-
-# cython: c_string_type=unicode, c_string_encoding=utf8
 
 from __future__ import unicode_literals
 from cpython.version cimport PY_MAJOR_VERSION

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ CMDCLASS = versioneer.get_cmdclass()
 HAS_CYTHON = False
 try:
     import Cython
+    from Cython.Build import cythonize
     HAS_CYTHON = True
 except ImportError:
     pass
@@ -194,6 +195,13 @@ CP_EXTENSION_MOD_DICT = \
 
 EXTENSION_MODS = [Extension("khmer._khmer", ** CP_EXTENSION_MOD_DICT)]
 
+CY_OPTS = {
+    'embedsignature': True,
+    'language_level': 3,
+    'c_string_type': 'unicode',
+    'c_string_encoding': 'utf8'
+}
+
 for cython_ext in glob.glob(os.path.join("khmer", "_oxli",
                                          "*.{0}".format(cy_ext))):
 
@@ -207,12 +215,16 @@ for cython_ext in glob.glob(os.path.join("khmer", "_oxli",
             "depends": [],
             "include_dirs": ["include", "."],
             "language": "c++",
-            "define_macros": [("VERSION", versioneer.get_version()), ],
+            "define_macros": [("VERSION", versioneer.get_version()), ]
         }
 
     ext_name = "khmer._oxli.{0}".format(
         splitext(os.path.basename(cython_ext))[0])
-    EXTENSION_MODS.append(Extension(ext_name, ** CY_EXTENSION_MOD_DICT))
+    EXTENSION_MODS.append(Extension(ext_name,
+                                    ** CY_EXTENSION_MOD_DICT))
+
+EXTENSION_MODS = cythonize(EXTENSION_MODS,
+                           compiler_directives=CY_OPTS)
 
 SCRIPTS = []
 SCRIPTS.extend([path_join("scripts", script)
@@ -228,8 +240,7 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: C++",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.5",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
@@ -283,7 +294,8 @@ SETUP_METADATA = \
         # "license": '', # empty as is conveyed by the classifier below
         "include_package_data": True,
         "zip_safe": False,
-        "classifiers": CLASSIFIERS
+        "classifiers": CLASSIFIERS,
+        "python_requires": '>=3.5'
     }
 
 


### PR DESCRIPTION
Addresses #1769 

Removes the travis builder, sets the minimum version in setup.py, adds cython directives (including language_level) to setup.py, changes imports to absolute in pyx files for Python 3.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
