### PR TITLE
[WIP] Experiment compacting counttables into a nodetable given a max abundance criterion

### DIFF
--- a/include/oxli/hashtable.hh
+++ b/include/oxli/hashtable.hh
@@ -624,6 +624,24 @@ class Nodetable : public oxli::MurmurHashtable
 public:
     explicit Nodetable(WordLength ksize, std::vector<uint64_t> sizes)
         : MurmurHashtable(ksize, new BitStorage(sizes)) { } ;
+
+    void compose_init(Counttable& other, BoundedCounterType max)
+    {
+        if (get_tablesizes() != other.get_tablesizes()) {
+            std::cerr << "Table size mismatch\n";
+            return;
+        }
+        store->compose_init(other.get_raw_tables(), max);
+    }
+
+    void compose_update(Counttable& other, BoundedCounterType max)
+    {
+        if (get_tablesizes() != other.get_tablesizes()) {
+            std::cerr << "Table size mismatch\n";
+            return;
+        }
+        store->compose_update(other.get_raw_tables(), max);
+    }
 };
 
 }

--- a/khmer/_oxli/graphs.pxd
+++ b/khmer/_oxli/graphs.pxd
@@ -120,6 +120,8 @@ cdef extern from "oxli/hashtable.hh" namespace "oxli" nogil:
 
     cdef cppclass CpNodetable "oxli::Nodetable" (CpMurmurHashtable):
         CpNodetable(WordLength, vector[uint64_t])
+        void compose_init(CpCounttable&, BoundedCounterType)
+        void compose_update(CpCounttable&, BoundedCounterType)
 
     cdef cppclass CpQFCounttable "oxli::QFCounttable" (CpHashtable):
         CpQFCounttable(WordLength, uint64_t) except +oxli_raise_py_error

--- a/khmer/_oxli/graphs.pyx
+++ b/khmer/_oxli/graphs.pyx
@@ -459,6 +459,12 @@ cdef class Nodetable(Hashtable):
             self._nt_this = make_shared[CpNodetable](k, _primes)
             self._ht_this = <shared_ptr[CpHashtable]>self._nt_this
 
+    def compose_init(self, Counttable ct, int max):
+        deref(self._nt_this).compose_init(deref(ct._ct_this), max)
+
+    def compose_update(self, Counttable ct, int max):
+        deref(self._nt_this).compose_update(deref(ct._ct_this), max)
+
 
 cdef class Hashgraph(Hashtable):
 

--- a/tests/test_counttable.py
+++ b/tests/test_counttable.py
@@ -199,3 +199,33 @@ def test_init_with_primes(sketchtype):
     primes = khmer.get_n_primes_near_x(4, random.randint(1000, 2000))
     sketch = sketchtype(31, 1, 1, primes=primes)
     assert sketch.hashsizes() == primes
+
+
+def test_compose():
+    counts1 = khmer.Counttable(21, 1e4, 4)
+    counts2 = khmer.Counttable(21, 1e4, 4)
+
+    counts1.add('GATTACAGATTACAGATTACA')
+    counts2.add('GATTACAGATTACAGATTACA')
+
+    counts1.add('TAGATCTGCTTGAAACAAGTG')
+    for _ in range(5):
+        counts2.add('TAGATCTGCTTGAAACAAGTG')
+
+    for _ in range(5):
+        counts1.add('AAGTGGATTTGAGAAAAAAGT')
+    counts2.add('AAGTGGATTTGAGAAAAAAGT')
+
+    for _ in range(5):
+        counts1.add('GGGGGGGGGGGGGGGGGGGGG')
+        counts2.add('GGGGGGGGGGGGGGGGGGGGG')
+
+    kmers = khmer.Nodetable(21, 1e4, 4)
+    kmers.compose_init(counts1, 3)
+    kmers.compose_update(counts2, 3)
+
+    assert kmers.get('GATTACAGATTACAGATTACA') == 1
+    assert kmers.get('TAGATCTGCTTGAAACAAGTG') == 0
+    assert kmers.get('AAGTGGATTTGAGAAAAAAGT') == 0
+    assert kmers.get('GGGGGGGGGGGGGGGGGGGGG') == 0
+    assert kmers.get('AAAAAAAAAAAAAAAAAAAAA') == 1


### PR DESCRIPTION
Scenario: I want to query some big ol' counttables, and my k-mers of interest are those that are abundance <= X. Rather than keeping several of these big counttables in memory at once, I'd like to be able to initialize and update a nodetable (with the same number of buckets) to indicate which k-mers satisfy the given criterion. That way I only have to keep one counttable in memory at a time.

This PR introduces two new methods for nodetables: `compose_init`, and `compose_update`. These methods do bit flipping directly on the byte array.

The build is currently failing. I'm guessing there's an issue at the C++ level, and maybe at the Cython level as well. This could really benefit from a preliminary review from @luizirber or @camillescott.

----------------------------------------

- [x] Is any new functionality in tested? (This can be checked with
      `make clean diff-cover` or the CodeCov report that is automatically
      generated following a successful CI build.)
- [ ] Was a spellchecker run on the source code and documentation after
      changes were made?
- [ ] Have any substantial changes been documented in `CHANGELOG.md`? See
      [keepachangelog](http://keepachangelog.com/) for more details.
