### PR TITLE
[MRG] Specify new min version for sphinx plugin

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinxcontrib-autoprogram==0.1.2
+sphinxcontrib-autoprogram>=0.1.4
 setuptools>=3.4.1
 guzzle_sphinx_theme==0.7.11
 Cython==0.25.2


### PR DESCRIPTION
This PR specifies a new minimum version number of one of the sphinx plugins we use to avoid doc build failures. Closes #1841.

Ready for review and merge!