### PR TITLE
[MRG] Some performance hacks and minor fixes on graph interface

### DIFF
--- a/include/oxli/hashtable.hh
+++ b/include/oxli/hashtable.hh
@@ -108,7 +108,7 @@ inline std::vector<uint64_t> get_n_primes_near_x(uint32_t n, uint64_t x)
     if (i % 2 == 0) {
         i--;
     }
-    while (primes.size() != n && i >= 0) {
+    while (primes.size() != n) {
         if (is_prime(i)) {
             primes.push_back(i);
         }

--- a/khmer/_oxli/graphs.pyx
+++ b/khmer/_oxli/graphs.pyx
@@ -439,7 +439,7 @@ cdef class Hashgraph(Hashtable):
     def neighbors(self, object kmer):
         '''Get a list of neighbor nodes for this k-mer.'''
         cdef Traverser traverser = Traverser(self)
-        return [str(n) for n in traverser._neighbors(self._build_kmer(kmer))]
+        return list(traverser._neighbors(self._build_kmer(kmer)))
 
     def calc_connected_graph_size(self, object kmer, max_size=0,
                                   break_on_circumference=False):
@@ -491,13 +491,13 @@ cdef class Hashgraph(Hashtable):
         '''Traverse the path through the graph starting with the given
         k-mer and avoiding high-degree nodes, finding (and returning)
         traversed k-mers and any encountered high-degree nodes.'''
-        cdef set[HashIntoType] adj
-        cdef set[HashIntoType] visited
+        cdef HashSet adj = HashSet(self.ksize())
+        cdef HashSet visited = HashSet(self.ksize())
         cdef CpKmer _kmer = self._build_kmer(kmer)
         cdef CpNodegraph * _stop_filter = stop_filter._ng_this.get()
         cdef int size = deref(self._hg_this).traverse_linear_path(_kmer,
-                                                                 adj,
-                                                                 visited,
+                                                                 adj.hs,
+                                                                 visited.hs,
                                                                  deref(_stop_filter),
                                                                  hdns.hs)
         return size, adj, visited

--- a/khmer/_oxli/hashset.pyx
+++ b/khmer/_oxli/hashset.pyx
@@ -1,4 +1,8 @@
 # -*- coding: UTF-8 -*-
+from khmer._oxli.hashing cimport Kmer, _hash_forward
+from khmer._oxli.oxli_types cimport *
+from khmer._oxli.utils cimport is_str, is_num, _bstring
+
 
 cdef class HashSet:
     def __cinit__(self, ksize, hashes=[]):
@@ -19,6 +23,18 @@ cdef class HashSet:
 
     def __len__(self):
         return self.hs.size()
+
+    def __contains__(self, object kmer):
+        cdef HashIntoType h
+
+        if is_num(kmer):
+            h = kmer
+        elif isinstance(kmer, Kmer):
+            h = kmer.kmer_u
+        elif is_str(kmer):
+            h = _hash_forward(_bstring(kmer), self.ksize)
+
+        return self.hs.find(h) != self.hs.end()
 
     def __add__(self, HashSet other):
         if self.ksize != other.ksize:

--- a/khmer/_oxli/traversal.pyx
+++ b/khmer/_oxli/traversal.pyx
@@ -4,7 +4,6 @@ from cython.operator cimport dereference as deref
 from khmer._oxli.oxli_types cimport *
 from khmer._oxli.graphs cimport Hashgraph
 from khmer._oxli.hashing cimport Kmer
-from khmer._oxli.hashing import Kmer
 
 
 cdef class Traverser:

--- a/src/oxli/hashgraph.cc
+++ b/src/oxli/hashgraph.cc
@@ -828,13 +828,15 @@ const
     while(!kmers.done()) {
         n++;
         if (n % 10000 == 0) {
-            std::cout << "... find_high_degree_nodes: " << n << "\n";
-            std::cout << std::flush;
+            std::cout << "\r... find_high_degree_nodes: " << n;
         }
         Kmer kmer = kmers.next();
         if ((traverser.degree(kmer)) > 2) {
             high_degree_nodes.insert(kmer);
         }
+    }
+    if (n >= 10000) {
+        std::cout << "\rfound " << n << " high degree nodes.\n";
     }
 }
 

--- a/tests/test_hashset.py
+++ b/tests/test_hashset.py
@@ -129,6 +129,13 @@ def test_contains_1():
     assert 2**35 not in hs
 
 
+def test_contains_2():
+    hs = khmer.HashSet(5, [8, 10])
+    assert khmer.reverse_hash(8, 5) in hs
+    assert khmer.reverse_hash(10, 5) in hs
+    assert khmer.reverse_hash(2**35, 5) not in hs
+
+
 def test_concat_1():
     hs = khmer.HashSet(5, [10, 12])
     hs2 = khmer.HashSet(5, [10, 13])

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -444,16 +444,16 @@ def test_kmer_neighbors():
         'AAAA', 'AAAA']  # AAAA on both sides
 
     h = nodegraph.hash('AAAT')
