### PR TITLE
[MRG] Stopgap for conditional cython import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,14 +64,14 @@ ez_setup.use_setuptools(version="3.4.1")
 
 CMDCLASS = versioneer.get_cmdclass()
 
-HAS_CYTHON = False
 try:
     import Cython
     from Cython.Build import cythonize
     HAS_CYTHON = True
+    cy_ext = 'pyx'
 except ImportError:
-    pass
-cy_ext = 'pyx' if HAS_CYTHON else 'cpp'
+    HAS_CYTHON = False
+    cy_ext = 'cpp'
 
 # strip out -Wstrict-prototypes; a hack suggested by
 # http://stackoverflow.com/a/9740721
@@ -223,12 +223,12 @@ for cython_ext in glob.glob(os.path.join("khmer", "_oxli",
         }
 
     ext_name = "khmer._oxli.{0}".format(
-        splitext(os.path.basename(cython_ext))[0])
-    EXTENSION_MODS.append(Extension(ext_name,
-                                    ** CY_EXTENSION_MOD_DICT))
+        splitext(os.path.basename(cython_ext))[0]
+    )
+    EXTENSION_MODS.append(Extension(ext_name, ** CY_EXTENSION_MOD_DICT))
 
-EXTENSION_MODS = cythonize(EXTENSION_MODS,
-                           compiler_directives=CY_OPTS)
+if HAS_CYTHON:
+    EXTENSION_MODS = cythonize(EXTENSION_MODS, compiler_directives=CY_OPTS)
 
 SCRIPTS = []
 SCRIPTS.extend([path_join("scripts", script)
@@ -282,8 +282,9 @@ SETUP_METADATA = \
         "packages": ['khmer', 'khmer.tests', 'oxli', 'khmer._oxli'],
         "package_data": {'khmer/_oxli': ['*.pxd']},
         "package_dir": {'khmer.tests': 'tests'},
-        "install_requires": ['screed >= 1.0', 'bz2file', 'Cython==0.25.2'],
-        "setup_requires": ["pytest-runner>=2.0,<3dev", "setuptools>=18.0"],
+        "install_requires": ['screed >= 1.0', 'bz2file', 'Cython>=0.25.2'],
+        "setup_requires": ["pytest-runner>=2.0,<3dev", "setuptools>=18.0",
+                           "Cython>=0.25.2"],
         "extras_require": {':python_version=="2.6"': ['argparse>=1.2.1'],
                            'docs': ['sphinx', 'sphinxcontrib-autoprogram'],
                            'tests': ['pytest>=2.9'],


### PR DESCRIPTION
The current `setup.py` file is a bit schizophrenic with respect to Cython. The `cythonize` function is conditionally imported, but is unconditionally called. This makes it impossible for packaging and installation systems without cython installed to even parse the file without failing.

This pull request introduces a temporary fix to this problem by making the call to `cythonize` conditional and then adding Cython as an explicit setup requirement.

Eventually we'll want to do this more cleanly, but for now this PR fixes #1783 and similar problems where calling Cython without making sure it's installed can be problematic.

- [x] Is it mergeable?
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
