### PR TITLE
Fix build for OS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,15 +168,12 @@ SOURCES.extend(path_join("third-party", "smhasher", bn + ".cc") for bn in [
     "MurmurHash3"])
 
 # Don't forget to update lib/Makefile with these flags!
-EXTRA_COMPILE_ARGS = ['-O3', '-std=c++11', '-pedantic',
-                      '-fno-omit-frame-pointer']
-EXTRA_LINK_ARGS = ['-fno-omit-frame-pointer']
+EXTRA_COMPILE_ARGS = ['-O3', '-std=c++11']
+EXTRA_LINK_ARGS = []
 
 if sys.platform == 'darwin':
-    # force 64bit only builds
-    EXTRA_COMPILE_ARGS.extend(['-arch', 'x86_64', '-mmacosx-version-min=10.7',
-                               '-stdlib=libc++'])
-    EXTRA_LINK_ARGS.append('-mmacosx-version-min=10.7')
+    EXTRA_COMPILE_ARGS.extend(['-arch', 'x86_64', '-mmacosx-version-min=10.9'])
+    EXTRA_LINK_ARGS.append('-mmacosx-version-min=10.9')
 
 if check_for_openmp():
     EXTRA_COMPILE_ARGS.extend(['-fopenmp'])


### PR DESCRIPTION
This PR updates the min OS X build target. 10.7 is very old and the setuptools/distutils build config for 10.7 uses outdated compiler options. Latest OS X release is 10.14, but even just updating to 10.9 as the min build version enables a proper build on recent versions.