### PR TITLE
[MRG] Relax the PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,27 @@
-- [ ] Is it mergeable?
-- [ ] `make test` Did it pass the tests?
-- [ ] `make clean diff-cover` If it introduces new functionality in
-  `scripts/` is it tested?
-- [ ] `make format diff_pylint_report cppcheck doc pydocstyle` Is it well
-  formatted?
-- [ ] Did it change the command-line interface? Only backwards-compatible
-  additions are allowed without a major version increment. Changing file
-  formats also requires a major version number increment.
-- [ ] For substantial changes or changes to the command-line interface, is it
-  documented in `CHANGELOG.md`? See [keepachangelog](http://keepachangelog.com/)
-  for more details.
+
+----------------------------------------
+
+> <u>Message from the khmer maintainers</u>:
+>
+> *Please provide a description of the pull request above, including a
+> reasonable level of detail and references to any relevant threads. After
+> creating the  pull request, complete and mark the checklist below. If any item
+> is not applicable, feel free to remove it or mark it as complete. If you are
+> unsure about any item, feel free to ask about it before or during code
+> review.*
+>
+> *When you are ready for the pull request to be reviewed, please post a comment
+> with a message such as "Ready for review!"*
+
+- [ ] Is any new functionality in tested? (This can be checked with
+      `make clean diff-cover` or the CodeCov report that is automatically
+      generated following a successful CI build.)
 - [ ] Was a spellchecker run on the source code and documentation after
-  changes were made?
-- [ ] Do the changes respect streaming IO? (Are they
-  tested for streaming IO?)
+      changes were made?
+- [ ] Have any changes to the command-line interface been explicitly described?
+      Only backwards-compatible additions are allowed without a major version
+      increment. Changing file formats also requires a major version number
+      increment.
+- [ ] Have any substantial changes been documented in `CHANGELOG.md`? See
+      [keepachangelog](http://keepachangelog.com/) for more details.
+- [ ] Do the changes respect streaming I/O? (Are they tested for streaming I/O?)


### PR DESCRIPTION
Following up on #1822, this PR updates the PR checklist and removes several items that are being ignored or have been satisfied in other ways. I've attempted to make the new checklist descriptive as to our current process, rather than prescriptive about what that process should be. I think it's a fairly reasonable compromise between what we should expect of new contributors and what we should remind frequent contributors to do without too much chafing.

Closes #1822.

Ready for discussion (and review and merge)!