### PR TITLE
[MRG] add HDN into stop filter, not end of linear path

### DIFF
--- a/src/oxli/hashgraph.cc
+++ b/src/oxli/hashgraph.cc
@@ -875,7 +875,7 @@ const
                 // if there are any adjacent high degree nodes, record;
                 adjacencies.insert(node);
                 // also, add this to the stop Bloom filter.
-                bf.count(kmer);
+                bf.count(node);
             } else if (set_contains(visited, node)) {
                 // do nothing - already visited
                 ;

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -1095,6 +1095,12 @@ def test_traverse_linear_path_2():
     assert nodegraph.hash(contig[100:121]) in conns
     assert len(conns) == 1
 
+    for k in conns:                       # everything in connections => stop
+        assert stopgraph.get(k)
+
+    for k in visited:                     # nothing in visited => stop
+        assert not stopgraph.get(k)
+
     # traverse from immediately after 100:121, should end at the end
     size, conns, visited = nodegraph.traverse_linear_path(contig[101:122],
                                                           degree_nodes,
@@ -1106,6 +1112,12 @@ def test_traverse_linear_path_2():
     assert nodegraph.hash(contig[100:121]) in conns
     assert len(conns) == 1
 
+    for k in conns:                       # everything in connections => stop
+        assert stopgraph.get(k)
+
+    for k in visited:                     # nothing in visited => stop
+        assert not stopgraph.get(k)
+
     # traverse from end, should end at 100:121
     size, conns, visited = nodegraph.traverse_linear_path(contig[-21:],
                                                           degree_nodes,
@@ -1116,6 +1128,12 @@ def test_traverse_linear_path_2():
     assert len(visited) == 879
     assert nodegraph.hash(contig[100:121]) in conns
     assert len(conns) == 1
+
+    for k in conns:                       # everything in connections => stop
+        assert stopgraph.get(k)
+
+    for k in visited:                     # nothing in visited => stop
+        assert not stopgraph.get(k)
 
 
 def test_traverse_linear_path_3_stopgraph():


### PR DESCRIPTION
This fixes a fun bug where `Hashgraph::traverse_linear_path` added the last linear node in a path into the stop bloom filter, rather than adding the high-degree node(s) that bookended the linear path.  This meant that attempts to assemble the linear paths afterwards were often truncated.

The tests have been updated to check this as well.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
