### PR TITLE
use full path for temporary filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ under semantic versioning, but will be in future versions of khmer.
   or generators where appropriate.
 - All constructors have been removed from khmer/__init__.py.
 - GraphLabels does not inherit from Hashgraph.
+- `trim-low-abund.py` doesn't error out when given multiple files with identical basenames
 
 ## [2.1.1] - 2017-05-25
 ### Added

--- a/scripts/trim-low-abund.py
+++ b/scripts/trim-low-abund.py
@@ -379,7 +379,7 @@ def main():
     pass2list = []
     for filename in args.input_filenames:
         # figure out temporary filename for 2nd pass
-        pass2filename = os.path.basename(filename) + '.pass2'
+        pass2filename = filename.replace(os.path.sep, '-') + '.pass2'
         pass2filename = os.path.join(tempdir, pass2filename)
         pass2fp = open(pass2filename, 'w')
 


### PR DESCRIPTION
In `trim-low-abund.py`, use the full path of the input filename rather than only the basename, in case of identical basenames which causes errors.

- [x] ~Is any new functionality in tested? (This can be checked with
      `make clean diff-cover` or the CodeCov report that is automatically
      generated following a successful CI build.)~
- [x] Was a spellchecker run on the source code and documentation after
      changes were made?
- [x] Have any changes to the command-line interface been explicitly described?
      Only backwards-compatible additions are allowed without a major version
      increment. Changing file formats also requires a major version number
      increment.
- [ ] Have any substantial changes been documented in `CHANGELOG.md`? See
      [keepachangelog](http://keepachangelog.com/) for more details.
- [x] Do the changes respect streaming I/O? (Are they tested for streaming I/O?)
