### PR TITLE
Create countgraph correctly

### DIFF
--- a/scripts/filter-abund.py
+++ b/scripts/filter-abund.py
@@ -130,7 +130,7 @@ def main():
     check_space(infiles, args.force)
 
     log_info('loading countgraph: {graph}', graph=args.input_graph)
-    countgraph = Countgraph.load(args.input_graph)
+    countgraph = khmer.load_countgraph(args.input_graph)
     ksize = countgraph.ksize()
 
     log_info("K: {ksize}", ksize=ksize)


### PR DESCRIPTION
The script in it's current form doesn't seem to create a Countgraph correctly. The call to create a Countgraph() object fails when passing a string as it expects an object. This edit fixes that issue.
