### PR TITLE
Convert to unordered_map where appropriate

### DIFF
--- a/include/oxli/hashgraph.hh
+++ b/include/oxli/hashgraph.hh
@@ -43,7 +43,6 @@ Contact: khmer-project@idyll.org
 #include <fstream>
 #include <iostream>
 #include <list>
-#include <map>
 #include <queue>
 #include <set>
 #include <string>

--- a/include/oxli/hashtable.hh
+++ b/include/oxli/hashtable.hh
@@ -44,7 +44,6 @@ Contact: khmer-project@idyll.org
 #include <fstream>
 #include <iostream>
 #include <list>
-#include <map>
 #include <queue>
 #include <set>
 #include <string>

--- a/include/oxli/oxli.hh
+++ b/include/oxli/oxli.hh
@@ -71,6 +71,7 @@ private:\
 
 #include <set>
 #include <map>
+#include <unordered_map>
 #include <queue>
 #include <list>
 #include <functional>
@@ -129,22 +130,22 @@ typedef void (*CallbackFn)(const char * info, void * callback_data,
 typedef unsigned int PartitionID;
 typedef std::set<HashIntoType> SeenSet;
 typedef std::set<PartitionID> PartitionSet;
-typedef std::map<HashIntoType, PartitionID*> PartitionMap;
-typedef std::map<PartitionID, PartitionID*> PartitionPtrMap;
-typedef std::map<PartitionID, SeenSet*> PartitionsToTagsMap;
+typedef std::unordered_map<HashIntoType, PartitionID*> PartitionMap;
+typedef std::unordered_map<PartitionID, PartitionID*> PartitionPtrMap;
+typedef std::unordered_map<PartitionID, SeenSet*> PartitionsToTagsMap;
 typedef std::set<PartitionID *> PartitionPtrSet;
-typedef std::map<PartitionID, PartitionPtrSet*> ReversePartitionMap;
+typedef std::unordered_map<PartitionID, PartitionPtrSet*> ReversePartitionMap;
 typedef std::queue<HashIntoType> NodeQueue;
-typedef std::map<PartitionID, PartitionID*> PartitionToPartitionPMap;
-typedef std::map<HashIntoType, unsigned int> TagCountMap;
-typedef std::map<PartitionID, unsigned int> PartitionCountMap;
+typedef std::unordered_map<PartitionID, PartitionID*> PartitionToPartitionPMap;
+typedef std::unordered_map<HashIntoType, unsigned int> TagCountMap;
+typedef std::unordered_map<PartitionID, unsigned int> PartitionCountMap;
 typedef std::map<unsigned long long, unsigned long long>
 PartitionCountDistribution;
 
 // types used in @camillescott's sparse labeling extension
 typedef unsigned long long int Label;
-typedef std::multimap<HashIntoType, Label> TagLabelMap;
-typedef std::multimap<Label, HashIntoType> LabelTagMap;
+typedef std::unordered_multimap<HashIntoType, Label> TagLabelMap;
+typedef std::unordered_multimap<Label, HashIntoType> LabelTagMap;
 typedef std::pair<HashIntoType, Label> TagLabelPair;
 typedef std::pair<Label, HashIntoType> LabelTagPair;
 typedef std::set<Label> LabelSet;

--- a/include/oxli/storage.hh
+++ b/include/oxli/storage.hh
@@ -41,12 +41,13 @@ Contact: khmer-project@idyll.org
 #include <cassert>
 #include <array>
 #include <mutex>
+#include <unordered_map>
 using MuxGuard = std::lock_guard<std::mutex>;
 
 #include "gqf.h"
 
 namespace oxli {
-typedef std::map<HashIntoType, BoundedCounterType> KmerCountMap;
+typedef std::unordered_map<HashIntoType, BoundedCounterType> KmerCountMap;
 
 //
 // base Storage class for hashtable-related storage of information in memory.

--- a/khmer/_oxli/oxli_types.pxd
+++ b/khmer/_oxli/oxli_types.pxd
@@ -1,5 +1,6 @@
 from libcpp cimport bool
 from libcpp.map cimport map
+from libcpp.unordered_map cimport unordered_map
 from libcpp.set cimport set
 from libcpp.string cimport string
 
@@ -13,12 +14,12 @@ cdef extern from "oxli/oxli.hh" namespace "oxli":
 
     ctypedef unsigned int PartitionID
     ctypedef set[PartitionID] PartitionSet
-    ctypedef map[HashIntoType, PartitionID*] PartitionMap
-    ctypedef map[PartitionID, PartitionID*] PartitionPtrMap
-    ctypedef map[PartitionID, HashIntoTypeSet*] PartitionToTagsMap
-    ctypedef map[PartitionID, unsigned int] PartitionCountMap
+    ctypedef unordered_map[HashIntoType, PartitionID*] PartitionMap
+    ctypedef unordered_map[PartitionID, PartitionID*] PartitionPtrMap
+    ctypedef unordered_map[PartitionID, HashIntoTypeSet*] PartitionToTagsMap
+    ctypedef unordered_map[PartitionID, unsigned int] PartitionCountMap
     ctypedef map[unsigned long long, unsigned long long] PartitionCountDistribution
-    ctypedef map[HashIntoType, unsigned int] TagCountMap
+    ctypedef unordered_map[HashIntoType, unsigned int] TagCountMap
     ctypedef unsigned char WordLength
     ctypedef unsigned short int BoundedCounterType
 

--- a/tests/test_subset_graph.py
+++ b/tests/test_subset_graph.py
@@ -700,10 +700,12 @@ def test_partition_overlap_2():
     assert x == ([(3, 8)], 0), x
 
     x = p2.partition_sizes()
+    x[0].sort(key=lambda pair: pair[0])
     assert x == ([(3, 6), (5, 6)], 0), x
 
     x = p1.partition_average_coverages(kh)
     assert x == [(3, 11)]
 
     x = p2.partition_average_coverages(kh)
+    x.sort(key=lambda pair: pair[0])
     assert x == [(3, 5), (5, 10)], x


### PR DESCRIPTION
`std::unordered_map` has O(1) amortized random access; `std::map` is O(log(n)), due to maintaining internal ordering of its elements. Most of our use cases don't require that ordering, so this switches them to `unordered_map` where appropriate. On map sizes on the order of 5 million elements, this is a 20x speedup for element access. For large datasets using `bigcount`, I imagine the benefit will be... considerable.

cc @ctb @luizirber @betatim 

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
