### PR TITLE
Fix build against Python 3.12

### DIFF
--- a/scripts/abundance-dist-single.py
+++ b/scripts/abundance-dist-single.py
@@ -218,6 +218,10 @@ def main():  # pylint: disable=too-many-locals,too-many-branches
 
     log_info('wrote to: {output}', output=args.output_histogram_filename)
 
+    # Ensure that the output files are properly written. Python 3.12 seems to
+    # be less forgiving here ..
+    hist_fp.close()
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/do-partition.py
+++ b/scripts/do-partition.py
@@ -168,8 +168,8 @@ def main():  # pylint: disable=too-many-locals,too-many-statements
         worker_q.put((nodegraph, _, start, end))
 
     print('enqueued %d subset tasks' % n_subsets, file=sys.stderr)
-    open('%s.info' % args.graphbase, 'w').write('%d subsets total\n'
-                                                % (n_subsets))
+    with open('%s.info' % args.graphbase, 'w') as info_fp:
+        info_fp.write('%d subsets total\n' % (n_subsets))
 
     if n_subsets < args.threads:
         args.threads = n_subsets

--- a/scripts/extract-long-sequences.py
+++ b/scripts/extract-long-sequences.py
@@ -52,7 +52,7 @@ import textwrap
 import sys
 from khmer import __version__
 from khmer.utils import write_record
-from khmer.kfile import add_output_compression_type, get_file_writer
+from khmer.kfile import add_output_compression_type, FileWriter
 from khmer.khmer_args import sanitize_help, KhmerArgumentParser
 
 
@@ -81,12 +81,12 @@ def get_parser():
 
 def main():
     args = sanitize_help(get_parser()).parse_args()
-    outfp = get_file_writer(args.output, args.gzip, args.bzip)
-    for filename in args.input_filenames:
-        for record in screed.open(filename):
-            if len(record['sequence']) >= args.length:
-                write_record(record, outfp)
-    print('wrote to: ' + args.output.name, file=sys.stderr)
+    with FileWriter(args.output, args.gzip, args.bzip) as outfp:
+        for filename in args.input_filenames:
+            for record in screed.open(filename):
+                if len(record['sequence']) >= args.length:
+                    write_record(record, outfp)
+        print('wrote to: ' + args.output.name, file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/scripts/fastq-to-fasta.py
+++ b/scripts/fastq-to-fasta.py
@@ -45,7 +45,7 @@ Use '-h' for parameter help.
 import sys
 import screed
 from khmer import __version__
-from khmer.kfile import (add_output_compression_type, get_file_writer,
+from khmer.kfile import (add_output_compression_type, FileWriter,
                          describe_file_handle)
 from khmer.utils import write_record
 from khmer.khmer_args import sanitize_help, KhmerArgumentParser
@@ -74,21 +74,21 @@ def main():
     args = sanitize_help(get_parser()).parse_args()
 
     print('fastq from ', args.input_sequence, file=sys.stderr)
-    outfp = get_file_writer(args.output, args.gzip, args.bzip)
-    n_count = 0
-    for n, record in enumerate(screed.open(args.input_sequence)):
-        if n % 10000 == 0:
-            print('...', n, file=sys.stderr)
+    with FileWriter(args.output, args.gzip, args.bzip) as outfp:
+        n_count = 0
+        for n, record in enumerate(screed.open(args.input_sequence)):
+            if n % 10000 == 0:
+                print('...', n, file=sys.stderr)
 
-        sequence = record['sequence']
+            sequence = record['sequence']
 
-        if 'N' in sequence:
-            if not args.n_keep:
-                n_count += 1
-                continue
+            if 'N' in sequence:
+                if not args.n_keep:
+                    n_count += 1
+                    continue
 
-        del record['quality']
-        write_record(record, outfp)
+            del record['quality']
+            write_record(record, outfp)
 
     print('\n' + 'lines from ' + args.input_sequence, file=sys.stderr)
 

--- a/scripts/filter-stoptags.py
+++ b/scripts/filter-stoptags.py
@@ -108,10 +108,9 @@ def main():
         print('filtering', infile, file=sys.stderr)
         outfile = os.path.basename(infile) + '.stopfilt'
 
-        outfp = open(outfile, 'w')
-
-        tsp = ThreadedSequenceProcessor(process_fn)
-        tsp.start(verbose_loader(infile), outfp)
+        with open(outfile, 'w') as outfp:
+            tsp = ThreadedSequenceProcessor(process_fn)
+            tsp.start(verbose_loader(infile), outfp)
 
         print('output in', outfile, file=sys.stderr)
 

--- a/scripts/partition-graph.py
+++ b/scripts/partition-graph.py
@@ -143,7 +143,8 @@ def main():
         worker_q.put((nodegraph, _, start, end))
 
     print('enqueued %d subset tasks' % n_subsets, file=sys.stderr)
-    open('%s.info' % basename, 'w').write('%d subsets total\n' % (n_subsets))
+    with open('%s.info' % basename, 'w') as info_fp:
+        info_fp.write('%d subsets total\n' % (n_subsets))
 
     n_threads = args.threads
     if n_subsets < n_threads:

--- a/tests/test_sandbox_scripts.py
+++ b/tests/test_sandbox_scripts.py
@@ -42,7 +42,7 @@ import os.path
 from io import StringIO
 import traceback
 import glob
-import imp
+import importlib
 
 import pytest
 
@@ -77,7 +77,8 @@ def _sandbox_scripts():
 @pytest.mark.parametrize("filename", _sandbox_scripts())
 def test_import_succeeds(filename, tmpdir, capsys):
     try:
-        mod = imp.load_source('__zzz', filename)
+        loader = importlib.machinery.SourceFileLoader('__zzz', filename)
+        mod = loader.load_module()
     except:
         print(traceback.format_exc())
         raise AssertionError("%s cannot be imported" % (filename,))

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
Ever since Python 3.2, `configparser.SafeConfigParser` has been deprecated in favor of `configparser.ConfigParser`. An alias existed for backward compatibility but the alias was dropped from Python 3.12.

The `imp` module was dropped from Python 3.12, but `importlib` can be used as a substitute.

Furthermore, Python scripts were not consistently closing the files that they opened for writing. With earlier versions of Python, it was not a big deal. But with Python 3.12, the files appear truncated. The second patch goes through every call to `open(..., mode="w")` and ensures that the resource is properly cleaned up after.

The change will probably fail to build with Python 2.7.

- [x] Is any new functionality in tested? (This can be checked with
      `make clean diff-cover` or the CodeCov report that is automatically
      generated following a successful CI build.)
- [x] Was a spellchecker run on the source code and documentation after
      changes were made?
- [x] Have any changes to the command-line interface been explicitly described?
      Only backwards-compatible additions are allowed without a major version
      increment. Changing file formats also requires a major version number
      increment.
- [ ] Have any substantial changes been documented in `CHANGELOG.md`? See
      [keepachangelog](http://keepachangelog.com/) for more details.
- [ ] Do the changes respect streaming I/O? (Are they tested for streaming I/O?)
