### PR TITLE
[MRG] Switch to use TRAVIS_COMMIT instead of TRAVIS_PULL_REQUEST_SHA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,9 @@ script:
   - make py-demos
   - make cpp-demos
   - cd examples/stamps && ./do.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd ../.. && COMMIT=$TRAVIS_PULL_REQUEST_SHA make docker-container; fi
+  # ${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} makes sure we get the commit
+  # that travis is testing during a PR and when we build master
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd ../.. && COMMIT=${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} make docker-container; fi
 
 # generate all the diagnostic reports
 after_success:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 WORKDIR /home
 
 ARG branch
-ENV branch ${branch:-v2.1.1}
+ENV branch ${branch:-v2.1.2}
 
 RUN git clone https://github.com/dib-lab/khmer.git && \
     cd khmer && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [build_ext]
 define = SEQAN_HAS_BZIP2,SEQAN_HAS_ZLIB
 undef = NO_UNIQUE_RC
+
+# When you update the include directories here also update the paths used in
+# docker/Dockerfile
 # libraries = z,bz2
 ## if using system libraries
 include-dirs = include:third-party/zlib:third-party/bzip2:third-party/seqan/core/include:third-party/smhasher:third-party/cqf


### PR DESCRIPTION
Fixes #1777 by switching from TRAVIS_PULL_REQUEST_SHA which can be empty to TRAVIS_COMMIT.

This might also fix the build error in #1801.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?

