### PR TITLE
[MRG] Unicode --> ASCII for contributor names

### DIFF
--- a/authors.csv
+++ b/authors.csv
@@ -5,7 +5,7 @@ Alex Hyer,theonehyer@gmail.com
 Alexander Johan Nederbragt,lex.nederbragt@ibv.uio.no
 Ali Aliyari,aaliyari@ucdavis.edu
 Amanda Charbonneau,charbo24@msu.edu
-Andreas Härpfer,ahaerpfer@gmail.com
+Andreas Harpfer,ahaerpfer@gmail.com
 Bede Constantinides,bede.constantinides@manchester.ac.uk
 Benjamin Taylor,taylo886@msu.edu
 Brian Wyss,wyssbria@msu.edu
@@ -21,7 +21,7 @@ Greg Edvenson,greg@edvenson.com
 Heather L. Wiencko,wienckhl@tcd.ie
 Humberto Ortiz-Zuazaga,humberto.ortiz@upr.edu
 Hussien F. Alameldin,hussien@msu.edu
-Iván González,igonzalez@mailaps.org
+Ivan Gonzalez,igonzalez@mailaps.org
 Jacob Fenton,bocajnotnef@gmail.com
 James A. Stapleton,jas@msu.edu
 James Spencer,james.s.spencer@gmail.com

--- a/authors.csv
+++ b/authors.csv
@@ -5,7 +5,7 @@ Alex Hyer,theonehyer@gmail.com
 Alexander Johan Nederbragt,lex.nederbragt@ibv.uio.no
 Ali Aliyari,aaliyari@ucdavis.edu
 Amanda Charbonneau,charbo24@msu.edu
-Andreas Harpfer,ahaerpfer@gmail.com
+Andreas Haerpfer,ahaerpfer@gmail.com
 Bede Constantinides,bede.constantinides@manchester.ac.uk
 Benjamin Taylor,taylo886@msu.edu
 Brian Wyss,wyssbria@msu.edu


### PR DESCRIPTION
I hate that it has come to this, but it looks like unless we want to do a lot of troubleshooting and hacking on pip itself, the easiest way to get rid of khmer's build issues with the Python3 toolchain is to remove non-ASCII characters from the author list (temporarily hopefully). See https://github.com/dib-lab/khmer/issues/1565#issuecomment-354156725.

- [x] Is it mergeable?
- [x] `make test` Did it pass the tests?
