### PR TITLE
[MRG] Remove clearing of sequence

### DIFF
--- a/src/oxli/hashtable.cc
+++ b/src/oxli/hashtable.cc
@@ -453,9 +453,6 @@ uint64_t * Hashtable::abundance_distribution(
 
     Read read;
 
-    string name;
-    string seq;
-
     // if not, could lead to overflow.
     if (sizeof(BoundedCounterType) != 2) {
         delete[] dist;
@@ -469,9 +466,8 @@ uint64_t * Hashtable::abundance_distribution(
             break;
         }
         read.set_clean_seq();
-        seq = read.cleaned_seq;
 
-        KmerHashIteratorPtr kmers = new_kmer_iterator(seq);
+        KmerHashIteratorPtr kmers = new_kmer_iterator(read.cleaned_seq);
 
         while(!kmers->done()) {
             HashIntoType kmer = kmers->next();
@@ -482,9 +478,6 @@ uint64_t * Hashtable::abundance_distribution(
                 BoundedCounterType n = get_count(kmer);
                 dist[n]++;
             }
-
-            name.clear();
-            seq.clear();
         }
     }
     return dist;


### PR DESCRIPTION
Clearing the string containing the sequence is not needed and was
happening too early (before the end of the loop).

Noticed this because when working on the rolling hash. For one of the unit tests the first character in the sequence would suddenly be `\0` which "breaks everything".

Any ideas how we can test for this explicitly? I don't :(

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?