-    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']      # AAAA on one side
-    assert n_to_str(nodegraph.neighbors('AAAT')) == ['AAAA'] # AAAA on one side
+    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']       # AAAA on 1 side
+    assert n_to_str(nodegraph.neighbors('AAAT')) == ['AAAA']  # AAAA on 1 side
 
     h = nodegraph.hash('AATA')
     assert nodegraph.neighbors(h) == []           # no neighbors
     assert n_to_str(nodegraph.neighbors('AATA')) == []      # AAAA on one side
 
     h = nodegraph.hash('TAAA')
-    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']    # AAAA on both sides
-    assert n_to_str(nodegraph.neighbors('TAAA')) == ['AAAA'] # AAAA on both
+    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']       # AAAA on both
+    assert n_to_str(nodegraph.neighbors('TAAA')) == ['AAAA']  # AAAA on both
 
 
 def test_kmer_neighbors_wrong_ksize():

--- a/tests/test_nodegraph.py
+++ b/tests/test_nodegraph.py
@@ -433,24 +433,27 @@ def test_kmer_neighbors():
     nodegraph = khmer.Nodegraph(4, 100, 1)
     nodegraph.consume_seqfile(inpfile)
 
+    def n_to_str(x):
+        return [str(i) for i in x]
+
     h = nodegraph.hash('AAAA')
     print(type('AAAA'))
-    assert nodegraph.neighbors(
-        h) == ['AAAA', 'AAAA']       # AAAA on both sides
-    assert nodegraph.neighbors('AAAA') == [
+    assert n_to_str(nodegraph.neighbors(
+        h)) == ['AAAA', 'AAAA']       # AAAA on both sides
+    assert n_to_str(nodegraph.neighbors('AAAA')) == [
         'AAAA', 'AAAA']  # AAAA on both sides
 
     h = nodegraph.hash('AAAT')
-    assert nodegraph.neighbors(h) == ['AAAA']          # AAAA on one side
-    assert nodegraph.neighbors('AAAT') == ['AAAA']     # AAAA on one side
+    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']      # AAAA on one side
+    assert n_to_str(nodegraph.neighbors('AAAT')) == ['AAAA'] # AAAA on one side
 
     h = nodegraph.hash('AATA')
     assert nodegraph.neighbors(h) == []           # no neighbors
-    assert nodegraph.neighbors('AATA') == []      # AAAA on one side
+    assert n_to_str(nodegraph.neighbors('AATA')) == []      # AAAA on one side
 
     h = nodegraph.hash('TAAA')
-    assert nodegraph.neighbors(h) == ['AAAA']          # AAAA on both sides
-    assert nodegraph.neighbors('TAAA') == ['AAAA']     # AAAA on both sides
+    assert n_to_str(nodegraph.neighbors(h)) == ['AAAA']    # AAAA on both sides
+    assert n_to_str(nodegraph.neighbors('TAAA')) == ['AAAA'] # AAAA on both
 
 
 def test_kmer_neighbors_wrong_ksize():


### PR DESCRIPTION
Some spotty patches to keep objects from being evaluated or converted prematurely; fixes a major performance regression noted in spacegraphcats (#1805).

* make graph.neighbors(...) return Kmers;
* traverse_linear_path now returns HashSets rather than sets;
* HashSet __contains__ now uses std::set::find instead of full enumeration;

Fixes #1806 #1805 #1807.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
- [x] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [x] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [x] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [x] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?
- [x] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
