### PR TITLE
[MRG] add a test to make sure that LinearAssembler.assemble takes hashes

### DIFF
--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -123,6 +123,15 @@ class TestLinearAssembler_RightBranching:
         assert len(path) == HDN.pos + K
         assert utils._equals_rc(path, contig[:len(path)])
 
+    def test_assemble_takes_hash(self, right_tip_structure):
+        # assemble from beginning of contig, up until branch point
+        graph, contig, L, HDN, R, tip = right_tip_structure
+        asm = khmer.LinearAssembler(graph)
+        path = asm.assemble(graph.hash(contig[0:K]))
+
+        assert len(path) == HDN.pos + K
+        assert utils._equals_rc(path, contig[:len(path)])
+
     def test_beginning_to_branch_revcomp(self, right_tip_structure):
         # assemble from beginning of contig, up until branch point
         # starting from rev comp


### PR DESCRIPTION
I was unable to find a test that checked to make sure that `LinearAssembler.assemble(...)` can take a hash (see #1765) so I wrote one.

Fixes #1765 (or at least makes sure it stays fixed :).

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
