### PR TITLE
Cythonization Improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,12 @@ CMDCLASS = versioneer.get_cmdclass()
 
 try:
     import Cython
+    from Cython.Distutil import Extension as CyExtension
     from Cython.Build import cythonize
     HAS_CYTHON = True
     cy_ext = 'pyx'
 except ImportError:
+    from setuptools import Extension as CyExtension
     HAS_CYTHON = False
     cy_ext = 'cpp'
 
@@ -223,13 +225,13 @@ for cython_ext in glob.glob(os.path.join("khmer", "_oxli",
             "define_macros": [("VERSION", versioneer.get_version()), ]
         }
 
+    if HAS_CYTHON:
+        CY_EXTENSION_MOD_DICT['cython_directives'] = CY_OPTS
+
     ext_name = "khmer._oxli.{0}".format(
         splitext(os.path.basename(cython_ext))[0]
     )
-    EXTENSION_MODS.append(Extension(ext_name, ** CY_EXTENSION_MOD_DICT))
-
-if HAS_CYTHON:
-    EXTENSION_MODS = cythonize(EXTENSION_MODS, compiler_directives=CY_OPTS)
+    EXTENSION_MODS.append(CyExtension(ext_name, ** CY_EXTENSION_MOD_DICT))
 
 SCRIPTS = []
 SCRIPTS.extend([path_join("scripts", script)

--- a/setup.py
+++ b/setup.py
@@ -66,14 +66,18 @@ CMDCLASS = versioneer.get_cmdclass()
 
 try:
     import Cython
-    from Cython.Distutil import Extension as CyExtension
-    from Cython.Build import cythonize
+    from Cython.Distutils import Extension as CyExtension
     HAS_CYTHON = True
     cy_ext = 'pyx'
+    print('*** NOTE: Found Cython, extension files will be '
+          'transpiled if this is an install invocation.',
+          file=sys.stderr)
 except ImportError:
     from setuptools import Extension as CyExtension
     HAS_CYTHON = False
     cy_ext = 'cpp'
+    print('*** WARNING: Cython not found, assuming cythonized '
+          'files available for compilation.', file=sys.stderr)
 
 # strip out -Wstrict-prototypes; a hack suggested by
 # http://stackoverflow.com/a/9740721


### PR DESCRIPTION
Edits setup.py to remove unnecessary calls to `cythonize` (such as during `clean`). Uses the `Extension` class provided by Cython, falling back to the regular one from setuptools if Cython isn't installed.

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
