### PR TITLE
change stdout-err to capsyd

### DIFF
--- a/tests/test_sandbox_scripts.py
+++ b/tests/test_sandbox_scripts.py
@@ -75,7 +75,7 @@ def _sandbox_scripts():
 
 
 @pytest.mark.parametrize("filename", _sandbox_scripts())
-def test_import_succeeds(filename, tmpdir):
+def test_import_succeeds(filename, tmpdir, capsys):
     try:
         mod = imp.load_source('__zzz', filename)
     except:
@@ -85,10 +85,6 @@ def test_import_succeeds(filename, tmpdir):
     with tmpdir.as_cwd():
         oldargs = sys.argv
         sys.argv = [filename]
-
-        oldout, olderr = sys.stdout, sys.stderr
-        sys.stdout = StringIO()
-        sys.stderr = StringIO()
 
         try:
             try:
@@ -104,8 +100,6 @@ def test_import_succeeds(filename, tmpdir):
                 pass                        # other failures are expected :)
         finally:
             sys.argv = oldargs
-            out, err = sys.stdout.getvalue(), sys.stderr.getvalue()
-            sys.stdout, sys.stderr = oldout, olderr
 
 
 @pytest.mark.skipif(not IN_REPOSITORY,


### PR DESCRIPTION
Related to Issue #1839
       removed stderr and changed to capsys

- [ ] Is it mergeable?
- [ ] `make test` Did it pass the tests?
- [ ] `make clean diff-cover` If it introduces new functionality in
  `scripts/` is it tested?
- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
  formatted?
- [ ] Did it change the command-line interface? Only backwards-compatible
  additions are allowed without a major version increment. Changing file
  formats also requires a major version number increment.
- [ ] For substantial changes or changes to the command-line interface, is it
  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
  for more details.
- [ ] Was a spellchecker run on the source code and documentation after
  changes were made?
- [ ] Do the changes respect streaming IO? (Are they
  tested for streaming IO?)
