### PR TITLE
[MRG] Switch QFCounttable to murmurhash

### DIFF
--- a/include/oxli/hashtable.hh
+++ b/include/oxli/hashtable.hh
@@ -556,11 +556,11 @@ public:
 };
 
 // Hashtable-derived class with QFStorage.
-class QFCounttable : public oxli::Hashtable
+class QFCounttable : public oxli::MurmurHashtable
 {
 public:
     explicit QFCounttable(WordLength ksize, int size)
-        : Hashtable(ksize, new QFStorage(size)) { } ;
+        : MurmurHashtable(ksize, new QFStorage(size)) { } ;
 };
 
 // Hashtable-derived class with BitStorage.


### PR DESCRIPTION
Switch QFCounttable to use murmur hash. This makes it somewhat more predictable when the QF will be "full", see https://github.com/dib-lab/khmer/issues/1751#issuecomment-329535858

Should we modify the CQF code to raise an exception instead of using an assert or is there a way to "catch" an assert? This way we can print a better message for the user when we do exhaust the available slots. An alternative would be to check every time we insert a kmer if all slots are used :-/

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?