### PR TITLE
[WIP] Support a man page make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,15 @@ build/sphinx/latex/khmer.pdf: $(SOURCES) doc/conf.py $(wildcard doc/*.rst) \
 	@echo ''
 	@echo '--> pdf in build/sphinx/latex/khmer.pdf'
 
+## man         : render documentation in Linux man
+man: build/sphinx/man/khmer.1
+
+build/sphinx/man/khmer.1: $(SOURCES) doc/conf.py $(wildcard doc/*.rst) $(wildcard doc/*/*.rst)
+	./setup.py build_sphinx --fresh-env --builder man
+	@echo ''
+	@echo '--> docs in build/sphinx/man <--'
+	@echo ''
+
 cppcheck-result.xml: $(CPPSOURCES)
 	$(CPPCHECK) --xml-version=2 2> cppcheck-result.xml
 


### PR DESCRIPTION
Supersedes #838. This may or may not be worth pursuing. If we do, we'll have to consider installation as well as trimming down on the excessive amount of release notes included.

Closes #619.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
